### PR TITLE
feat: Add Mastodon favicon platform handler

### DIFF
--- a/src/favicons/defaults.ts
+++ b/src/favicons/defaults.ts
@@ -4,6 +4,7 @@ import type { HeadersMethodOptions } from '../common/uris/headers/types.js'
 import type { HtmlMethodOptions } from '../common/uris/html/types.js'
 import type { PlatformMethodOptions } from '../common/uris/platform/types.js'
 import { githubHandler } from './platform/handlers/github.js'
+import { mastodonHandler } from './platform/handlers/mastodon.js'
 
 export const defaultIconRels = [
   'icon',
@@ -38,5 +39,5 @@ export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
 }
 
 export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
-  handlers: [githubHandler],
+  handlers: [githubHandler, mastodonHandler],
 }

--- a/src/favicons/index.test.ts
+++ b/src/favicons/index.test.ts
@@ -197,6 +197,27 @@ describe('discoverFavicons', () => {
     expect(value).toEqual(expected)
   })
 
+  it('should discover favicon from mastodon platform handler', async () => {
+    const avatarUrl = 'https://files.mastodon.social/accounts/avatars/000/123/original/avatar.png'
+    const mockFetch = createMockFetch({
+      'https://mastodon.social/@user':
+        '<html><head><meta name="generator" content="Mastodon v4.2.0"></head></html>',
+      'https://mastodon.social/api/v1/accounts/lookup?acct=user': JSON.stringify({
+        avatar: avatarUrl,
+      }),
+      [avatarUrl]: 'binary',
+    })
+    const value = await discoverFavicons('https://mastodon.social/@user', {
+      methods: ['platform'],
+      fetchFn: mockFetch,
+    })
+    const expected: Array<DiscoverResult<FaviconResult>> = [
+      { url: avatarUrl, isValid: true, method: 'platform' },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
   it('should return empty array for invalid URLs', async () => {
     const mockFetch = createMockFetch({})
     const value = await discoverFavicons('not-a-valid-url', {

--- a/src/favicons/platform/handlers/mastodon.test.ts
+++ b/src/favicons/platform/handlers/mastodon.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'bun:test'
+import type { DiscoverFetchFn, DiscoverUriEntry } from '../../../common/types.js'
+import { mastodonHandler } from './mastodon.js'
+
+const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => {
+  return async (url: string) => ({
+    url,
+    body: responses[url] ?? '',
+    headers: new Headers(),
+    status: url in responses ? 200 : 404,
+    statusText: url in responses ? 'OK' : 'Not Found',
+  })
+}
+
+const mastodonHtml = '<html><head><meta name="generator" content="Mastodon v4.2.0"></head></html>'
+const mastodonHeaders = new Headers({ server: 'Mastodon' })
+
+describe('mastodonHandler', () => {
+  describe('match', () => {
+    it('should match /@ profile path with Mastodon generator in HTML', () => {
+      expect(mastodonHandler.match('https://mastodon.social/@user', mastodonHtml)).toBe(true)
+      expect(mastodonHandler.match('https://example.com/@user', mastodonHtml)).toBe(true)
+    })
+
+    it('should match /@ profile path with Mastodon server header', () => {
+      const result = mastodonHandler.match('https://example.com/@user', '', mastodonHeaders)
+
+      expect(result).toBe(true)
+    })
+
+    it('should match when both HTML and headers indicate Mastodon', () => {
+      const result = mastodonHandler.match(
+        'https://example.com/@user',
+        mastodonHtml,
+        mastodonHeaders,
+      )
+
+      expect(result).toBe(true)
+    })
+
+    it('should not match without Mastodon signals', () => {
+      const result = mastodonHandler.match(
+        'https://example.com/@user',
+        '<html></html>',
+        new Headers({ server: 'nginx' }),
+      )
+
+      expect(mastodonHandler.match('https://example.com/@user', '<html></html>')).toBe(false)
+      expect(result).toBe(false)
+    })
+
+    it('should not match without content and headers', () => {
+      expect(mastodonHandler.match('https://mastodon.social/@user')).toBe(false)
+      expect(mastodonHandler.match('https://mastodon.social/@user', '')).toBe(false)
+    })
+
+    it('should not match non-profile paths', () => {
+      expect(mastodonHandler.match('https://mastodon.social/about', mastodonHtml)).toBe(false)
+      expect(mastodonHandler.match('https://mastodon.social/', mastodonHtml)).toBe(false)
+    })
+
+    it('should not match non-@ profile paths', () => {
+      expect(mastodonHandler.match('https://mastodon.social/user', mastodonHtml)).toBe(false)
+    })
+
+    it('should not match invalid URLs', () => {
+      expect(mastodonHandler.match('not-a-url', mastodonHtml)).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should resolve avatar from Mastodon API', async () => {
+      const mockFetch = createMockFetch({
+        'https://mastodon.social/api/v1/accounts/lookup?acct=user': JSON.stringify({
+          avatar: 'https://files.mastodon.social/accounts/avatars/000/123/original/avatar.png',
+        }),
+      })
+      const value = await mastodonHandler.resolve(
+        'https://mastodon.social/@user',
+        mastodonHtml,
+        mockFetch,
+      )
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://files.mastodon.social/accounts/avatars/000/123/original/avatar.png' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should return empty array when fetchFn is not provided', async () => {
+      const value = await mastodonHandler.resolve('https://mastodon.social/@user', mastodonHtml)
+
+      expect(value).toEqual([])
+    })
+
+    it('should return empty array when API returns no avatar', async () => {
+      const mockFetch = createMockFetch({
+        'https://mastodon.social/api/v1/accounts/lookup?acct=user': JSON.stringify({}),
+      })
+      const value = await mastodonHandler.resolve(
+        'https://mastodon.social/@user',
+        mastodonHtml,
+        mockFetch,
+      )
+
+      expect(value).toEqual([])
+    })
+
+    it('should return empty array when API returns invalid JSON', async () => {
+      const mockFetch = createMockFetch({
+        'https://mastodon.social/api/v1/accounts/lookup?acct=user': 'not json',
+      })
+      const value = await mastodonHandler.resolve(
+        'https://mastodon.social/@user',
+        mastodonHtml,
+        mockFetch,
+      )
+
+      expect(value).toEqual([])
+    })
+
+    it('should return empty array when fetch throws', async () => {
+      const mockFetch: DiscoverFetchFn = async () => {
+        throw new Error('Network error')
+      }
+      const value = await mastodonHandler.resolve(
+        'https://mastodon.social/@user',
+        mastodonHtml,
+        mockFetch,
+      )
+
+      expect(value).toEqual([])
+    })
+
+    it('should use correct API URL for different instances', async () => {
+      const mockFetch = createMockFetch({
+        'https://hachyderm.io/api/v1/accounts/lookup?acct=dev': JSON.stringify({
+          avatar: 'https://media.hachyderm.io/avatars/dev.png',
+        }),
+      })
+      const value = await mastodonHandler.resolve(
+        'https://hachyderm.io/@dev',
+        mastodonHtml,
+        mockFetch,
+      )
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://media.hachyderm.io/avatars/dev.png' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+  })
+})

--- a/src/favicons/platform/handlers/mastodon.test.ts
+++ b/src/favicons/platform/handlers/mastodon.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import type { DiscoverFetchFn, DiscoverUriEntry } from '../../../common/types.js'
-import { mastodonHandler } from './mastodon.js'
+import { isMastodonHeaders, isMastodonHtml, isProfilePath, mastodonHandler } from './mastodon.js'
 
 const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => {
   return async (url: string) => ({
@@ -12,59 +12,144 @@ const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => 
   })
 }
 
-const mastodonHtml = '<html><head><meta name="generator" content="Mastodon v4.2.0"></head></html>'
-const mastodonHeaders = new Headers({ server: 'Mastodon' })
+describe('isProfilePath', () => {
+  it('should return true for /@ paths', () => {
+    expect(isProfilePath('/@user')).toBe(true)
+    expect(isProfilePath('/@admin')).toBe(true)
+  })
+
+  it('should return true for /@ path with trailing slash', () => {
+    expect(isProfilePath('/@user/')).toBe(true)
+  })
+
+  it('should return false for multi-segment /@ paths', () => {
+    expect(isProfilePath('/@user/123456789')).toBe(false)
+    expect(isProfilePath('/@user/with/extra')).toBe(false)
+  })
+
+  it('should return false for paths without @', () => {
+    expect(isProfilePath('/user')).toBe(false)
+    expect(isProfilePath('/about')).toBe(false)
+  })
+
+  it('should return false for root path', () => {
+    expect(isProfilePath('/')).toBe(false)
+  })
+
+  it('should return false for empty string', () => {
+    expect(isProfilePath('')).toBe(false)
+  })
+})
+
+describe('isMastodonHtml', () => {
+  it('should return true for standard Mastodon generator meta tag', () => {
+    expect(isMastodonHtml('<meta name="generator" content="Mastodon v4.2.0">')).toBe(true)
+  })
+
+  it('should return true for case variations', () => {
+    expect(isMastodonHtml('<meta name="generator" content="mastodon v4.0.0">')).toBe(true)
+    expect(isMastodonHtml('<meta name="generator" content="MASTODON v4.0.0">')).toBe(true)
+  })
+
+  it('should return true for generator tag with single quotes', () => {
+    expect(isMastodonHtml("<meta name='generator' content='Mastodon v4.2.0'>")).toBe(true)
+  })
+
+  it('should return true for tag within full HTML document', () => {
+    const value = '<html><head><meta name="generator" content="Mastodon v4.2.0"></head></html>'
+
+    expect(isMastodonHtml(value)).toBe(true)
+  })
+
+  it('should return false for non-Mastodon generator', () => {
+    expect(isMastodonHtml('<meta name="generator" content="WordPress 6.0">')).toBe(false)
+  })
+
+  it('should return false for HTML without generator tag', () => {
+    expect(isMastodonHtml('<html><head><title>Test</title></head></html>')).toBe(false)
+  })
+
+  it('should return false for empty string', () => {
+    expect(isMastodonHtml('')).toBe(false)
+  })
+})
+
+describe('isMastodonHeaders', () => {
+  it('should return true for Mastodon server header', () => {
+    expect(isMastodonHeaders(new Headers({ server: 'Mastodon' }))).toBe(true)
+  })
+
+  it('should return true for case variations', () => {
+    expect(isMastodonHeaders(new Headers({ server: 'mastodon' }))).toBe(true)
+    expect(isMastodonHeaders(new Headers({ server: 'MASTODON' }))).toBe(true)
+  })
+
+  it('should return true for server header with version', () => {
+    expect(isMastodonHeaders(new Headers({ server: 'Mastodon/4.2.0' }))).toBe(true)
+  })
+
+  it('should return true for server header containing Mastodon as substring', () => {
+    expect(isMastodonHeaders(new Headers({ server: 'nginx (Mastodon)' }))).toBe(true)
+  })
+
+  it('should return false for non-Mastodon server', () => {
+    expect(isMastodonHeaders(new Headers({ server: 'nginx' }))).toBe(false)
+    expect(isMastodonHeaders(new Headers({ server: 'Apache' }))).toBe(false)
+  })
+
+  it('should return false for missing server header', () => {
+    expect(isMastodonHeaders(new Headers())).toBe(false)
+    expect(isMastodonHeaders(new Headers({ 'content-type': 'text/html' }))).toBe(false)
+  })
+})
 
 describe('mastodonHandler', () => {
   describe('match', () => {
-    it('should match /@ profile path with Mastodon generator in HTML', () => {
-      expect(mastodonHandler.match('https://mastodon.social/@user', mastodonHtml)).toBe(true)
-      expect(mastodonHandler.match('https://example.com/@user', mastodonHtml)).toBe(true)
+    it('should match profile path with Mastodon HTML', () => {
+      const value = '<meta name="generator" content="Mastodon v4.2.0">'
+
+      expect(mastodonHandler.match('https://mastodon.social/@user', value)).toBe(true)
+      expect(mastodonHandler.match('https://example.com/@user', value)).toBe(true)
     })
 
-    it('should match /@ profile path with Mastodon server header', () => {
-      const result = mastodonHandler.match('https://example.com/@user', '', mastodonHeaders)
-
-      expect(result).toBe(true)
+    it('should match profile path with Mastodon server header', () => {
+      expect(
+        mastodonHandler.match('https://example.com/@user', '', new Headers({ server: 'Mastodon' })),
+      ).toBe(true)
     })
 
     it('should match when both HTML and headers indicate Mastodon', () => {
-      const result = mastodonHandler.match(
-        'https://example.com/@user',
-        mastodonHtml,
-        mastodonHeaders,
-      )
+      const value = '<meta name="generator" content="Mastodon v4.2.0">'
 
-      expect(result).toBe(true)
+      expect(
+        mastodonHandler.match(
+          'https://example.com/@user',
+          value,
+          new Headers({ server: 'Mastodon' }),
+        ),
+      ).toBe(true)
     })
 
     it('should not match without Mastodon signals', () => {
-      const result = mastodonHandler.match(
-        'https://example.com/@user',
-        '<html></html>',
-        new Headers({ server: 'nginx' }),
-      )
-
       expect(mastodonHandler.match('https://example.com/@user', '<html></html>')).toBe(false)
-      expect(result).toBe(false)
+      expect(
+        mastodonHandler.match('https://example.com/@user', '', new Headers({ server: 'nginx' })),
+      ).toBe(false)
     })
 
     it('should not match without content and headers', () => {
       expect(mastodonHandler.match('https://mastodon.social/@user')).toBe(false)
-      expect(mastodonHandler.match('https://mastodon.social/@user', '')).toBe(false)
     })
 
     it('should not match non-profile paths', () => {
-      expect(mastodonHandler.match('https://mastodon.social/about', mastodonHtml)).toBe(false)
-      expect(mastodonHandler.match('https://mastodon.social/', mastodonHtml)).toBe(false)
-    })
+      const value = '<meta name="generator" content="Mastodon v4.2.0">'
 
-    it('should not match non-@ profile paths', () => {
-      expect(mastodonHandler.match('https://mastodon.social/user', mastodonHtml)).toBe(false)
+      expect(mastodonHandler.match('https://mastodon.social/about', value)).toBe(false)
+      expect(mastodonHandler.match('https://mastodon.social/', value)).toBe(false)
     })
 
     it('should not match invalid URLs', () => {
-      expect(mastodonHandler.match('not-a-url', mastodonHtml)).toBe(false)
+      expect(mastodonHandler.match('not-a-url')).toBe(false)
     })
   })
 
@@ -88,8 +173,55 @@ describe('mastodonHandler', () => {
       expect(value).toEqual(expected)
     })
 
+    it('should resolve avatar from different instance', async () => {
+      const mockFetch = createMockFetch({
+        'https://hachyderm.io/api/v1/accounts/lookup?acct=dev': JSON.stringify({
+          avatar: 'https://media.hachyderm.io/avatars/dev.png',
+        }),
+      })
+      const value = await mastodonHandler.resolve(
+        'https://hachyderm.io/@dev',
+        undefined,
+        undefined,
+        mockFetch,
+      )
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://media.hachyderm.io/avatars/dev.png' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
     it('should return empty array when fetchFn is not provided', async () => {
       const value = await mastodonHandler.resolve('https://mastodon.social/@user')
+
+      expect(value).toEqual([])
+    })
+
+    it('should return empty array when avatar is empty string', async () => {
+      const mockFetch = createMockFetch({
+        'https://mastodon.social/api/v1/accounts/lookup?acct=user': JSON.stringify({ avatar: '' }),
+      })
+      const value = await mastodonHandler.resolve(
+        'https://mastodon.social/@user',
+        undefined,
+        undefined,
+        mockFetch,
+      )
+
+      expect(value).toEqual([])
+    })
+
+    it('should return empty array when avatar is not a string', async () => {
+      const mockFetch = createMockFetch({
+        'https://mastodon.social/api/v1/accounts/lookup?acct=user': JSON.stringify({ avatar: 123 }),
+      })
+      const value = await mastodonHandler.resolve(
+        'https://mastodon.social/@user',
+        undefined,
+        undefined,
+        mockFetch,
+      )
 
       expect(value).toEqual([])
     })
@@ -136,23 +268,11 @@ describe('mastodonHandler', () => {
       expect(value).toEqual([])
     })
 
-    it('should use correct API URL for different instances', async () => {
-      const mockFetch = createMockFetch({
-        'https://hachyderm.io/api/v1/accounts/lookup?acct=dev': JSON.stringify({
-          avatar: 'https://media.hachyderm.io/avatars/dev.png',
-        }),
-      })
-      const value = await mastodonHandler.resolve(
-        'https://hachyderm.io/@dev',
-        undefined,
-        undefined,
-        mockFetch,
-      )
-      const expected: Array<DiscoverUriEntry> = [
-        { uri: 'https://media.hachyderm.io/avatars/dev.png' },
-      ]
+    it('should return empty array for invalid URL', async () => {
+      const mockFetch = createMockFetch({})
+      const value = await mastodonHandler.resolve('not-a-url', undefined, undefined, mockFetch)
 
-      expect(value).toEqual(expected)
+      expect(value).toEqual([])
     })
   })
 })

--- a/src/favicons/platform/handlers/mastodon.test.ts
+++ b/src/favicons/platform/handlers/mastodon.test.ts
@@ -77,7 +77,8 @@ describe('mastodonHandler', () => {
       })
       const value = await mastodonHandler.resolve(
         'https://mastodon.social/@user',
-        mastodonHtml,
+        undefined,
+        undefined,
         mockFetch,
       )
       const expected: Array<DiscoverUriEntry> = [
@@ -88,7 +89,7 @@ describe('mastodonHandler', () => {
     })
 
     it('should return empty array when fetchFn is not provided', async () => {
-      const value = await mastodonHandler.resolve('https://mastodon.social/@user', mastodonHtml)
+      const value = await mastodonHandler.resolve('https://mastodon.social/@user')
 
       expect(value).toEqual([])
     })
@@ -99,7 +100,8 @@ describe('mastodonHandler', () => {
       })
       const value = await mastodonHandler.resolve(
         'https://mastodon.social/@user',
-        mastodonHtml,
+        undefined,
+        undefined,
         mockFetch,
       )
 
@@ -112,7 +114,8 @@ describe('mastodonHandler', () => {
       })
       const value = await mastodonHandler.resolve(
         'https://mastodon.social/@user',
-        mastodonHtml,
+        undefined,
+        undefined,
         mockFetch,
       )
 
@@ -125,7 +128,8 @@ describe('mastodonHandler', () => {
       }
       const value = await mastodonHandler.resolve(
         'https://mastodon.social/@user',
-        mastodonHtml,
+        undefined,
+        undefined,
         mockFetch,
       )
 
@@ -140,7 +144,8 @@ describe('mastodonHandler', () => {
       })
       const value = await mastodonHandler.resolve(
         'https://hachyderm.io/@dev',
-        mastodonHtml,
+        undefined,
+        undefined,
         mockFetch,
       )
       const expected: Array<DiscoverUriEntry> = [

--- a/src/favicons/platform/handlers/mastodon.ts
+++ b/src/favicons/platform/handlers/mastodon.ts
@@ -30,11 +30,9 @@ export const mastodonHandler: PlatformHandler = {
       if (headers && isMastodonHeaders(headers)) {
         return true
       }
+    } catch {}
 
-      return false
-    } catch {
-      return false
-    }
+    return false
   },
 
   resolve: async (url, _content, _headers, fetchFn) => {

--- a/src/favicons/platform/handlers/mastodon.ts
+++ b/src/favicons/platform/handlers/mastodon.ts
@@ -1,16 +1,16 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 
-const isProfilePath = (pathname: string): boolean => {
+export const isProfilePath = (pathname: string): boolean => {
   const segments = pathname.split('/').filter(Boolean)
 
   return segments.length === 1 && segments[0].startsWith('@')
 }
 
-const isMastodonHtml = (html: string): boolean => {
-  return /<meta[^>]+name=["']generator["'][^>]+content=["']Mastodon/i.test(html)
+export const isMastodonHtml = (content: string): boolean => {
+  return /<meta[^>]+name=["']generator["'][^>]+content=["']Mastodon/i.test(content)
 }
 
-const isMastodonHeaders = (headers: Headers): boolean => {
+export const isMastodonHeaders = (headers: Headers): boolean => {
   return /mastodon/i.test(headers.get('server') ?? '')
 }
 

--- a/src/favicons/platform/handlers/mastodon.ts
+++ b/src/favicons/platform/handlers/mastodon.ts
@@ -1,0 +1,61 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+
+const isProfilePath = (pathname: string): boolean => {
+  const segments = pathname.split('/').filter(Boolean)
+
+  return segments.length === 1 && segments[0].startsWith('@')
+}
+
+const isMastodonHtml = (html: string): boolean => {
+  return /<meta[^>]+name=["']generator["'][^>]+content=["']Mastodon/i.test(html)
+}
+
+const isMastodonHeaders = (headers: Headers): boolean => {
+  return /mastodon/i.test(headers.get('server') ?? '')
+}
+
+export const mastodonHandler: PlatformHandler = {
+  match: (url, content, headers) => {
+    try {
+      const { pathname } = new URL(url)
+
+      if (!isProfilePath(pathname)) {
+        return false
+      }
+
+      if (content && isMastodonHtml(content)) {
+        return true
+      }
+
+      if (headers && isMastodonHeaders(headers)) {
+        return true
+      }
+
+      return false
+    } catch {
+      return false
+    }
+  },
+
+  resolve: async (url, _content, fetchFn) => {
+    if (!fetchFn) {
+      return []
+    }
+
+    try {
+      const { hostname, pathname } = new URL(url)
+      const username = pathname.split('/').filter(Boolean)[0].replace('@', '')
+      const apiUrl = `https://${hostname}/api/v1/accounts/lookup?acct=${username}`
+      const response = await fetchFn(apiUrl)
+      const data = JSON.parse(typeof response.body === 'string' ? response.body : '')
+
+      if (typeof data.avatar === 'string' && data.avatar.length > 0) {
+        return [{ uri: data.avatar }]
+      }
+
+      return []
+    } catch {
+      return []
+    }
+  },
+}

--- a/src/favicons/platform/handlers/mastodon.ts
+++ b/src/favicons/platform/handlers/mastodon.ts
@@ -37,7 +37,7 @@ export const mastodonHandler: PlatformHandler = {
     }
   },
 
-  resolve: async (url, _content, fetchFn) => {
+  resolve: async (url, _content, _headers, fetchFn) => {
     if (!fetchFn) {
       return []
     }


### PR DESCRIPTION
This PR adds a Mastodon favicon handler, working against any instance rather than a hardcoded list.

- Add Mastodon handler that detects instances via HTML generator meta tag or `Server` header
- Resolves profile avatars via `/api/v1/accounts/lookup` API
- Works with any Mastodon instance, no hardcoded instance list
