### PR TITLE
feat: Add Bluesky favicon platform handler

### DIFF
--- a/src/favicons/defaults.ts
+++ b/src/favicons/defaults.ts
@@ -3,6 +3,7 @@ import type { GuessMethodOptions } from '../common/uris/guess/types.js'
 import type { HeadersMethodOptions } from '../common/uris/headers/types.js'
 import type { HtmlMethodOptions } from '../common/uris/html/types.js'
 import type { PlatformMethodOptions } from '../common/uris/platform/types.js'
+import { blueskyHandler } from './platform/handlers/bluesky.js'
 import { githubHandler } from './platform/handlers/github.js'
 import { mastodonHandler } from './platform/handlers/mastodon.js'
 
@@ -39,5 +40,5 @@ export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
 }
 
 export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
-  handlers: [githubHandler, mastodonHandler],
+  handlers: [githubHandler, mastodonHandler, blueskyHandler],
 }

--- a/src/favicons/index.test.ts
+++ b/src/favicons/index.test.ts
@@ -218,6 +218,25 @@ describe('discoverFavicons', () => {
     expect(value).toEqual(expected)
   })
 
+  it('should discover favicon from bluesky platform handler', async () => {
+    const avatarUrl = 'https://cdn.bsky.app/img/avatar/plain/did:plc:abc123/avatar.jpg'
+    const mockFetch = createMockFetch({
+      'https://bsky.app/profile/user.bsky.social': '<html></html>',
+      'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=user.bsky.social':
+        JSON.stringify({ avatar: avatarUrl }),
+      [avatarUrl]: 'binary',
+    })
+    const value = await discoverFavicons('https://bsky.app/profile/user.bsky.social', {
+      methods: ['platform'],
+      fetchFn: mockFetch,
+    })
+    const expected: Array<DiscoverResult<FaviconResult>> = [
+      { url: avatarUrl, isValid: true, method: 'platform' },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
   it('should return empty array for invalid URLs', async () => {
     const mockFetch = createMockFetch({})
     const value = await discoverFavicons('not-a-valid-url', {

--- a/src/favicons/platform/handlers/bluesky.test.ts
+++ b/src/favicons/platform/handlers/bluesky.test.ts
@@ -57,7 +57,8 @@ describe('blueskyHandler', () => {
       })
       const value = await blueskyHandler.resolve(
         'https://bsky.app/profile/user.bsky.social',
-        '',
+        undefined,
+        undefined,
         mockFetch,
       )
       const expected: Array<DiscoverUriEntry> = [{ uri: avatarUrl }]
@@ -66,7 +67,7 @@ describe('blueskyHandler', () => {
     })
 
     it('should return empty array when fetchFn is not provided', async () => {
-      const value = await blueskyHandler.resolve('https://bsky.app/profile/user.bsky.social', '')
+      const value = await blueskyHandler.resolve('https://bsky.app/profile/user.bsky.social')
 
       expect(value).toEqual([])
     })
@@ -78,7 +79,8 @@ describe('blueskyHandler', () => {
       })
       const value = await blueskyHandler.resolve(
         'https://bsky.app/profile/user.bsky.social',
-        '',
+        undefined,
+        undefined,
         mockFetch,
       )
 
@@ -92,7 +94,8 @@ describe('blueskyHandler', () => {
       })
       const value = await blueskyHandler.resolve(
         'https://bsky.app/profile/user.bsky.social',
-        '',
+        undefined,
+        undefined,
         mockFetch,
       )
 
@@ -105,7 +108,8 @@ describe('blueskyHandler', () => {
       }
       const value = await blueskyHandler.resolve(
         'https://bsky.app/profile/user.bsky.social',
-        '',
+        undefined,
+        undefined,
         mockFetch,
       )
 
@@ -120,7 +124,8 @@ describe('blueskyHandler', () => {
       })
       const value = await blueskyHandler.resolve(
         'https://bsky.app/profile/example.com',
-        '',
+        undefined,
+        undefined,
         mockFetch,
       )
       const expected: Array<DiscoverUriEntry> = [{ uri: avatarUrl }]

--- a/src/favicons/platform/handlers/bluesky.test.ts
+++ b/src/favicons/platform/handlers/bluesky.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import type { DiscoverFetchFn, DiscoverUriEntry } from '../../../common/types.js'
-import { blueskyHandler } from './bluesky.js'
+import { blueskyHandler, isProfilePath } from './bluesky.js'
 
 const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => {
   return async (url: string) => ({
@@ -12,6 +12,45 @@ const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => 
   })
 }
 
+describe('isProfilePath', () => {
+  it('should return true for /profile/handle paths', () => {
+    expect(isProfilePath('/profile/user.bsky.social')).toBe(true)
+    expect(isProfilePath('/profile/example.com')).toBe(true)
+  })
+
+  it('should return true for /profile/handle with extra segments', () => {
+    expect(isProfilePath('/profile/user.bsky.social/posts')).toBe(true)
+    expect(isProfilePath('/profile/user.bsky.social/followers')).toBe(true)
+  })
+
+  it('should return true for /profile/handle with trailing slash', () => {
+    expect(isProfilePath('/profile/user.bsky.social/')).toBe(true)
+  })
+
+  it('should return false for /profile without handle', () => {
+    expect(isProfilePath('/profile')).toBe(false)
+    expect(isProfilePath('/profile/')).toBe(false)
+  })
+
+  it('should return false for non-profile paths', () => {
+    expect(isProfilePath('/about')).toBe(false)
+    expect(isProfilePath('/settings')).toBe(false)
+  })
+
+  it('should return false for case variation of /profile', () => {
+    expect(isProfilePath('/Profile/user.bsky.social')).toBe(false)
+    expect(isProfilePath('/PROFILE/user.bsky.social')).toBe(false)
+  })
+
+  it('should return false for root path', () => {
+    expect(isProfilePath('/')).toBe(false)
+  })
+
+  it('should return false for empty string', () => {
+    expect(isProfilePath('')).toBe(false)
+  })
+})
+
 describe('blueskyHandler', () => {
   describe('match', () => {
     it('should match bsky.app profile URLs', () => {
@@ -22,10 +61,6 @@ describe('blueskyHandler', () => {
       expect(blueskyHandler.match('https://www.bsky.app/profile/user.bsky.social')).toBe(true)
     })
 
-    it('should match custom domain handles', () => {
-      expect(blueskyHandler.match('https://bsky.app/profile/example.com')).toBe(true)
-    })
-
     it('should match profile URLs with extra path segments', () => {
       expect(blueskyHandler.match('https://bsky.app/profile/user.bsky.social/posts')).toBe(true)
     })
@@ -33,10 +68,6 @@ describe('blueskyHandler', () => {
     it('should not match non-profile paths', () => {
       expect(blueskyHandler.match('https://bsky.app/about')).toBe(false)
       expect(blueskyHandler.match('https://bsky.app/')).toBe(false)
-    })
-
-    it('should not match profile path without handle', () => {
-      expect(blueskyHandler.match('https://bsky.app/profile')).toBe(false)
     })
 
     it('should not match non-bsky URLs', () => {
@@ -50,10 +81,11 @@ describe('blueskyHandler', () => {
 
   describe('resolve', () => {
     it('should resolve avatar from Bluesky API', async () => {
-      const avatarUrl = 'https://cdn.bsky.app/img/avatar/plain/did:plc:abc123/avatar.jpg'
       const mockFetch = createMockFetch({
         'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=user.bsky.social':
-          JSON.stringify({ avatar: avatarUrl }),
+          JSON.stringify({
+            avatar: 'https://cdn.bsky.app/img/avatar/plain/did:plc:abc123/avatar.jpg',
+          }),
       })
       const value = await blueskyHandler.resolve(
         'https://bsky.app/profile/user.bsky.social',
@@ -61,13 +93,65 @@ describe('blueskyHandler', () => {
         undefined,
         mockFetch,
       )
-      const expected: Array<DiscoverUriEntry> = [{ uri: avatarUrl }]
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://cdn.bsky.app/img/avatar/plain/did:plc:abc123/avatar.jpg' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve avatar for custom domain handle', async () => {
+      const mockFetch = createMockFetch({
+        'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=example.com':
+          JSON.stringify({
+            avatar: 'https://cdn.bsky.app/img/avatar/plain/did:plc:xyz/avatar.jpg',
+          }),
+      })
+      const value = await blueskyHandler.resolve(
+        'https://bsky.app/profile/example.com',
+        undefined,
+        undefined,
+        mockFetch,
+      )
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://cdn.bsky.app/img/avatar/plain/did:plc:xyz/avatar.jpg' },
+      ]
 
       expect(value).toEqual(expected)
     })
 
     it('should return empty array when fetchFn is not provided', async () => {
       const value = await blueskyHandler.resolve('https://bsky.app/profile/user.bsky.social')
+
+      expect(value).toEqual([])
+    })
+
+    it('should return empty array when avatar is empty string', async () => {
+      const mockFetch = createMockFetch({
+        'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=user.bsky.social':
+          JSON.stringify({ avatar: '' }),
+      })
+      const value = await blueskyHandler.resolve(
+        'https://bsky.app/profile/user.bsky.social',
+        undefined,
+        undefined,
+        mockFetch,
+      )
+
+      expect(value).toEqual([])
+    })
+
+    it('should return empty array when avatar is not a string', async () => {
+      const mockFetch = createMockFetch({
+        'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=user.bsky.social':
+          JSON.stringify({ avatar: 123 }),
+      })
+      const value = await blueskyHandler.resolve(
+        'https://bsky.app/profile/user.bsky.social',
+        undefined,
+        undefined,
+        mockFetch,
+      )
 
       expect(value).toEqual([])
     })
@@ -116,21 +200,11 @@ describe('blueskyHandler', () => {
       expect(value).toEqual([])
     })
 
-    it('should handle custom domain handles', async () => {
-      const avatarUrl = 'https://cdn.bsky.app/img/avatar/plain/did:plc:xyz/avatar.jpg'
-      const mockFetch = createMockFetch({
-        'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=example.com':
-          JSON.stringify({ avatar: avatarUrl }),
-      })
-      const value = await blueskyHandler.resolve(
-        'https://bsky.app/profile/example.com',
-        undefined,
-        undefined,
-        mockFetch,
-      )
-      const expected: Array<DiscoverUriEntry> = [{ uri: avatarUrl }]
+    it('should return empty array for invalid URL', async () => {
+      const mockFetch = createMockFetch({})
+      const value = await blueskyHandler.resolve('not-a-url', undefined, undefined, mockFetch)
 
-      expect(value).toEqual(expected)
+      expect(value).toEqual([])
     })
   })
 })

--- a/src/favicons/platform/handlers/bluesky.test.ts
+++ b/src/favicons/platform/handlers/bluesky.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'bun:test'
+import type { DiscoverFetchFn, DiscoverUriEntry } from '../../../common/types.js'
+import { blueskyHandler } from './bluesky.js'
+
+const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => {
+  return async (url: string) => ({
+    url,
+    body: responses[url] ?? '',
+    headers: new Headers(),
+    status: url in responses ? 200 : 404,
+    statusText: url in responses ? 'OK' : 'Not Found',
+  })
+}
+
+describe('blueskyHandler', () => {
+  describe('match', () => {
+    it('should match bsky.app profile URLs', () => {
+      expect(blueskyHandler.match('https://bsky.app/profile/user.bsky.social')).toBe(true)
+    })
+
+    it('should match www.bsky.app profile URLs', () => {
+      expect(blueskyHandler.match('https://www.bsky.app/profile/user.bsky.social')).toBe(true)
+    })
+
+    it('should match custom domain handles', () => {
+      expect(blueskyHandler.match('https://bsky.app/profile/example.com')).toBe(true)
+    })
+
+    it('should match profile URLs with extra path segments', () => {
+      expect(blueskyHandler.match('https://bsky.app/profile/user.bsky.social/posts')).toBe(true)
+    })
+
+    it('should not match non-profile paths', () => {
+      expect(blueskyHandler.match('https://bsky.app/about')).toBe(false)
+      expect(blueskyHandler.match('https://bsky.app/')).toBe(false)
+    })
+
+    it('should not match profile path without handle', () => {
+      expect(blueskyHandler.match('https://bsky.app/profile')).toBe(false)
+    })
+
+    it('should not match non-bsky URLs', () => {
+      expect(blueskyHandler.match('https://example.com/profile/user')).toBe(false)
+    })
+
+    it('should not match invalid URLs', () => {
+      expect(blueskyHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should resolve avatar from Bluesky API', async () => {
+      const avatarUrl = 'https://cdn.bsky.app/img/avatar/plain/did:plc:abc123/avatar.jpg'
+      const mockFetch = createMockFetch({
+        'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=user.bsky.social':
+          JSON.stringify({ avatar: avatarUrl }),
+      })
+      const value = await blueskyHandler.resolve(
+        'https://bsky.app/profile/user.bsky.social',
+        '',
+        mockFetch,
+      )
+      const expected: Array<DiscoverUriEntry> = [{ uri: avatarUrl }]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should return empty array when fetchFn is not provided', async () => {
+      const value = await blueskyHandler.resolve('https://bsky.app/profile/user.bsky.social', '')
+
+      expect(value).toEqual([])
+    })
+
+    it('should return empty array when API returns no avatar', async () => {
+      const mockFetch = createMockFetch({
+        'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=user.bsky.social':
+          JSON.stringify({}),
+      })
+      const value = await blueskyHandler.resolve(
+        'https://bsky.app/profile/user.bsky.social',
+        '',
+        mockFetch,
+      )
+
+      expect(value).toEqual([])
+    })
+
+    it('should return empty array when API returns invalid JSON', async () => {
+      const mockFetch = createMockFetch({
+        'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=user.bsky.social':
+          'not json',
+      })
+      const value = await blueskyHandler.resolve(
+        'https://bsky.app/profile/user.bsky.social',
+        '',
+        mockFetch,
+      )
+
+      expect(value).toEqual([])
+    })
+
+    it('should return empty array when fetch throws', async () => {
+      const mockFetch: DiscoverFetchFn = async () => {
+        throw new Error('Network error')
+      }
+      const value = await blueskyHandler.resolve(
+        'https://bsky.app/profile/user.bsky.social',
+        '',
+        mockFetch,
+      )
+
+      expect(value).toEqual([])
+    })
+
+    it('should handle custom domain handles', async () => {
+      const avatarUrl = 'https://cdn.bsky.app/img/avatar/plain/did:plc:xyz/avatar.jpg'
+      const mockFetch = createMockFetch({
+        'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=example.com':
+          JSON.stringify({ avatar: avatarUrl }),
+      })
+      const value = await blueskyHandler.resolve(
+        'https://bsky.app/profile/example.com',
+        '',
+        mockFetch,
+      )
+      const expected: Array<DiscoverUriEntry> = [{ uri: avatarUrl }]
+
+      expect(value).toEqual(expected)
+    })
+  })
+})

--- a/src/favicons/platform/handlers/bluesky.ts
+++ b/src/favicons/platform/handlers/bluesky.ts
@@ -20,7 +20,7 @@ export const blueskyHandler: PlatformHandler = {
     }
   },
 
-  resolve: async (url, _content, fetchFn) => {
+  resolve: async (url, _content, _headers, fetchFn) => {
     if (!fetchFn) {
       return []
     }

--- a/src/favicons/platform/handlers/bluesky.ts
+++ b/src/favicons/platform/handlers/bluesky.ts
@@ -1,0 +1,45 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { isHostOf } from '../../../common/utils.js'
+
+const hosts = ['bsky.app', 'www.bsky.app']
+
+const isProfilePath = (pathname: string): boolean => {
+  const segments = pathname.split('/').filter(Boolean)
+
+  return segments.length >= 2 && segments[0] === 'profile'
+}
+
+export const blueskyHandler: PlatformHandler = {
+  match: (url) => {
+    try {
+      const { pathname } = new URL(url)
+
+      return isHostOf(url, hosts) && isProfilePath(pathname)
+    } catch {
+      return false
+    }
+  },
+
+  resolve: async (url, _content, fetchFn) => {
+    if (!fetchFn) {
+      return []
+    }
+
+    try {
+      const { pathname } = new URL(url)
+      const segments = pathname.split('/').filter(Boolean)
+      const handle = segments[1]
+      const apiUrl = `https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=${handle}`
+      const response = await fetchFn(apiUrl)
+      const data = JSON.parse(typeof response.body === 'string' ? response.body : '')
+
+      if (typeof data.avatar === 'string' && data.avatar.length > 0) {
+        return [{ uri: data.avatar }]
+      }
+
+      return []
+    } catch {
+      return []
+    }
+  },
+}

--- a/src/favicons/platform/handlers/bluesky.ts
+++ b/src/favicons/platform/handlers/bluesky.ts
@@ -12,12 +12,10 @@ export const isProfilePath = (pathname: string): boolean => {
 export const blueskyHandler: PlatformHandler = {
   match: (url) => {
     try {
-      const { pathname } = new URL(url)
+      return isHostOf(url, hosts) && isProfilePath(new URL(url).pathname)
+    } catch {}
 
-      return isHostOf(url, hosts) && isProfilePath(pathname)
-    } catch {
-      return false
-    }
+    return false
   },
 
   resolve: async (url, _content, _headers, fetchFn) => {

--- a/src/favicons/platform/handlers/bluesky.ts
+++ b/src/favicons/platform/handlers/bluesky.ts
@@ -1,9 +1,9 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { isHostOf } from '../../../common/utils.js'
 
-const hosts = ['bsky.app', 'www.bsky.app']
+export const hosts = ['bsky.app', 'www.bsky.app']
 
-const isProfilePath = (pathname: string): boolean => {
+export const isProfilePath = (pathname: string): boolean => {
   const segments = pathname.split('/').filter(Boolean)
 
   return segments.length >= 2 && segments[0] === 'profile'


### PR DESCRIPTION
This PR adds a Bluesky favicon handler, resolving profile avatars through the AT Protocol public API.

- Add Bluesky handler that resolves profile avatars via AT Protocol public API
- Uses `app.bsky.actor.getProfile` endpoint to look up avatar URLs
- Supports both `.bsky.social` handles and custom domain handles
