### PR TITLE
feat: Make platform pipeline async with content/headers in match

### DIFF
--- a/src/common/discover/index.ts
+++ b/src/common/discover/index.ts
@@ -48,7 +48,7 @@ export const discover = async <TValid>(
   const methodsConfig = normalizeMethodsConfig(normalizedInput, methods, defaults)
 
   // Step 3: Discover URIs using selected methods.
-  const urisByMethod = discoverUris(methodsConfig)
+  const urisByMethod = await discoverUris(methodsConfig, fetchFn)
 
   // Step 4: Normalize and deduplicate URIs per method group, deduping across groups.
   const seen = new Set<string>()

--- a/src/common/discover/utils.ts
+++ b/src/common/discover/utils.ts
@@ -80,6 +80,7 @@ export const normalizeMethodsConfig = (
 
     methodsConfig.platform = {
       html: input.content ?? '',
+      headers: input.headers,
       options: {
         ...defaults.platform,
         ...platformOptions,

--- a/src/common/discover/utils.ts
+++ b/src/common/discover/utils.ts
@@ -79,7 +79,7 @@ export const normalizeMethodsConfig = (
     const platformOptions = methodsObj.platform === true ? {} : methodsObj.platform
 
     methodsConfig.platform = {
-      html: input.content ?? '',
+      content: input.content ?? '',
       headers: input.headers,
       options: {
         ...defaults.platform,

--- a/src/common/discover/utils.ts
+++ b/src/common/discover/utils.ts
@@ -79,7 +79,7 @@ export const normalizeMethodsConfig = (
     const platformOptions = methodsObj.platform === true ? {} : methodsObj.platform
 
     methodsConfig.platform = {
-      content: input.content ?? '',
+      content: input.content,
       headers: input.headers,
       options: {
         ...defaults.platform,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -110,7 +110,7 @@ export type DiscoverMethodsConfigDefaults = {
 // Internal methods config with full options and input data.
 export type DiscoverMethodsConfigInternal = {
   platform?: {
-    content: string
+    content?: string
     headers?: Headers
     options: PlatformMethodOptions
   }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -111,6 +111,7 @@ export type DiscoverMethodsConfigDefaults = {
 export type DiscoverMethodsConfigInternal = {
   platform?: {
     html: string
+    headers?: Headers
     options: PlatformMethodOptions
   }
   html?: {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -110,7 +110,7 @@ export type DiscoverMethodsConfigDefaults = {
 // Internal methods config with full options and input data.
 export type DiscoverMethodsConfigInternal = {
   platform?: {
-    html: string
+    content: string
     headers?: Headers
     options: PlatformMethodOptions
   }

--- a/src/common/uris/index.test.ts
+++ b/src/common/uris/index.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'bun:test'
 import { discoverUris } from './index.js'
 
 describe('discoverUris', () => {
-  it('should return empty object when no methods configured', () => {
-    const value = discoverUris({})
+  it('should return empty object when no methods configured', async () => {
+    const value = await discoverUris({})
     const expected = {}
 
     expect(value).toEqual(expected)
   })
 
-  it('should discover URIs from HTML method', () => {
-    const value = discoverUris({
+  it('should discover URIs from HTML method', async () => {
+    const value = await discoverUris({
       html: {
         html: '<link rel="alternate" type="application/rss+xml" href="/feed.xml">',
         options: {
@@ -26,11 +26,11 @@ describe('discoverUris', () => {
     expect(value).toEqual(expected)
   })
 
-  it('should discover URIs from Headers method', () => {
+  it('should discover URIs from Headers method', async () => {
     const headers = new Headers({
       Link: '</feed.xml>; rel="alternate"; type="application/rss+xml"',
     })
-    const value = discoverUris({
+    const value = await discoverUris({
       headers: {
         headers,
         options: {
@@ -43,8 +43,8 @@ describe('discoverUris', () => {
     expect(value).toEqual(expected)
   })
 
-  it('should discover URIs from Guess method', () => {
-    const value = discoverUris({
+  it('should discover URIs from Guess method', async () => {
+    const value = await discoverUris({
       guess: {
         options: {
           baseUrl: 'https://example.com',
@@ -59,11 +59,11 @@ describe('discoverUris', () => {
     expect(value).toEqual(expected)
   })
 
-  it('should return URIs from all methods in separate properties', () => {
+  it('should return URIs from all methods in separate properties', async () => {
     const headers = new Headers({
       Link: '</rss.xml>; rel="alternate"; type="application/rss+xml"',
     })
-    const value = discoverUris({
+    const value = await discoverUris({
       html: {
         html: '<link rel="alternate" type="application/rss+xml" href="/feed.xml">',
         options: {
@@ -95,11 +95,11 @@ describe('discoverUris', () => {
     expect(value).toEqual(expected)
   })
 
-  it('should keep duplicate URIs across methods in separate properties', () => {
+  it('should keep duplicate URIs across methods in separate properties', async () => {
     const headers = new Headers({
       Link: '</feed.xml>; rel="alternate"; type="application/rss+xml", </rss.xml>; rel="alternate"; type="application/rss+xml"',
     })
-    const value = discoverUris({
+    const value = await discoverUris({
       html: {
         html: '<link rel="alternate" type="application/rss+xml" href="/feed.xml"><link rel="feed" href="/rss.xml">',
         options: {
@@ -124,8 +124,8 @@ describe('discoverUris', () => {
     expect(value).toEqual(expected)
   })
 
-  it('should skip methods that return empty results', () => {
-    const value = discoverUris({
+  it('should skip methods that return empty results', async () => {
+    const value = await discoverUris({
       html: {
         html: '<div>No feeds here</div>',
         options: {
@@ -147,8 +147,8 @@ describe('discoverUris', () => {
     expect(value).toEqual(expected)
   })
 
-  it('should pass through array entries from platform handler', () => {
-    const value = discoverUris({
+  it('should pass through array entries from platform handler', async () => {
+    const value = await discoverUris({
       platform: {
         html: '',
         options: {
@@ -175,8 +175,8 @@ describe('discoverUris', () => {
     expect(value).toEqual(expected)
   })
 
-  it('should handle mixed string and array entries across methods', () => {
-    const value = discoverUris({
+  it('should handle mixed string and array entries across methods', async () => {
+    const value = await discoverUris({
       platform: {
         html: '',
         options: {

--- a/src/common/uris/index.test.ts
+++ b/src/common/uris/index.test.ts
@@ -150,7 +150,6 @@ describe('discoverUris', () => {
   it('should pass through array entries from platform handler', async () => {
     const value = await discoverUris({
       platform: {
-        content: '',
         options: {
           baseUrl: 'https://example.com',
           handlers: [
@@ -178,7 +177,6 @@ describe('discoverUris', () => {
   it('should handle mixed string and array entries across methods', async () => {
     const value = await discoverUris({
       platform: {
-        content: '',
         options: {
           baseUrl: 'https://example.com',
           handlers: [

--- a/src/common/uris/index.test.ts
+++ b/src/common/uris/index.test.ts
@@ -150,7 +150,7 @@ describe('discoverUris', () => {
   it('should pass through array entries from platform handler', async () => {
     const value = await discoverUris({
       platform: {
-        html: '',
+        content: '',
         options: {
           baseUrl: 'https://example.com',
           handlers: [
@@ -178,7 +178,7 @@ describe('discoverUris', () => {
   it('should handle mixed string and array entries across methods', async () => {
     const value = await discoverUris({
       platform: {
-        html: '',
+        content: '',
         options: {
           baseUrl: 'https://example.com',
           handlers: [

--- a/src/common/uris/index.ts
+++ b/src/common/uris/index.ts
@@ -16,7 +16,7 @@ export const discoverUris = async (
 
   if (config.platform) {
     const uris = await discoverUrisFromPlatform(
-      config.platform.html,
+      config.platform.content,
       config.platform.headers,
       config.platform.options,
       fetchFn,

--- a/src/common/uris/index.ts
+++ b/src/common/uris/index.ts
@@ -1,14 +1,26 @@
-import type { DiscoverMethodsConfigInternal, DiscoverUrisResult } from '../types.js'
+import type {
+  DiscoverFetchFn,
+  DiscoverMethodsConfigInternal,
+  DiscoverUrisResult,
+} from '../types.js'
 import { discoverUrisFromGuess } from './guess/index.js'
 import { discoverUrisFromHeaders } from './headers/index.js'
 import { discoverUrisFromHtml } from './html/index.js'
 import { discoverUrisFromPlatform } from './platform/index.js'
 
-export const discoverUris = (config: DiscoverMethodsConfigInternal): DiscoverUrisResult => {
+export const discoverUris = async (
+  config: DiscoverMethodsConfigInternal,
+  fetchFn?: DiscoverFetchFn,
+): Promise<DiscoverUrisResult> => {
   const result: DiscoverUrisResult = {}
 
   if (config.platform) {
-    const uris = discoverUrisFromPlatform(config.platform.html, config.platform.options)
+    const uris = await discoverUrisFromPlatform(
+      config.platform.html,
+      config.platform.headers,
+      config.platform.options,
+      fetchFn,
+    )
 
     if (uris.length > 0) {
       result.platform = uris

--- a/src/common/uris/platform/index.test.ts
+++ b/src/common/uris/platform/index.test.ts
@@ -11,7 +11,7 @@ describe('discoverUrisFromPlatform', () => {
     const value = { baseUrl: 'https://example.com', handlers: [handler] }
     const expected = [{ uri: 'https://example.com/feed.xml' }]
 
-    expect(await discoverUrisFromPlatform('', undefined, value)).toEqual(expected)
+    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual(expected)
   })
 
   it('should return empty array when no handler matches', async () => {
@@ -21,13 +21,13 @@ describe('discoverUrisFromPlatform', () => {
     }
     const value = { baseUrl: 'https://example.com', handlers: [handler] }
 
-    expect(await discoverUrisFromPlatform('', undefined, value)).toEqual([])
+    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual([])
   })
 
   it('should return empty array when handlers array is empty', async () => {
     const value = { baseUrl: 'https://example.com', handlers: [] }
 
-    expect(await discoverUrisFromPlatform('', undefined, value)).toEqual([])
+    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual([])
   })
 
   it('should continue to next handler if first handler throws', async () => {
@@ -47,7 +47,7 @@ describe('discoverUrisFromPlatform', () => {
     }
     const expected = [{ uri: 'https://example.com/feed.xml' }]
 
-    expect(await discoverUrisFromPlatform('', undefined, value)).toEqual(expected)
+    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual(expected)
   })
 
   it('should continue to next handler if resolve throws', async () => {
@@ -67,7 +67,7 @@ describe('discoverUrisFromPlatform', () => {
     }
     const expected = [{ uri: 'https://example.com/feed.xml' }]
 
-    expect(await discoverUrisFromPlatform('', undefined, value)).toEqual(expected)
+    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual(expected)
   })
 
   it('should pass html content to handler resolve method', async () => {
@@ -105,7 +105,7 @@ describe('discoverUrisFromPlatform', () => {
     }
     const value = { baseUrl: 'https://example.com/page', handlers: [handler] }
 
-    await discoverUrisFromPlatform('', undefined, value)
+    await discoverUrisFromPlatform(undefined, undefined, value)
 
     expect(matchedUrl).toBe('https://example.com/page')
     expect(resolvedUrl).toBe('https://example.com/page')
@@ -126,7 +126,7 @@ describe('discoverUrisFromPlatform', () => {
     }
     const expected = [{ uri: 'https://example.com/first.xml' }]
 
-    expect(await discoverUrisFromPlatform('', undefined, value)).toEqual(expected)
+    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual(expected)
   })
 
   it('should not call resolve on non-matching handlers', async () => {
@@ -148,7 +148,7 @@ describe('discoverUrisFromPlatform', () => {
       handlers: [firstHandler, secondHandler],
     }
 
-    await discoverUrisFromPlatform('', undefined, value)
+    await discoverUrisFromPlatform(undefined, undefined, value)
 
     expect(secondResolvedCalled).toBe(false)
   })
@@ -176,7 +176,7 @@ describe('discoverUrisFromPlatform', () => {
       handlers: [firstHandler, secondHandler],
     }
 
-    await discoverUrisFromPlatform('', undefined, value)
+    await discoverUrisFromPlatform(undefined, undefined, value)
 
     expect(callOrder).toEqual(['first', 'second'])
   })

--- a/src/common/uris/platform/index.test.ts
+++ b/src/common/uris/platform/index.test.ts
@@ -3,7 +3,7 @@ import { discoverUrisFromPlatform } from './index.js'
 import type { PlatformHandler } from './types.js'
 
 describe('discoverUrisFromPlatform', () => {
-  it('should return URIs when handler matches', () => {
+  it('should return URIs when handler matches', async () => {
     const handler: PlatformHandler = {
       match: () => true,
       resolve: () => [{ uri: 'https://example.com/feed.xml' }],
@@ -11,26 +11,26 @@ describe('discoverUrisFromPlatform', () => {
     const value = { baseUrl: 'https://example.com', handlers: [handler] }
     const expected = [{ uri: 'https://example.com/feed.xml' }]
 
-    expect(discoverUrisFromPlatform('', value)).toEqual(expected)
+    expect(await discoverUrisFromPlatform('', undefined, value)).toEqual(expected)
   })
 
-  it('should return empty array when no handler matches', () => {
+  it('should return empty array when no handler matches', async () => {
     const handler: PlatformHandler = {
       match: () => false,
       resolve: () => [{ uri: 'https://example.com/feed.xml' }],
     }
     const value = { baseUrl: 'https://example.com', handlers: [handler] }
 
-    expect(discoverUrisFromPlatform('', value)).toEqual([])
+    expect(await discoverUrisFromPlatform('', undefined, value)).toEqual([])
   })
 
-  it('should return empty array when handlers array is empty', () => {
+  it('should return empty array when handlers array is empty', async () => {
     const value = { baseUrl: 'https://example.com', handlers: [] }
 
-    expect(discoverUrisFromPlatform('', value)).toEqual([])
+    expect(await discoverUrisFromPlatform('', undefined, value)).toEqual([])
   })
 
-  it('should continue to next handler if first handler throws', () => {
+  it('should continue to next handler if first handler throws', async () => {
     const throwingHandler: PlatformHandler = {
       match: () => {
         throw new Error('Handler error')
@@ -47,10 +47,10 @@ describe('discoverUrisFromPlatform', () => {
     }
     const expected = [{ uri: 'https://example.com/feed.xml' }]
 
-    expect(discoverUrisFromPlatform('', value)).toEqual(expected)
+    expect(await discoverUrisFromPlatform('', undefined, value)).toEqual(expected)
   })
 
-  it('should continue to next handler if resolve throws', () => {
+  it('should continue to next handler if resolve throws', async () => {
     const throwingHandler: PlatformHandler = {
       match: () => true,
       resolve: () => {
@@ -67,10 +67,10 @@ describe('discoverUrisFromPlatform', () => {
     }
     const expected = [{ uri: 'https://example.com/feed.xml' }]
 
-    expect(discoverUrisFromPlatform('', value)).toEqual(expected)
+    expect(await discoverUrisFromPlatform('', undefined, value)).toEqual(expected)
   })
 
-  it('should pass html content to handler resolve method', () => {
+  it('should pass html content to handler resolve method', async () => {
     let receivedHtml = ''
     const handler: PlatformHandler = {
       match: () => true,
@@ -83,12 +83,12 @@ describe('discoverUrisFromPlatform', () => {
     const html = '<html><body>Test</body></html>'
     const value = { baseUrl: 'https://example.com', handlers: [handler] }
 
-    discoverUrisFromPlatform(html, value)
+    await discoverUrisFromPlatform(html, undefined, value)
 
     expect(receivedHtml).toBe(html)
   })
 
-  it('should pass baseUrl to handler match and resolve methods', () => {
+  it('should pass baseUrl to handler match and resolve methods', async () => {
     let matchedUrl = ''
     let resolvedUrl = ''
     const handler: PlatformHandler = {
@@ -105,13 +105,13 @@ describe('discoverUrisFromPlatform', () => {
     }
     const value = { baseUrl: 'https://example.com/page', handlers: [handler] }
 
-    discoverUrisFromPlatform('', value)
+    await discoverUrisFromPlatform('', undefined, value)
 
     expect(matchedUrl).toBe('https://example.com/page')
     expect(resolvedUrl).toBe('https://example.com/page')
   })
 
-  it('should use first matching handler when multiple handlers match', () => {
+  it('should use first matching handler when multiple handlers match', async () => {
     const firstHandler: PlatformHandler = {
       match: () => true,
       resolve: () => [{ uri: 'https://example.com/first.xml' }],
@@ -126,10 +126,10 @@ describe('discoverUrisFromPlatform', () => {
     }
     const expected = [{ uri: 'https://example.com/first.xml' }]
 
-    expect(discoverUrisFromPlatform('', value)).toEqual(expected)
+    expect(await discoverUrisFromPlatform('', undefined, value)).toEqual(expected)
   })
 
-  it('should not call resolve on non-matching handlers', () => {
+  it('should not call resolve on non-matching handlers', async () => {
     let secondResolvedCalled = false
     const firstHandler: PlatformHandler = {
       match: () => true,
@@ -148,12 +148,12 @@ describe('discoverUrisFromPlatform', () => {
       handlers: [firstHandler, secondHandler],
     }
 
-    discoverUrisFromPlatform('', value)
+    await discoverUrisFromPlatform('', undefined, value)
 
     expect(secondResolvedCalled).toBe(false)
   })
 
-  it('should check handlers in provided order', () => {
+  it('should check handlers in provided order', async () => {
     const callOrder: Array<string> = []
     const firstHandler: PlatformHandler = {
       match: () => {
@@ -176,7 +176,7 @@ describe('discoverUrisFromPlatform', () => {
       handlers: [firstHandler, secondHandler],
     }
 
-    discoverUrisFromPlatform('', value)
+    await discoverUrisFromPlatform('', undefined, value)
 
     expect(callOrder).toEqual(['first', 'second'])
   })

--- a/src/common/uris/platform/index.ts
+++ b/src/common/uris/platform/index.ts
@@ -2,7 +2,7 @@ import type { DiscoverFetchFn, DiscoverUriEntry } from '../../types.js'
 import type { PlatformMethodOptions } from './types.js'
 
 export const discoverUrisFromPlatform = async (
-  content: string,
+  content: string | undefined,
   headers: Headers | undefined,
   options: PlatformMethodOptions,
   fetchFn?: DiscoverFetchFn,

--- a/src/common/uris/platform/index.ts
+++ b/src/common/uris/platform/index.ts
@@ -1,16 +1,18 @@
-import type { DiscoverUriEntry } from '../../types.js'
+import type { DiscoverFetchFn, DiscoverUriEntry } from '../../types.js'
 import type { PlatformMethodOptions } from './types.js'
 
-export const discoverUrisFromPlatform = (
+export const discoverUrisFromPlatform = async (
   html: string,
+  headers: Headers | undefined,
   options: PlatformMethodOptions,
-): Array<DiscoverUriEntry> => {
+  fetchFn?: DiscoverFetchFn,
+): Promise<Array<DiscoverUriEntry>> => {
   const { baseUrl, handlers } = options
 
   for (const handler of handlers) {
     try {
-      if (handler.match(baseUrl)) {
-        return handler.resolve(baseUrl, html)
+      if (handler.match(baseUrl, html, headers)) {
+        return await handler.resolve(baseUrl, html, fetchFn)
       }
     } catch {
       // Handler error - continue to next.

--- a/src/common/uris/platform/index.ts
+++ b/src/common/uris/platform/index.ts
@@ -2,7 +2,7 @@ import type { DiscoverFetchFn, DiscoverUriEntry } from '../../types.js'
 import type { PlatformMethodOptions } from './types.js'
 
 export const discoverUrisFromPlatform = async (
-  html: string,
+  content: string,
   headers: Headers | undefined,
   options: PlatformMethodOptions,
   fetchFn?: DiscoverFetchFn,
@@ -11,8 +11,8 @@ export const discoverUrisFromPlatform = async (
 
   for (const handler of handlers) {
     try {
-      if (handler.match(baseUrl, html, headers)) {
-        return await handler.resolve(baseUrl, html, fetchFn)
+      if (handler.match(baseUrl, content, headers)) {
+        return await handler.resolve(baseUrl, content, fetchFn)
       }
     } catch {
       // Handler error - continue to next.

--- a/src/common/uris/platform/index.ts
+++ b/src/common/uris/platform/index.ts
@@ -12,7 +12,7 @@ export const discoverUrisFromPlatform = async (
   for (const handler of handlers) {
     try {
       if (handler.match(baseUrl, content, headers)) {
-        return await handler.resolve(baseUrl, content, fetchFn)
+        return await handler.resolve(baseUrl, content, headers, fetchFn)
       }
     } catch {
       // Handler error - continue to next.

--- a/src/common/uris/platform/types.ts
+++ b/src/common/uris/platform/types.ts
@@ -1,8 +1,12 @@
-import type { DiscoverUriEntry } from '../../types.js'
+import type { DiscoverFetchFn, DiscoverUriEntry } from '../../types.js'
 
 export type PlatformHandler = {
-  match: (url: string) => boolean
-  resolve: (url: string, content?: string) => Array<DiscoverUriEntry>
+  match: (url: string, content?: string, headers?: Headers) => boolean
+  resolve: (
+    url: string,
+    content?: string,
+    fetchFn?: DiscoverFetchFn,
+  ) => Array<DiscoverUriEntry> | Promise<Array<DiscoverUriEntry>>
 }
 
 export type PlatformMethodOptions = {

--- a/src/common/uris/platform/types.ts
+++ b/src/common/uris/platform/types.ts
@@ -5,6 +5,7 @@ export type PlatformHandler = {
   resolve: (
     url: string,
     content?: string,
+    headers?: Headers,
     fetchFn?: DiscoverFetchFn,
   ) => Array<DiscoverUriEntry> | Promise<Array<DiscoverUriEntry>>
 }


### PR DESCRIPTION
This PR makes the platform pipeline async, so a handler can reach an API before answering.

- Make `discoverUrisFromPlatform` and `discoverUris` async to support handlers that need API calls
- Pass `fetchFn` through the pipeline so async handlers can make network requests
- Pass `content` and `headers` to `PlatformHandler.match` so handlers can detect platforms from page signals (e.g. meta generator tag, server header)
- All changes are backward-compatible: existing sync handlers work unchanged
