### PR TITLE
feat: Add GitHub Gist favicon platform handler

### DIFF
--- a/src/favicons/defaults.ts
+++ b/src/favicons/defaults.ts
@@ -5,6 +5,7 @@ import type { HtmlMethodOptions } from '../common/uris/html/types.js'
 import type { PlatformMethodOptions } from '../common/uris/platform/types.js'
 import { blueskyHandler } from './platform/handlers/bluesky.js'
 import { githubHandler } from './platform/handlers/github.js'
+import { githubGistHandler } from './platform/handlers/githubGist.js'
 import { mastodonHandler } from './platform/handlers/mastodon.js'
 import { redditHandler } from './platform/handlers/reddit.js'
 
@@ -41,5 +42,5 @@ export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
 }
 
 export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
-  handlers: [githubHandler, mastodonHandler, blueskyHandler, redditHandler],
+  handlers: [githubHandler, githubGistHandler, mastodonHandler, blueskyHandler, redditHandler],
 }

--- a/src/favicons/platform/handlers/githubGist.test.ts
+++ b/src/favicons/platform/handlers/githubGist.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'bun:test'
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import { githubGistHandler } from './githubGist.js'
+
+describe('githubGistHandler', () => {
+  describe('match', () => {
+    it('should match gist.github.com URLs', () => {
+      expect(githubGistHandler.match('https://gist.github.com/octocat')).toBe(true)
+    })
+
+    it('should not match github.com URLs', () => {
+      expect(githubGistHandler.match('https://github.com/octocat')).toBe(false)
+    })
+
+    it('should not match non-github URLs', () => {
+      expect(githubGistHandler.match('https://gitlab.com/user')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should resolve user avatar from user URL', () => {
+      const value = githubGistHandler.resolve('https://gist.github.com/octocat')
+      const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/octocat.png' }]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve user avatar from gist URL', () => {
+      const value = githubGistHandler.resolve('https://gist.github.com/octocat/abc123def456')
+      const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/octocat.png' }]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve user avatar from starred URL', () => {
+      const value = githubGistHandler.resolve('https://gist.github.com/octocat/starred')
+      const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/octocat.png' }]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should return empty array for root URL', () => {
+      const value = githubGistHandler.resolve('https://gist.github.com')
+
+      expect(value).toEqual([])
+    })
+
+    it('should return empty array for excluded paths', () => {
+      expect(githubGistHandler.resolve('https://gist.github.com/discover')).toEqual([])
+      expect(githubGistHandler.resolve('https://gist.github.com/search')).toEqual([])
+      expect(githubGistHandler.resolve('https://gist.github.com/login')).toEqual([])
+      expect(githubGistHandler.resolve('https://gist.github.com/join')).toEqual([])
+      expect(githubGistHandler.resolve('https://gist.github.com/settings')).toEqual([])
+    })
+
+    it('should handle excluded paths case-insensitively', () => {
+      expect(githubGistHandler.resolve('https://gist.github.com/Discover')).toEqual([])
+      expect(githubGistHandler.resolve('https://gist.github.com/SEARCH')).toEqual([])
+    })
+  })
+})

--- a/src/favicons/platform/handlers/githubGist.ts
+++ b/src/favicons/platform/handlers/githubGist.ts
@@ -1,0 +1,26 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { isAnyOf, isHostOf } from '../../../common/utils.js'
+import { excludedPaths, hosts } from '../../../feeds/platform/handlers/githubGist.js'
+
+export const githubGistHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const segments = pathname.split('/').filter(Boolean)
+
+    if (segments.length === 0) {
+      return []
+    }
+
+    const user = segments[0]
+
+    if (isAnyOf(user, excludedPaths)) {
+      return []
+    }
+
+    return [{ uri: `https://github.com/${user}.png` }]
+  },
+}

--- a/src/feeds/platform/handlers/githubGist.ts
+++ b/src/feeds/platform/handlers/githubGist.ts
@@ -1,8 +1,8 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
 
-const hosts = ['gist.github.com']
-const excludedPaths = ['discover', 'search', 'login', 'join', 'settings']
+export const hosts = ['gist.github.com']
+export const excludedPaths = ['discover', 'search', 'login', 'join', 'settings']
 
 export const githubGistHandler: PlatformHandler = {
   match: (url) => {


### PR DESCRIPTION
This PR adds a GitHub Gist favicon handler, resolving user avatars from `github.com/{user}.png`.

- Add favicon platform handler for `gist.github.com` that resolves user avatars via `https://github.com/{user}.png`
- Export `hosts` and `excludedPaths` from the feed gist handler to share with the favicon handler
- Register handler in default platform options
