### PR TITLE
feat: Add Tumblr favicon platform handler

### DIFF
--- a/src/favicons/defaults.ts
+++ b/src/favicons/defaults.ts
@@ -7,6 +7,7 @@ import { blueskyHandler } from './platform/handlers/bluesky.js'
 import { githubHandler } from './platform/handlers/github.js'
 import { mastodonHandler } from './platform/handlers/mastodon.js'
 import { redditHandler } from './platform/handlers/reddit.js'
+import { tumblrHandler } from './platform/handlers/tumblr.js'
 
 export const defaultIconRels = [
   'icon',
@@ -41,5 +42,5 @@ export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
 }
 
 export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
-  handlers: [githubHandler, mastodonHandler, blueskyHandler, redditHandler],
+  handlers: [githubHandler, mastodonHandler, blueskyHandler, redditHandler, tumblrHandler],
 }

--- a/src/favicons/platform/handlers/tumblr.test.ts
+++ b/src/favicons/platform/handlers/tumblr.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'bun:test'
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import { tumblrHandler } from './tumblr.js'
+
+describe('tumblrHandler', () => {
+  describe('match', () => {
+    it('should match tumblr.com subdomain URLs', () => {
+      expect(tumblrHandler.match('https://staff.tumblr.com')).toBe(true)
+    })
+
+    it('should match tumblr.com subdomain URLs with path', () => {
+      expect(tumblrHandler.match('https://engineering.tumblr.com/post/123')).toBe(true)
+    })
+
+    it('should not match tumblr.com root', () => {
+      expect(tumblrHandler.match('https://tumblr.com')).toBe(false)
+    })
+
+    it('should not match non-tumblr URLs', () => {
+      expect(tumblrHandler.match('https://example.com')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should resolve blog avatar from subdomain URL', () => {
+      const value = tumblrHandler.resolve('https://staff.tumblr.com')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://api.tumblr.com/v2/blog/staff/avatar/512' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve blog avatar from subdomain URL with path', () => {
+      const value = tumblrHandler.resolve('https://engineering.tumblr.com/post/123')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://api.tumblr.com/v2/blog/engineering/avatar/512' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve blog avatar from subdomain URL with tagged path', () => {
+      const value = tumblrHandler.resolve('https://staff.tumblr.com/tagged/updates')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://api.tumblr.com/v2/blog/staff/avatar/512' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+  })
+})

--- a/src/favicons/platform/handlers/tumblr.ts
+++ b/src/favicons/platform/handlers/tumblr.ts
@@ -1,0 +1,20 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { isSubdomainOf } from '../../../common/utils.js'
+import { domains } from '../../../feeds/platform/handlers/tumblr.js'
+
+export const tumblrHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, domains)
+  },
+
+  resolve: (url) => {
+    const { hostname } = new URL(url)
+    const blog = hostname.split('.')[0]
+
+    if (!blog) {
+      return []
+    }
+
+    return [{ uri: `https://api.tumblr.com/v2/blog/${blog}/avatar/512` }]
+  },
+}

--- a/src/feeds/platform/handlers/tumblr.ts
+++ b/src/feeds/platform/handlers/tumblr.ts
@@ -1,11 +1,13 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isSubdomainOf } from '../../../common/utils.js'
 
+export const domains = ['tumblr.com']
+
 const tagPathRegex = /^\/tagged\/([^/]+)/
 
 export const tumblrHandler: PlatformHandler = {
   match: (url) => {
-    return isSubdomainOf(url, 'tumblr.com')
+    return isSubdomainOf(url, domains)
   },
 
   resolve: (url) => {


### PR DESCRIPTION
This PR adds a Tumblr favicon handler, resolving blog avatars through the Tumblr API.

- Add favicon platform handler for Tumblr blogs that resolves avatars via `https://api.tumblr.com/v2/blog/{blog}/avatar/512` (no API key needed, returns 302 redirect)
- Extract `domains` constant from feed Tumblr handler to share with favicon handler
- Register handler in default platform options
