### PR TITLE
feat: Add Codeberg favicon platform handler

### DIFF
--- a/src/favicons/defaults.ts
+++ b/src/favicons/defaults.ts
@@ -4,6 +4,7 @@ import type { HeadersMethodOptions } from '../common/uris/headers/types.js'
 import type { HtmlMethodOptions } from '../common/uris/html/types.js'
 import type { PlatformMethodOptions } from '../common/uris/platform/types.js'
 import { blueskyHandler } from './platform/handlers/bluesky.js'
+import { codebergHandler } from './platform/handlers/codeberg.js'
 import { githubHandler } from './platform/handlers/github.js'
 import { mastodonHandler } from './platform/handlers/mastodon.js'
 import { redditHandler } from './platform/handlers/reddit.js'
@@ -41,5 +42,5 @@ export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
 }
 
 export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
-  handlers: [githubHandler, mastodonHandler, blueskyHandler, redditHandler],
+  handlers: [githubHandler, mastodonHandler, blueskyHandler, redditHandler, codebergHandler],
 }

--- a/src/favicons/platform/handlers/codeberg.test.ts
+++ b/src/favicons/platform/handlers/codeberg.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test'
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import { codebergHandler } from './codeberg.js'
+
+describe('codebergHandler', () => {
+  describe('match', () => {
+    it('should match codeberg.org URLs', () => {
+      expect(codebergHandler.match('https://codeberg.org/user')).toBe(true)
+    })
+
+    it('should match www.codeberg.org URLs', () => {
+      expect(codebergHandler.match('https://www.codeberg.org/user')).toBe(true)
+    })
+
+    it('should match gitea.com URLs', () => {
+      expect(codebergHandler.match('https://gitea.com/user')).toBe(true)
+    })
+
+    it('should match www.gitea.com URLs', () => {
+      expect(codebergHandler.match('https://www.gitea.com/user')).toBe(true)
+    })
+
+    it('should not match non-codeberg URLs', () => {
+      expect(codebergHandler.match('https://github.com/user')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should resolve user avatar from user URL', () => {
+      const value = codebergHandler.resolve('https://codeberg.org/forgejo')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://codeberg.org/user/avatar/forgejo/512' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve user avatar from repo URL', () => {
+      const value = codebergHandler.resolve('https://codeberg.org/forgejo/forgejo')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://codeberg.org/user/avatar/forgejo/512' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve user avatar from deep path', () => {
+      const value = codebergHandler.resolve('https://codeberg.org/forgejo/forgejo/src/branch/main')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://codeberg.org/user/avatar/forgejo/512' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve user avatar using gitea.com origin', () => {
+      const value = codebergHandler.resolve('https://gitea.com/gitea')
+      const expected: Array<DiscoverUriEntry> = [{ uri: 'https://gitea.com/user/avatar/gitea/512' }]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should return empty array for root URL', () => {
+      expect(codebergHandler.resolve('https://codeberg.org')).toEqual([])
+    })
+
+    it('should return empty array for excluded paths', () => {
+      expect(codebergHandler.resolve('https://codeberg.org/explore')).toEqual([])
+      expect(codebergHandler.resolve('https://codeberg.org/admin')).toEqual([])
+      expect(codebergHandler.resolve('https://codeberg.org/api')).toEqual([])
+    })
+
+    it('should handle excluded paths case-insensitively', () => {
+      expect(codebergHandler.resolve('https://codeberg.org/Explore')).toEqual([])
+      expect(codebergHandler.resolve('https://codeberg.org/ADMIN')).toEqual([])
+    })
+  })
+})

--- a/src/favicons/platform/handlers/codeberg.ts
+++ b/src/favicons/platform/handlers/codeberg.ts
@@ -1,0 +1,26 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { isAnyOf, isHostOf } from '../../../common/utils.js'
+import { excludedPaths, hosts } from '../../../feeds/platform/handlers/codeberg.js'
+
+export const codebergHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { origin, pathname } = new URL(url)
+    const segments = pathname.split('/').filter(Boolean)
+
+    if (segments.length === 0) {
+      return []
+    }
+
+    const username = segments[0]
+
+    if (isAnyOf(username, excludedPaths)) {
+      return []
+    }
+
+    return [{ uri: `${origin}/user/avatar/${username}/512` }]
+  },
+}

--- a/src/feeds/platform/handlers/codeberg.ts
+++ b/src/feeds/platform/handlers/codeberg.ts
@@ -1,8 +1,8 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
 
-const hosts = ['codeberg.org', 'www.codeberg.org', 'gitea.com', 'www.gitea.com']
-const excludedPaths = [
+export const hosts = ['codeberg.org', 'www.codeberg.org', 'gitea.com', 'www.gitea.com']
+export const excludedPaths = [
   'explore',
   'admin',
   'user',


### PR DESCRIPTION
This PR adds a Codeberg favicon handler, which also covers Gitea.

- Add favicon handler for Codeberg/Gitea that resolves user avatars via `{origin}/user/avatar/{username}/512`
- Export `hosts` and `excludedPaths` from feed handler for reuse
- Works across codeberg.org and gitea.com domains
