### PR TITLE
feat: Add Lobsters favicon platform handler

### DIFF
--- a/src/favicons/defaults.ts
+++ b/src/favicons/defaults.ts
@@ -5,6 +5,7 @@ import type { HtmlMethodOptions } from '../common/uris/html/types.js'
 import type { PlatformMethodOptions } from '../common/uris/platform/types.js'
 import { blueskyHandler } from './platform/handlers/bluesky.js'
 import { githubHandler } from './platform/handlers/github.js'
+import { lobstersHandler } from './platform/handlers/lobsters.js'
 import { mastodonHandler } from './platform/handlers/mastodon.js'
 import { redditHandler } from './platform/handlers/reddit.js'
 
@@ -41,5 +42,5 @@ export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
 }
 
 export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
-  handlers: [githubHandler, mastodonHandler, blueskyHandler, redditHandler],
+  handlers: [githubHandler, mastodonHandler, blueskyHandler, redditHandler, lobstersHandler],
 }

--- a/src/favicons/platform/handlers/lobsters.test.ts
+++ b/src/favicons/platform/handlers/lobsters.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test'
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import { lobstersHandler } from './lobsters.js'
+
+describe('lobstersHandler', () => {
+  describe('match', () => {
+    it('should match user URLs', () => {
+      expect(lobstersHandler.match('https://lobste.rs/~jcs')).toBe(true)
+      expect(lobstersHandler.match('https://lobste.rs/~pushcx')).toBe(true)
+    })
+
+    it('should not match homepage', () => {
+      expect(lobstersHandler.match('https://lobste.rs')).toBe(false)
+      expect(lobstersHandler.match('https://lobste.rs/')).toBe(false)
+    })
+
+    it('should not match tag pages', () => {
+      expect(lobstersHandler.match('https://lobste.rs/t/programming')).toBe(false)
+    })
+
+    it('should not match domain pages', () => {
+      expect(lobstersHandler.match('https://lobste.rs/domains/github.com')).toBe(false)
+    })
+
+    it('should not match top pages', () => {
+      expect(lobstersHandler.match('https://lobste.rs/top')).toBe(false)
+    })
+
+    it('should not match newest pages', () => {
+      expect(lobstersHandler.match('https://lobste.rs/newest')).toBe(false)
+    })
+
+    it('should not match non-lobsters URLs', () => {
+      expect(lobstersHandler.match('https://example.com/~user')).toBe(false)
+    })
+
+    it('should not match invalid URLs', () => {
+      expect(lobstersHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should resolve user avatar from user URL', () => {
+      const value = lobstersHandler.resolve('https://lobste.rs/~jcs')
+      const expected: Array<DiscoverUriEntry> = [{ uri: 'https://lobste.rs/avatars/jcs-100.png' }]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve user avatar from user URL with trailing slash', () => {
+      const value = lobstersHandler.resolve('https://lobste.rs/~pushcx/')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://lobste.rs/avatars/pushcx-100.png' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should return empty array for non-user path', () => {
+      expect(lobstersHandler.resolve('https://lobste.rs/t/programming')).toEqual([])
+    })
+  })
+})

--- a/src/favicons/platform/handlers/lobsters.ts
+++ b/src/favicons/platform/handlers/lobsters.ts
@@ -1,0 +1,30 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { isHostOf } from '../../../common/utils.js'
+import { hosts } from '../../../feeds/platform/handlers/lobsters.js'
+
+const userPathRegex = /^\/~([a-zA-Z0-9_-]+)/
+
+export const lobstersHandler: PlatformHandler = {
+  match: (url) => {
+    try {
+      const { pathname } = new URL(url)
+
+      return isHostOf(url, hosts) && userPathRegex.test(pathname)
+    } catch {}
+
+    return false
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const match = pathname.match(userPathRegex)
+
+    if (!match?.[1]) {
+      return []
+    }
+
+    const username = match[1]
+
+    return [{ uri: `https://lobste.rs/avatars/${username}-100.png` }]
+  },
+}

--- a/src/feeds/platform/handlers/lobsters.ts
+++ b/src/feeds/platform/handlers/lobsters.ts
@@ -1,7 +1,7 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isHostOf } from '../../../common/utils.js'
 
-const hosts = ['lobste.rs']
+export const hosts = ['lobste.rs']
 const tagPathRegex = /^\/t\/([a-zA-Z0-9,_-]+)/
 const domainPathRegex = /^\/domains\/([^/]+)/
 const userPathRegex = /^\/~([a-zA-Z0-9_-]+)/


### PR DESCRIPTION
This PR adds a Lobsters favicon handler, matching only user profile pages.

- Add favicon handler for Lobsters that resolves user avatars via `https://lobste.rs/avatars/{username}-100.png`
- Only matches user profile pages (`/~{username}`), not homepage/tags/domains
- Export `hosts` from feed handler for reuse
