### PR TITLE
feat: Add SourceForge favicon platform handler

### DIFF
--- a/src/favicons/defaults.ts
+++ b/src/favicons/defaults.ts
@@ -7,6 +7,7 @@ import { blueskyHandler } from './platform/handlers/bluesky.js'
 import { githubHandler } from './platform/handlers/github.js'
 import { mastodonHandler } from './platform/handlers/mastodon.js'
 import { redditHandler } from './platform/handlers/reddit.js'
+import { sourceforgeHandler } from './platform/handlers/sourceforge.js'
 
 export const defaultIconRels = [
   'icon',
@@ -41,5 +42,5 @@ export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
 }
 
 export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
-  handlers: [githubHandler, mastodonHandler, blueskyHandler, redditHandler],
+  handlers: [githubHandler, mastodonHandler, blueskyHandler, redditHandler, sourceforgeHandler],
 }

--- a/src/favicons/platform/handlers/sourceforge.test.ts
+++ b/src/favicons/platform/handlers/sourceforge.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test'
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import { sourceforgeHandler } from './sourceforge.js'
+
+describe('sourceforgeHandler', () => {
+  describe('match', () => {
+    it('should match project URLs', () => {
+      expect(sourceforgeHandler.match('https://sourceforge.net/projects/mingw')).toBe(true)
+    })
+
+    it('should match project subpath URLs', () => {
+      expect(sourceforgeHandler.match('https://sourceforge.net/projects/mingw/files')).toBe(true)
+    })
+
+    it('should match www variant', () => {
+      expect(sourceforgeHandler.match('https://www.sourceforge.net/projects/mingw')).toBe(true)
+    })
+
+    it('should not match homepage', () => {
+      expect(sourceforgeHandler.match('https://sourceforge.net')).toBe(false)
+      expect(sourceforgeHandler.match('https://sourceforge.net/')).toBe(false)
+    })
+
+    it('should not match non-project paths', () => {
+      expect(sourceforgeHandler.match('https://sourceforge.net/about')).toBe(false)
+      expect(sourceforgeHandler.match('https://sourceforge.net/directory')).toBe(false)
+    })
+
+    it('should not match non-sourceforge URLs', () => {
+      expect(sourceforgeHandler.match('https://example.com/projects/mingw')).toBe(false)
+    })
+
+    it('should not match invalid URLs', () => {
+      expect(sourceforgeHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should resolve project icon from project URL', () => {
+      const value = sourceforgeHandler.resolve('https://sourceforge.net/projects/mingw')
+      const expected: Array<DiscoverUriEntry> = [{ uri: 'https://a.fsdn.com/allura/p/mingw/icon' }]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve project icon from project subpath', () => {
+      const value = sourceforgeHandler.resolve('https://sourceforge.net/projects/mingw/files')
+      const expected: Array<DiscoverUriEntry> = [{ uri: 'https://a.fsdn.com/allura/p/mingw/icon' }]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should return empty array for non-project path', () => {
+      expect(sourceforgeHandler.resolve('https://sourceforge.net/about')).toEqual([])
+    })
+  })
+})

--- a/src/favicons/platform/handlers/sourceforge.ts
+++ b/src/favicons/platform/handlers/sourceforge.ts
@@ -1,0 +1,29 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { isHostOf } from '../../../common/utils.js'
+import { hosts } from '../../../feeds/platform/handlers/sourceforge.js'
+
+export const sourceforgeHandler: PlatformHandler = {
+  match: (url) => {
+    try {
+      const { pathname } = new URL(url)
+      const segments = pathname.split('/').filter(Boolean)
+
+      return isHostOf(url, hosts) && segments[0] === 'projects' && !!segments[1]
+    } catch {}
+
+    return false
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const segments = pathname.split('/').filter(Boolean)
+
+    if (segments[0] !== 'projects' || !segments[1]) {
+      return []
+    }
+
+    const project = segments[1]
+
+    return [{ uri: `https://a.fsdn.com/allura/p/${project}/icon` }]
+  },
+}

--- a/src/feeds/platform/handlers/sourceforge.ts
+++ b/src/feeds/platform/handlers/sourceforge.ts
@@ -1,7 +1,7 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isHostOf } from '../../../common/utils.js'
 
-const hosts = ['sourceforge.net', 'www.sourceforge.net']
+export const hosts = ['sourceforge.net', 'www.sourceforge.net']
 
 export const sourceforgeHandler: PlatformHandler = {
   match: (url) => {


### PR DESCRIPTION
This PR adds a SourceForge favicon handler, matching only project pages.

- Add favicon handler for SourceForge that resolves project icons via `https://a.fsdn.com/allura/p/{project}/icon`
- Only matches project pages (`/projects/{project}`), not homepage or other paths
- Export `hosts` from feed handler for reuse
