### PR TITLE
feat: Add DeviantArt favicon platform handler

### DIFF
--- a/src/favicons/defaults.ts
+++ b/src/favicons/defaults.ts
@@ -4,6 +4,7 @@ import type { HeadersMethodOptions } from '../common/uris/headers/types.js'
 import type { HtmlMethodOptions } from '../common/uris/html/types.js'
 import type { PlatformMethodOptions } from '../common/uris/platform/types.js'
 import { blueskyHandler } from './platform/handlers/bluesky.js'
+import { deviantartHandler } from './platform/handlers/deviantart.js'
 import { githubHandler } from './platform/handlers/github.js'
 import { mastodonHandler } from './platform/handlers/mastodon.js'
 import { redditHandler } from './platform/handlers/reddit.js'
@@ -41,5 +42,5 @@ export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
 }
 
 export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
-  handlers: [githubHandler, mastodonHandler, blueskyHandler, redditHandler],
+  handlers: [githubHandler, mastodonHandler, blueskyHandler, redditHandler, deviantartHandler],
 }

--- a/src/favicons/platform/handlers/deviantart.test.ts
+++ b/src/favicons/platform/handlers/deviantart.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'bun:test'
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import { deviantartHandler } from './deviantart.js'
+
+describe('deviantartHandler', () => {
+  describe('match', () => {
+    it('should match profile URLs', () => {
+      expect(deviantartHandler.match('https://www.deviantart.com/artistname')).toBe(true)
+    })
+
+    it('should match gallery URLs', () => {
+      expect(deviantartHandler.match('https://www.deviantart.com/artistname/gallery')).toBe(true)
+    })
+
+    it('should match gallery/all URLs', () => {
+      expect(deviantartHandler.match('https://www.deviantart.com/artistname/gallery/all')).toBe(
+        true,
+      )
+    })
+
+    it('should match favourites URLs', () => {
+      expect(deviantartHandler.match('https://www.deviantart.com/artistname/favourites')).toBe(true)
+    })
+
+    it('should not match tag pages', () => {
+      expect(deviantartHandler.match('https://www.deviantart.com/tag/photography')).toBe(false)
+    })
+
+    it('should not match excluded paths', () => {
+      expect(deviantartHandler.match('https://www.deviantart.com/about')).toBe(false)
+      expect(deviantartHandler.match('https://www.deviantart.com/join')).toBe(false)
+      expect(deviantartHandler.match('https://www.deviantart.com/search')).toBe(false)
+    })
+
+    it('should not match root URL', () => {
+      expect(deviantartHandler.match('https://www.deviantart.com')).toBe(false)
+      expect(deviantartHandler.match('https://www.deviantart.com/')).toBe(false)
+    })
+
+    it('should not match non-deviantart URLs', () => {
+      expect(deviantartHandler.match('https://example.com/artistname')).toBe(false)
+    })
+
+    it('should not match invalid URLs', () => {
+      expect(deviantartHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should resolve user avatar with 3 URI alternatives', () => {
+      const value = deviantartHandler.resolve('https://www.deviantart.com/artistname')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.jpg' },
+        { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.gif' },
+        { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.png' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve user avatar from gallery URL', () => {
+      const value = deviantartHandler.resolve('https://www.deviantart.com/artistname/gallery/all')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.jpg' },
+        { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.gif' },
+        { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.png' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should normalize username to lowercase', () => {
+      const value = deviantartHandler.resolve('https://www.deviantart.com/ArtistName')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.jpg' },
+        { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.gif' },
+        { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.png' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should return empty array for tag pages', () => {
+      expect(deviantartHandler.resolve('https://www.deviantart.com/tag/photography')).toEqual([])
+    })
+
+    it('should return empty array for excluded paths', () => {
+      expect(deviantartHandler.resolve('https://www.deviantart.com/about')).toEqual([])
+      expect(deviantartHandler.resolve('https://www.deviantart.com/search')).toEqual([])
+    })
+
+    it('should return empty array for root URL', () => {
+      expect(deviantartHandler.resolve('https://www.deviantart.com/')).toEqual([])
+    })
+  })
+})

--- a/src/favicons/platform/handlers/deviantart.ts
+++ b/src/favicons/platform/handlers/deviantart.ts
@@ -1,0 +1,47 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { isAnyOf, isHostOf } from '../../../common/utils.js'
+import { excludedPaths, hosts } from '../../../feeds/platform/handlers/deviantart.js'
+
+export const deviantartHandler: PlatformHandler = {
+  match: (url) => {
+    try {
+      const { pathname } = new URL(url)
+      const segments = pathname.split('/').filter(Boolean)
+
+      if (!isHostOf(url, hosts) || segments.length === 0) {
+        return false
+      }
+
+      if (segments[0] === 'tag') {
+        return false
+      }
+
+      return !isAnyOf(segments[0], excludedPaths)
+    } catch {}
+
+    return false
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const segments = pathname.split('/').filter(Boolean)
+
+    if (segments.length === 0 || segments[0] === 'tag') {
+      return []
+    }
+
+    const username = segments[0].toLowerCase()
+
+    if (isAnyOf(username, excludedPaths) || username.length < 2) {
+      return []
+    }
+
+    const uri: Array<string> = [
+      `https://a.deviantart.net/avatars-big/${username[0]}/${username[1]}/${username}.jpg`,
+      `https://a.deviantart.net/avatars-big/${username[0]}/${username[1]}/${username}.gif`,
+      `https://a.deviantart.net/avatars-big/${username[0]}/${username[1]}/${username}.png`,
+    ]
+
+    return uri.map((value) => ({ uri: value }))
+  },
+}

--- a/src/feeds/platform/handlers/deviantart.ts
+++ b/src/feeds/platform/handlers/deviantart.ts
@@ -1,9 +1,9 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
 
-const hosts = ['deviantart.com', 'www.deviantart.com']
+export const hosts = ['deviantart.com', 'www.deviantart.com']
 const feedBaseUrl = 'https://backend.deviantart.com/rss.xml'
-const excludedPaths = [
+export const excludedPaths = [
   'about',
   'join',
   'search',


### PR DESCRIPTION
This PR adds a DeviantArt favicon handler, returning three URI alternatives because the avatar extension varies per user.

- Add favicon handler for DeviantArt that resolves user avatars via `https://a.deviantart.net/avatars-big/{u[0]}/{u[1]}/{username}.{ext}`
- Returns 3 URI alternatives (.jpg, .gif, .png) since avatar extension varies per user
- Skips tag pages, excluded system paths, and usernames shorter than 2 characters
- Export `hosts` and `excludedPaths` from feed handler for reuse
