### PR TITLE
feat: Extract icon from Atom and JSON Feed content

### DIFF
--- a/docs/reference/discover-feeds.md
+++ b/docs/reference/discover-feeds.md
@@ -63,7 +63,7 @@ Returns a promise that resolves to an array of results:
   title: 'Example Blog',
   description: 'A blog about examples',
   siteUrl: 'https://example.com',
-  icon: 'https://example.com/icon.png',
+  icon: 'https://example.com/icon.png', // Atom and JSON Feed only.
 }
 
 // Invalid result (when includeInvalid: true)

--- a/docs/reference/discover-feeds.md
+++ b/docs/reference/discover-feeds.md
@@ -63,6 +63,7 @@ Returns a promise that resolves to an array of results:
   title: 'Example Blog',
   description: 'A blog about examples',
   siteUrl: 'https://example.com',
+  icon: 'https://example.com/icon.png',
 }
 
 // Invalid result (when includeInvalid: true)

--- a/docs/reference/discover-feeds.md
+++ b/docs/reference/discover-feeds.md
@@ -77,6 +77,8 @@ Returns a promise that resolves to an array of results:
 
 The `method` field indicates which discovery method produced the result. Results from the [Platform method](/feeds/platform) also include a [`hint`](/feeds/platform#hints) that identifies the type of feed.
 
+The `icon` field is extracted from dedicated icon fields available in Atom and JSON Feed formats. For RSS and RDF, or if the `icon` is not present in the Atom and JSON Feed, use [`discoverFavicons`](/other/favicons) as a fallback to find the site's icon.
+
 ## Examples
 
 ### Basic Usage

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -131,6 +131,7 @@ type FeedResult = {
   title?: string
   description?: string
   siteUrl?: string
+  icon?: string
 }
 ```
 

--- a/docs/reference/typescript.md
+++ b/docs/reference/typescript.md
@@ -42,6 +42,7 @@ for (const feed of feeds) {
     console.log(feed.title)       // string | undefined
     console.log(feed.description) // string | undefined
     console.log(feed.siteUrl)     // string | undefined
+    console.log(feed.icon)        // string | undefined
     console.log(feed.method)      // DiscoverMethod | undefined
     console.log(feed.hint)        // DiscoverUriHint | undefined
   } else {
@@ -63,6 +64,7 @@ type FeedResult = {
   title?: string
   description?: string
   siteUrl?: string
+  icon?: string
 }
 ```
 

--- a/src/feeds/extractors.test.ts
+++ b/src/feeds/extractors.test.ts
@@ -307,6 +307,210 @@ describe('defaultExtractor', () => {
     expect(result).toEqual(expected)
   })
 
+  it('should extract icon from Atom feed', async () => {
+    const atom = `
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Test</title>
+        <link rel="alternate" href="https://example.com"/>
+        <subtitle>Test feed</subtitle>
+        <icon>https://example.com/icon.png</icon>
+      </feed>
+    `
+    const result = await defaultExtractor({
+      content: atom,
+      headers: new Headers(),
+      url: 'https://example.com/feed.xml',
+    })
+    const expected: DiscoverResult<FeedResult> = {
+      url: 'https://example.com/feed.xml',
+      isValid: true,
+      format: 'atom',
+      title: 'Test',
+      description: 'Test feed',
+      siteUrl: 'https://example.com',
+      icon: 'https://example.com/icon.png',
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should extract icon from JSON Feed favicon field', async () => {
+    const json = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Test',
+      home_page_url: 'https://example.com',
+      description: 'Test feed',
+      favicon: 'https://example.com/favicon.ico',
+      items: [],
+    })
+    const result = await defaultExtractor({
+      content: json,
+      headers: new Headers(),
+      url: 'https://example.com/feed.json',
+    })
+    const expected: DiscoverResult<FeedResult> = {
+      url: 'https://example.com/feed.json',
+      isValid: true,
+      format: 'json',
+      title: 'Test',
+      description: 'Test feed',
+      siteUrl: 'https://example.com',
+      icon: 'https://example.com/favicon.ico',
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should fall back to icon field when JSON Feed has no favicon', async () => {
+    const json = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Test',
+      home_page_url: 'https://example.com',
+      description: 'Test feed',
+      icon: 'https://example.com/icon.png',
+      items: [],
+    })
+    const result = await defaultExtractor({
+      content: json,
+      headers: new Headers(),
+      url: 'https://example.com/feed.json',
+    })
+    const expected: DiscoverResult<FeedResult> = {
+      url: 'https://example.com/feed.json',
+      isValid: true,
+      format: 'json',
+      title: 'Test',
+      description: 'Test feed',
+      siteUrl: 'https://example.com',
+      icon: 'https://example.com/icon.png',
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should prefer favicon over icon in JSON Feed', async () => {
+    const json = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Test',
+      home_page_url: 'https://example.com',
+      description: 'Test feed',
+      favicon: 'https://example.com/favicon.ico',
+      icon: 'https://example.com/icon.png',
+      items: [],
+    })
+    const result = await defaultExtractor({
+      content: json,
+      headers: new Headers(),
+      url: 'https://example.com/feed.json',
+    })
+    const expected: DiscoverResult<FeedResult> = {
+      url: 'https://example.com/feed.json',
+      isValid: true,
+      format: 'json',
+      title: 'Test',
+      description: 'Test feed',
+      siteUrl: 'https://example.com',
+      icon: 'https://example.com/favicon.ico',
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should not extract icon from RSS image', async () => {
+    const rss = `
+      <rss version="2.0">
+        <channel>
+          <title>Test</title>
+          <link>https://example.com</link>
+          <description>Test feed</description>
+          <image>
+            <url>https://example.com/image.png</url>
+            <title>Test</title>
+            <link>https://example.com</link>
+          </image>
+        </channel>
+      </rss>
+    `
+    const result = await defaultExtractor({
+      content: rss,
+      headers: new Headers(),
+      url: 'https://example.com/feed.xml',
+    })
+    const expected: DiscoverResult<FeedResult> = {
+      url: 'https://example.com/feed.xml',
+      isValid: true,
+      format: 'rss',
+      title: 'Test',
+      description: 'Test feed',
+      siteUrl: 'https://example.com',
+      icon: undefined,
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should not extract icon from RDF image', async () => {
+    const rdf = `
+      <rdf:RDF
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns="http://purl.org/rss/1.0/">
+        <channel>
+          <title>Test</title>
+          <link>https://example.com</link>
+          <description>Test feed</description>
+        </channel>
+        <image rdf:about="https://example.com/image.png">
+          <title>Test</title>
+          <link>https://example.com</link>
+          <url>https://example.com/image.png</url>
+        </image>
+      </rdf:RDF>
+    `
+    const result = await defaultExtractor({
+      content: rdf,
+      headers: new Headers(),
+      url: 'https://example.com/feed.xml',
+    })
+    const expected: DiscoverResult<FeedResult> = {
+      url: 'https://example.com/feed.xml',
+      isValid: true,
+      format: 'rdf',
+      title: 'Test',
+      description: 'Test feed',
+      siteUrl: 'https://example.com',
+      icon: undefined,
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should not extract icon from Atom logo', async () => {
+    const atom = `
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Test</title>
+        <link rel="alternate" href="https://example.com"/>
+        <subtitle>Test feed</subtitle>
+        <logo>https://example.com/logo.png</logo>
+      </feed>
+    `
+    const result = await defaultExtractor({
+      content: atom,
+      headers: new Headers(),
+      url: 'https://example.com/feed.xml',
+    })
+    const expected: DiscoverResult<FeedResult> = {
+      url: 'https://example.com/feed.xml',
+      isValid: true,
+      format: 'atom',
+      title: 'Test',
+      description: 'Test feed',
+      siteUrl: 'https://example.com',
+      icon: undefined,
+    }
+
+    expect(result).toEqual(expected)
+  })
+
   it('should not use headers for detection', async () => {
     const headers = new Headers()
     headers.set('content-type', 'application/rss+xml')

--- a/src/feeds/extractors.ts
+++ b/src/feeds/extractors.ts
@@ -34,6 +34,7 @@ export const defaultExtractor: DiscoverExtractFn<FeedResult> = async ({ content,
         title: feed.title,
         description: feed.subtitle,
         siteUrl: getLinkOfType(feed.links, 'alternate')?.href,
+        icon: feed.icon,
       }
     }
 
@@ -45,6 +46,7 @@ export const defaultExtractor: DiscoverExtractFn<FeedResult> = async ({ content,
         title: feed.title,
         description: feed.description,
         siteUrl: feed.home_page_url,
+        icon: feed.favicon ?? feed.icon,
       }
     }
   } catch {

--- a/src/feeds/types.ts
+++ b/src/feeds/types.ts
@@ -3,4 +3,5 @@ export type FeedResult = {
   title?: string
   description?: string
   siteUrl?: string
+  icon?: string
 }


### PR DESCRIPTION
This PR extracts the icon from Atom and JSON Feed content during discovery, adding an `icon` field to `FeedResult`.

- Add `icon` field to `FeedResult` type, extracted from feed content during discovery
- Atom: uses `feed.icon` (small, favicon-like per spec)
- JSON Feed: uses `feed.favicon ?? feed.icon` (prefers smaller favicon over app icon)
- RSS/RDF `<image>` intentionally excluded: it's a channel image, not an icon-dedicated field

Parked for now: may revisit after the `feed` method is added to `discoverFavicons`.
