### PR TITLE
feat: Add feed method to favicon discovery

### DIFF
--- a/docs/other/favicons.md
+++ b/docs/other/favicons.md
@@ -28,6 +28,8 @@ Each result contains the favicon URL and validation status:
 
 | Method | Source | Description |
 |--------|--------|-------------|
+| `platform` | Platform-specific handlers | Extracts avatars/icons from known platforms (GitHub, Mastodon, Bluesky, etc.) |
+| `feed` | Feed content | Extracts icon from Atom `<icon>` and JSON Feed `favicon`/`icon` fields |
 | `html` | HTML `<link>` tags | Parses icon-related link elements |
 | `headers` | HTTP `Link` headers | Parses `rel="icon"` links from response headers |
 | `guess` | Known paths | Tries common favicon paths like `/favicon.ico`, `/apple-touch-icon.png` |
@@ -41,7 +43,7 @@ Each result contains the favicon URL and validation status:
 
 ## Specifying Methods
 
-By default, all discovery methods are used (html, headers, guess). You can customize which methods to use with `methods` option.
+By default, all discovery methods are used (platform, feed, html, headers, guess). You can customize which methods to use with `methods` option.
 
 ### Array Syntax
 
@@ -49,7 +51,7 @@ Use an array to enable methods with their default options:
 
 ```typescript
 const favicons = await discoverFavicons(url, {
-  methods: ['html', 'headers', 'guess'],
+  methods: ['platform', 'feed', 'html', 'headers', 'guess'],
 })
 ```
 
@@ -62,6 +64,7 @@ const favicons = await discoverFavicons(url, {
   methods: {
     html: true, // Use defaults
     headers: true, // Use defaults
+    feed: true, // Use defaults
     guess: {
       uris: ['/favicon.ico', '/icon.svg'],
     },

--- a/docs/other/favicons.md
+++ b/docs/other/favicons.md
@@ -4,7 +4,7 @@ title: Discover Favicons
 
 # Discover Favicons
 
-Feedscout can discover favicon URLs from webpages. Favicons are site icons used in browser tabs, bookmarks, and feed readers.
+Feedscout can discover favicon URLs from webpages and feeds. Favicons are site icons used in browser tabs, bookmarks, and feed readers.
 
 ## Basic Usage
 
@@ -24,47 +24,34 @@ Each result contains the favicon URL and validation status:
 }
 ```
 
-## Discovery Methods
-
-| Method | Source | Description |
-|--------|--------|-------------|
-| `platform` | Platform-specific handlers | Extracts avatars/icons from known platforms (GitHub, Mastodon, Bluesky, etc.) |
-| `feed` | Feed content | Extracts icon from Atom `<icon>` and JSON Feed `favicon`/`icon` fields |
-| `html` | HTML `<link>` tags | Parses icon-related link elements |
-| `headers` | HTTP `Link` headers | Parses `rel="icon"` links from response headers |
-| `guess` | Known paths | Tries common favicon paths like `/favicon.ico`, `/apple-touch-icon.png` |
-
-## How Discovery Works
-
-1. **URI Collection** — Each enabled method extracts potential favicon URLs.
-2. **Deduplication** — Duplicate URLs are removed.
-3. **Validation** — Each URL is fetched and checked for a successful status code.
-4. **Results** — Valid favicon URLs are returned.
-
-## Specifying Methods
-
-By default, all discovery methods are used (platform, feed, html, headers, guess). You can customize which methods to use with `methods` option.
-
-### Array Syntax
-
-Use an array to enable methods with their default options:
+By default, all discovery methods are used (platform, feed, html, headers, guess). You can customize which methods to use:
 
 ```typescript
-const favicons = await discoverFavicons(url, {
-  methods: ['platform', 'feed', 'html', 'headers', 'guess'],
+const favicons = await discoverFavicons('https://example.com', {
+  methods: ['html', 'headers', 'guess'],
 })
 ```
 
-### Object Syntax
+## Discovery Methods
 
-Use an object to customize individual method options:
+Favicons use the same discovery pipeline as feeds — see the [Feeds](/feeds) section for details on how each method works.
+
+| Method | What It Looks For |
+|--------|-------------------|
+| Platform | Avatars/icons from known platforms (GitHub, Mastodon, Bluesky, etc.) |
+| Feed | `<icon>` in Atom feeds, `favicon`/`icon` in JSON Feeds |
+| HTML | `<link>` tags with `rel="icon"`, `rel="shortcut"`, `rel="apple-touch-icon"` |
+| Headers | `Link` headers with icon-related `rel` values |
+| Guess | Common paths like `/favicon.ico`, `/apple-touch-icon.png` |
+
+## Configuration
+
+Customize discovery the same way as feeds:
 
 ```typescript
 const favicons = await discoverFavicons(url, {
   methods: {
-    html: true, // Use defaults
-    headers: true, // Use defaults
-    feed: true, // Use defaults
+    html: true,
     guess: {
       uris: ['/favicon.ico', '/icon.svg'],
     },
@@ -72,91 +59,26 @@ const favicons = await discoverFavicons(url, {
 })
 ```
 
-Set a method to `true` to use defaults, or provide an options object to customize.
-
-## Using Existing Content
-
-If you already have the HTML content and headers, pass them directly to avoid an extra fetch:
+## Default Guess Paths
 
 ```typescript
-// Response fetched someplace else
-const response = await fetch('https://example.com')
+import { defaultGuessPaths } from 'feedscout/favicons'
 
-const favicons = await discoverFavicons(
-  {
-    url: 'https://example.com',
-    content: await response.text(),
-    headers: response.headers,
-  },
-  { methods: ['html', 'headers'] },
-)
+// [
+//   '/favicon.ico',
+//   '/apple-touch-icon.png',
+//   '/apple-touch-icon-precomposed.png',
+//   '/favicon.png',
+//   '/favicon.svg',
+// ]
 ```
 
-## Options
+## Default Link Selectors
 
-### Stop on First Method
-
-Stop URI collection after the first discovery method that produces results:
+Favicon discovery looks for these `rel` values in HTML `<link>` tags and HTTP `Link` headers:
 
 ```typescript
-const favicons = await discoverFavicons(url, {
-  methods: ['html', 'headers', 'guess'],
-  stopOnFirstMethod: true,
-})
-// Only URIs from the first successful method are validated
-```
+import { defaultIconRels, linkSelectors } from 'feedscout/favicons'
 
-### Stop on First Result
-
-Return immediately after finding a valid result:
-
-```typescript
-const favicons = await discoverFavicons(url, {
-  methods: ['html', 'guess'],
-  stopOnFirstResult: true,
-})
-// Returns array with at most 1 result
-```
-
-### Concurrency
-
-Control how many URLs are validated in parallel:
-
-```typescript
-const favicons = await discoverFavicons(url, {
-  methods: ['html', 'guess'],
-  concurrency: 5, // Default is 3
-})
-```
-
-### Include Invalid
-
-Include invalid results for debugging:
-
-```typescript
-const favicons = await discoverFavicons(url, {
-  methods: ['html', 'guess'],
-  includeInvalid: true,
-})
-
-for (const favicon of favicons) {
-  if (favicon.isValid) {
-    console.log(`Found: ${favicon.url}`)
-  } else {
-    console.log(`Invalid: ${favicon.url}`)
-  }
-}
-```
-
-### Progress Tracking
-
-Monitor discovery progress with a callback:
-
-```typescript
-const favicons = await discoverFavicons(url, {
-  methods: ['html', 'guess'],
-  onProgress: ({ tested, total, found, current }) => {
-    console.log(`[${tested}/${total}] ${current} (${found} found)`)
-  },
-})
+// ['icon', 'shortcut', 'apple-touch-icon', 'apple-touch-icon-precomposed']
 ```

--- a/docs/other/favicons.md
+++ b/docs/other/favicons.md
@@ -44,6 +44,21 @@ Favicons use the same discovery pipeline as feeds — see the [Feeds](/feeds) se
 | Headers | `Link` headers with icon-related `rel` values |
 | Guess | Common paths like `/favicon.ico`, `/apple-touch-icon.png` |
 
+## Extracting Icons from Feeds
+
+When given a feed URL, favicon discovery can extract icons directly from the feed content. Atom feeds provide an `<icon>` element, and JSON Feeds include `favicon` and `icon` fields:
+
+```typescript
+// Pass a feed URL to extract its icon
+const favicons = await discoverFavicons('https://example.com/feed.xml')
+
+// Or provide existing feed content
+const favicons = await discoverFavicons({
+  url: 'https://example.com/feed.json',
+  content: feedContent,
+})
+```
+
 ## Configuration
 
 Customize discovery the same way as feeds:

--- a/docs/reference/discover-blogrolls.md
+++ b/docs/reference/discover-blogrolls.md
@@ -11,7 +11,7 @@ Discovers and validates OPML blogrolls from a webpage.
 ```typescript
 function discoverBlogrolls(
   input: DiscoverInput,
-  options?: DiscoverOptions<BlogrollResult>,
+  options?: DiscoverOptions<BlogrollResult, 'html' | 'headers' | 'guess'>,
 ): Promise<Array<DiscoverResult<BlogrollResult>>>
 ```
 

--- a/docs/reference/discover-favicons.md
+++ b/docs/reference/discover-favicons.md
@@ -39,7 +39,7 @@ All options are optional. When not provided, sensible defaults are used.
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `methods` | `DiscoverMethodsConfig` | `['html', 'headers', 'guess']` | Which methods to use |
+| `methods` | `DiscoverMethodsConfig` | `['platform', 'feed', 'html', 'headers', 'guess']` | Which methods to use |
 | `fetchFn` | `DiscoverFetchFn` | native fetch | Custom fetch function |
 | `extractFn` | `DiscoverExtractFn` | status check | Custom extraction function |
 | `normalizeUrlFn` | `DiscoverNormalizeUrlFn` | | Custom URL normalization function |

--- a/docs/reference/discover-favicons.md
+++ b/docs/reference/discover-favicons.md
@@ -4,7 +4,7 @@ title: "Reference: discoverFavicons"
 
 # discoverFavicons
 
-Discovers favicon URLs from a webpage or feed. Uses the same discovery pipeline as `discoverFeeds` and `discoverBlogrolls`.
+Discovers favicon URLs from a webpage or feed.
 
 ## Signature
 
@@ -28,8 +28,8 @@ discoverFavicons('https://example.com', options)
 // Object - provide existing content/headers
 discoverFavicons({
   url: 'https://example.com',
-  content: htmlContent,     // Optional HTML content
-  headers: responseHeaders, // Optional HTTP headers
+  content: htmlContent,
+  headers: responseHeaders,
 }, options)
 ```
 
@@ -66,10 +66,9 @@ Returns a promise that resolves to an array of results:
   url: 'https://example.com/missing.png',
   isValid: false,
   method: 'guess',
+  error: Error,
 }
 ```
-
-Results are deduplicated by URL — the first occurrence (from the highest-priority method) is kept.
 
 ## Examples
 
@@ -78,7 +77,13 @@ Results are deduplicated by URL — the first occurrence (from the highest-prior
 ```typescript
 import { discoverFavicons } from 'feedscout'
 
+// Simple usage - all methods enabled by default
 const favicons = await discoverFavicons('https://example.com')
+
+// Or specify which methods to use
+const favicons = await discoverFavicons('https://example.com', {
+  methods: ['html', 'headers', 'guess'],
+})
 ```
 
 ### With Custom Options

--- a/docs/reference/discover-favicons.md
+++ b/docs/reference/discover-favicons.md
@@ -4,7 +4,7 @@ title: "Reference: discoverFavicons"
 
 # discoverFavicons
 
-Discovers favicon URLs from a webpage. Uses the same discovery pipeline as `discoverFeeds` and `discoverBlogrolls`.
+Discovers favicon URLs from a webpage or feed. Uses the same discovery pipeline as `discoverFeeds` and `discoverBlogrolls`.
 
 ## Signature
 
@@ -78,13 +78,7 @@ Results are deduplicated by URL — the first occurrence (from the highest-prior
 ```typescript
 import { discoverFavicons } from 'feedscout'
 
-// Simple usage - all methods enabled by default
 const favicons = await discoverFavicons('https://example.com')
-
-// Or specify which methods to use
-const favicons = await discoverFavicons('https://example.com', {
-  methods: ['html', 'guess'],
-})
 ```
 
 ### With Custom Options
@@ -96,49 +90,6 @@ const favicons = await discoverFavicons('https://example.com', {
       uris: ['/favicon.ico', '/icon.svg'],
     },
   },
-  concurrency: 3,
   stopOnFirstResult: true,
 })
 ```
-
-### With Existing Content
-
-```typescript
-const response = await fetch('https://example.com')
-
-const favicons = await discoverFavicons(
-  {
-    url: 'https://example.com',
-    content: await response.text(),
-    headers: response.headers,
-  },
-  { methods: ['html', 'headers'] },
-)
-```
-
-### With Progress Tracking
-
-```typescript
-const favicons = await discoverFavicons('https://example.com', {
-  methods: ['html', 'guess'],
-  onProgress: ({ tested, total, found, current }) => {
-    console.log(`[${tested}/${total}] ${current} (${found} found)`)
-  },
-})
-```
-
-### With Custom HTTP Client
-
-```typescript
-import type { DiscoverFetchFn } from 'feedscout'
-
-const myCustomFetch: DiscoverFetchFn = async (url, options) => {
-  // Handle the request and return response here.
-}
-
-const favicons = await discoverFavicons('https://example.com', {
-  fetchFn: myCustomFetch,
-})
-```
-
-See [Customize Data Fetching](/customization/data-fetching) for examples with Axios, Got, Ky, and more.

--- a/docs/reference/discover-feeds.md
+++ b/docs/reference/discover-feeds.md
@@ -58,7 +58,7 @@ Returns a promise that resolves to an array of results:
 {
   url: 'https://example.com/feed.xml',
   isValid: true,
-  method: 'guess',       // 'platform' | 'html' | 'headers' | 'guess'
+  method: 'guess',       // 'platform' | 'feed' | 'html' | 'headers' | 'guess'
   format: 'rss',         // 'rss' | 'atom' | 'json' | 'rdf'
   title: 'Example Blog',
   description: 'A blog about examples',

--- a/docs/reference/discover-feeds.md
+++ b/docs/reference/discover-feeds.md
@@ -11,7 +11,7 @@ Discovers and validates feeds from a webpage.
 ```typescript
 function discoverFeeds(
   input: DiscoverInput,
-  options?: DiscoverOptions<FeedResult>,
+  options?: DiscoverOptions<FeedResult, 'platform' | 'html' | 'headers' | 'guess'>,
 ): Promise<Array<DiscoverResult<FeedResult>>>
 ```
 
@@ -58,7 +58,7 @@ Returns a promise that resolves to an array of results:
 {
   url: 'https://example.com/feed.xml',
   isValid: true,
-  method: 'guess',       // 'platform' | 'feed' | 'html' | 'headers' | 'guess'
+  method: 'guess',       // 'platform' | 'html' | 'headers' | 'guess'
   format: 'rss',         // 'rss' | 'atom' | 'json' | 'rdf'
   title: 'Example Blog',
   description: 'A blog about examples',

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -64,7 +64,7 @@ type DiscoverOptions<TValid, TMethods extends DiscoverMethod = DiscoverMethod> =
 Union type of available discovery method names:
 
 ```typescript
-type DiscoverMethod = 'platform' | 'html' | 'headers' | 'guess'
+type DiscoverMethod = 'platform' | 'feed' | 'html' | 'headers' | 'guess'
 ```
 
 ### DiscoverMethodsConfig
@@ -77,6 +77,7 @@ type DiscoverMethodsConfig<TMethods extends DiscoverMethod = DiscoverMethod> =
   | Pick<
       {
         platform?: true | Partial<PlatformMethodOptions>
+        feed?: true | Partial<FeedMethodOptions>
         html?: true | Partial<Omit<HtmlMethodOptions, 'baseUrl'>>
         headers?: true | Partial<Omit<HeadersMethodOptions, 'baseUrl'>>
         guess?: true | Partial<Omit<GuessMethodOptions, 'baseUrl'>>
@@ -123,7 +124,7 @@ type DiscoverResult<TValid> =
     }
 ```
 
-The `method` field indicates which discovery method produced the result (`'platform'`, `'html'`, `'headers'`, or `'guess'`). See [Platform method hints](/feeds/platform#hints) for details on the `hint` property.
+The `method` field indicates which discovery method produced the result (`'platform'`, `'feed'`, `'html'`, `'headers'`, or `'guess'`). See [Platform method hints](/feeds/platform#hints) for details on the `hint` property.
 
 ### FeedResult
 
@@ -257,6 +258,18 @@ type DiscoverExtractFnInput = {
 ```
 
 ## Method Option Types
+
+### FeedMethodOptions
+
+Options for Feed discovery method:
+
+```typescript
+type FeedMethodOptions = {
+  extractUrls: (params: { format: string; feed: unknown }) => Array<string>
+}
+```
+
+The `extractUrls` callback receives the parsed feed format and data, and should return an array of URLs. For favicons, the default extractor pulls `icon` from Atom feeds and `favicon`/`icon` from JSON Feeds.
 
 ### HtmlMethodOptions
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -43,7 +43,7 @@ type DiscoverInputObject = {
 
 ### DiscoverOptions
 
-Options for `discoverFeeds` and `discoverBlogrolls`. All fields are optional for simple usage:
+Options for discovery functions. All fields are optional for simple usage. The `TMethods` parameter restricts which methods are available — each discoverer narrows it to its supported methods:
 
 ```typescript
 type DiscoverOptions<TValid, TMethods extends DiscoverMethod = DiscoverMethod> = {
@@ -264,12 +264,14 @@ type DiscoverExtractFnInput = {
 Options for Feed discovery method:
 
 ```typescript
+type FeedMethodData = ReturnType<typeof parseFeed>
+
 type FeedMethodOptions = {
-  extractUrls: (params: { format: string; feed: unknown }) => Array<string>
+  extractUrls: (params: FeedMethodData) => Array<string>
 }
 ```
 
-The `extractUrls` callback receives the parsed feed format and data, and should return an array of URLs. For favicons, the default extractor pulls `icon` from Atom feeds and `favicon`/`icon` from JSON Feeds.
+`FeedMethodData` is the return type of feedsmith's `parseFeed` — it contains `format` (e.g. `'atom'`, `'json'`) and `feed` (the parsed feed object). The `extractUrls` callback should return an array of URLs. For favicons, the default extractor pulls `icon` from Atom feeds and `favicon`/`icon` from JSON Feeds.
 
 ### HtmlMethodOptions
 

--- a/src/common/discover/utils.test.ts
+++ b/src/common/discover/utils.test.ts
@@ -439,9 +439,13 @@ describe('normalizeMethodsConfig', () => {
   const ignoredUris = ['wp-json/oembed/', 'wp-json/wp/']
   const anchorLabels = ['rss', 'feed', 'atom', 'subscribe', 'syndicate', 'json feed']
   const linkSelectors = [{ rel: 'alternate', types: feedMimeTypes }, { rel: 'feed' }]
+  const extractUrls = () => [] as Array<string>
   const defaults = {
     platform: {
       handlers: [],
+    },
+    feed: {
+      extractUrls,
     },
     html: {
       linkSelectors,
@@ -826,6 +830,65 @@ describe('normalizeMethodsConfig', () => {
     const throwing = () => normalizeMethodsConfig(value, ['platform'], defaults)
 
     expect(throwing).toThrow(locales.errors.platformMethodRequiresUrl)
+  })
+
+  it('should normalize feed method with defaults', () => {
+    const value = {
+      url: 'https://example.com',
+      content: '<feed>content</feed>',
+    }
+    const result = normalizeMethodsConfig(value, ['feed'], defaults)
+    const expected = {
+      feed: {
+        content: '<feed>content</feed>',
+        options: {
+          extractUrls,
+        },
+      },
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should normalize feed method with custom extractUrls', () => {
+    const customExtractUrls = () => ['https://example.com/icon.png']
+    const value = {
+      url: 'https://example.com',
+      content: '<feed>content</feed>',
+    }
+    const result = normalizeMethodsConfig(
+      value,
+      { feed: { extractUrls: customExtractUrls } },
+      defaults,
+    )
+    const expected = {
+      feed: {
+        content: '<feed>content</feed>',
+        options: {
+          extractUrls: customExtractUrls,
+        },
+      },
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should throw error when feed method requested without content', () => {
+    const value = {
+      url: 'https://example.com',
+    }
+    const throwing = () => normalizeMethodsConfig(value, ['feed'], defaults)
+
+    expect(throwing).toThrow(locales.errors.feedMethodRequiresContent)
+  })
+
+  it('should throw error when feed method in object format without content', () => {
+    const value = {
+      url: 'https://example.com',
+    }
+    const throwing = () => normalizeMethodsConfig(value, { feed: true }, defaults)
+
+    expect(throwing).toThrow(locales.errors.feedMethodRequiresContent)
   })
 
   it('should throw error when html method requested without content', () => {

--- a/src/common/discover/utils.ts
+++ b/src/common/discover/utils.ts
@@ -89,6 +89,22 @@ export const normalizeMethodsConfig = (
     }
   }
 
+  if (methodsObj.feed && defaults.feed) {
+    if (input.content === undefined) {
+      throw new Error(locales.errors.feedMethodRequiresContent)
+    }
+
+    const feedOptions = methodsObj.feed === true ? {} : methodsObj.feed
+
+    methodsConfig.feed = {
+      content: input.content,
+      options: {
+        ...defaults.feed,
+        ...feedOptions,
+      },
+    }
+  }
+
   if (methodsObj.html && defaults.html) {
     if (input.content === undefined) {
       throw new Error(locales.errors.htmlMethodRequiresContent)

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -1,6 +1,7 @@
 {
   "errors": {
     "platformMethodRequiresUrl": "Platform method requires url to be provided in input",
+    "feedMethodRequiresContent": "Feed method requires content to be provided in input",
     "htmlMethodRequiresContent": "HTML method requires content to be provided in input",
     "headersMethodRequiresHeaders": "Headers method requires headers to be provided in input",
     "guessMethodRequiresUrl": "Guess method requires url to be provided in input"

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,3 +1,4 @@
+import type { FeedMethodOptions } from './uris/feed/types.js'
 import type { GuessMethodOptions } from './uris/guess/types.js'
 import type { HeadersMethodOptions } from './uris/headers/types.js'
 import type { HtmlMethodOptions } from './uris/html/types.js'
@@ -15,7 +16,7 @@ export type DiscoverUriEntry = {
   hint?: DiscoverUriHint
 }
 
-export const discoverMethodOrder = ['platform', 'html', 'headers', 'guess'] as const
+export const discoverMethodOrder = ['platform', 'feed', 'html', 'headers', 'guess'] as const
 
 export type DiscoverMethod = (typeof discoverMethodOrder)[number]
 
@@ -95,6 +96,7 @@ export type DiscoverMethodsConfig<TMethods extends DiscoverMethod = DiscoverMeth
   | Pick<
       {
         platform?: true | Partial<PlatformMethodOptions>
+        feed?: true | Partial<FeedMethodOptions>
         html?: true | Partial<Omit<HtmlMethodOptions, 'baseUrl'>>
         headers?: true | Partial<Omit<HeadersMethodOptions, 'baseUrl'>>
         guess?: true | Partial<Omit<GuessMethodOptions, 'baseUrl'>>
@@ -105,6 +107,7 @@ export type DiscoverMethodsConfig<TMethods extends DiscoverMethod = DiscoverMeth
 // Defaults for method options (without baseUrl which comes from input).
 export type DiscoverMethodsConfigDefaults = {
   platform?: Omit<PlatformMethodOptions, 'baseUrl'>
+  feed?: FeedMethodOptions
   html?: Omit<HtmlMethodOptions, 'baseUrl'>
   headers?: Omit<HeadersMethodOptions, 'baseUrl'>
   guess?: Omit<GuessMethodOptions, 'baseUrl'>
@@ -116,6 +119,10 @@ export type DiscoverMethodsConfigInternal = {
     content?: string
     headers?: Headers
     options: PlatformMethodOptions
+  }
+  feed?: {
+    content: string
+    options: FeedMethodOptions
   }
   html?: {
     html: string

--- a/src/common/uris/feed/index.test.ts
+++ b/src/common/uris/feed/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { omitEmpty } from '../../utils.js'
 import { discoverUrisFromFeed } from './index.js'
 
 describe('discoverUrisFromFeed', () => {
@@ -13,8 +14,7 @@ describe('discoverUrisFromFeed', () => {
     const value = discoverUrisFromFeed(content, {
       extractUrls: ({ format, feed }) => {
         if (format === 'atom') {
-          const record = feed as Record<string, unknown>
-          return [record.icon as string].filter(Boolean)
+          return omitEmpty([feed.icon])
         }
         return []
       },
@@ -35,8 +35,7 @@ describe('discoverUrisFromFeed', () => {
     const value = discoverUrisFromFeed(content, {
       extractUrls: ({ format, feed }) => {
         if (format === 'json') {
-          const record = feed as Record<string, unknown>
-          return [record.favicon as string, record.icon as string].filter(Boolean)
+          return omitEmpty([feed.favicon, feed.icon])
         }
         return []
       },
@@ -82,9 +81,11 @@ describe('discoverUrisFromFeed', () => {
       items: [],
     })
     const value = discoverUrisFromFeed(content, {
-      extractUrls: ({ feed }) => {
-        const record = feed as Record<string, unknown>
-        return [record.favicon as string, record.icon as string, '']
+      extractUrls: ({ format, feed }) => {
+        if (format === 'json') {
+          return omitEmpty([feed.favicon, feed.icon])
+        }
+        return []
       },
     })
     const expected = ['https://example.com/favicon.ico']

--- a/src/common/uris/feed/index.test.ts
+++ b/src/common/uris/feed/index.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'bun:test'
+import { discoverUrisFromFeed } from './index.js'
+
+describe('discoverUrisFromFeed', () => {
+  it('should extract icon from Atom feed', () => {
+    const content = `<?xml version="1.0" encoding="utf-8"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Example</title>
+        <icon>https://example.com/icon.png</icon>
+        <id>urn:uuid:1</id>
+        <updated>2024-01-01T00:00:00Z</updated>
+      </feed>`
+    const value = discoverUrisFromFeed(content, {
+      extractUrls: ({ format, feed }) => {
+        if (format === 'atom') {
+          const record = feed as Record<string, unknown>
+          return [record.icon as string].filter(Boolean)
+        }
+        return []
+      },
+    })
+    const expected = ['https://example.com/icon.png']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should extract favicon and icon from JSON Feed', () => {
+    const content = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Example',
+      favicon: 'https://example.com/favicon.ico',
+      icon: 'https://example.com/icon.png',
+      items: [],
+    })
+    const value = discoverUrisFromFeed(content, {
+      extractUrls: ({ format, feed }) => {
+        if (format === 'json') {
+          const record = feed as Record<string, unknown>
+          return [record.favicon as string, record.icon as string].filter(Boolean)
+        }
+        return []
+      },
+    })
+    const expected = ['https://example.com/favicon.ico', 'https://example.com/icon.png']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should return empty array for RSS feed', () => {
+    const content = `<?xml version="1.0"?>
+      <rss version="2.0">
+        <channel>
+          <title>Example</title>
+          <link>https://example.com</link>
+        </channel>
+      </rss>`
+    const value = discoverUrisFromFeed(content, {
+      extractUrls: ({ format }) => {
+        if (format === 'atom' || format === 'json') {
+          return ['should-not-reach']
+        }
+        return []
+      },
+    })
+
+    expect(value).toEqual([])
+  })
+
+  it('should return empty array for invalid content', () => {
+    const value = discoverUrisFromFeed('not a feed', {
+      extractUrls: () => ['should-not-reach'],
+    })
+
+    expect(value).toEqual([])
+  })
+
+  it('should filter out empty and undefined values', () => {
+    const content = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Example',
+      favicon: 'https://example.com/favicon.ico',
+      items: [],
+    })
+    const value = discoverUrisFromFeed(content, {
+      extractUrls: ({ feed }) => {
+        const record = feed as Record<string, unknown>
+        return [record.favicon as string, record.icon as string, '']
+      },
+    })
+    const expected = ['https://example.com/favicon.ico']
+
+    expect(value).toEqual(expected)
+  })
+})

--- a/src/common/uris/feed/index.ts
+++ b/src/common/uris/feed/index.ts
@@ -1,0 +1,16 @@
+import { parseFeed } from 'feedsmith'
+import type { FeedMethodOptions } from './types.js'
+
+export const discoverUrisFromFeed = (
+  content: string,
+  options: FeedMethodOptions,
+): Array<string> => {
+  try {
+    const { format, feed } = parseFeed(content)
+    const urls = options.extractUrls({ format, feed })
+
+    return urls.filter((url) => url != null && url !== '')
+  } catch {}
+
+  return []
+}

--- a/src/common/uris/feed/index.ts
+++ b/src/common/uris/feed/index.ts
@@ -6,8 +6,8 @@ export const discoverUrisFromFeed = (
   options: FeedMethodOptions,
 ): Array<string> => {
   try {
-    const { format, feed } = parseFeed(content)
-    const urls = options.extractUrls({ format, feed })
+    const result = parseFeed(content)
+    const urls = options.extractUrls(result)
 
     return urls.filter((url) => url != null && url !== '')
   } catch {}

--- a/src/common/uris/feed/index.ts
+++ b/src/common/uris/feed/index.ts
@@ -1,4 +1,5 @@
 import { parseFeed } from 'feedsmith'
+import { omitEmpty } from '../../utils.js'
 import type { FeedMethodOptions } from './types.js'
 
 export const discoverUrisFromFeed = (
@@ -9,7 +10,7 @@ export const discoverUrisFromFeed = (
     const result = parseFeed(content)
     const urls = options.extractUrls(result)
 
-    return urls.filter((url) => url != null && url !== '')
+    return omitEmpty(urls)
   } catch {}
 
   return []

--- a/src/common/uris/feed/types.ts
+++ b/src/common/uris/feed/types.ts
@@ -1,3 +1,8 @@
+import type { parseFeed } from 'feedsmith'
+
+// TODO: Replace with named export when available in Feedsmith 3.x.
+export type ParseFeedResult = ReturnType<typeof parseFeed>
+
 export type FeedMethodOptions = {
-  extractUrls: (params: { format: string; feed: unknown }) => Array<string>
+  extractUrls: (params: ParseFeedResult) => Array<string>
 }

--- a/src/common/uris/feed/types.ts
+++ b/src/common/uris/feed/types.ts
@@ -1,8 +1,8 @@
 import type { parseFeed } from 'feedsmith'
 
 // TODO: Replace with named export when available in Feedsmith 3.x.
-export type ParseFeedResult = ReturnType<typeof parseFeed>
+export type FeedMethodData = ReturnType<typeof parseFeed>
 
 export type FeedMethodOptions = {
-  extractUrls: (params: ParseFeedResult) => Array<string>
+  extractUrls: (params: FeedMethodData) => Array<string>
 }

--- a/src/common/uris/feed/types.ts
+++ b/src/common/uris/feed/types.ts
@@ -1,0 +1,3 @@
+export type FeedMethodOptions = {
+  extractUrls: (params: { format: string; feed: unknown }) => Array<string>
+}

--- a/src/common/uris/index.test.ts
+++ b/src/common/uris/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { omitEmpty } from '../utils.js'
 import { discoverUris } from './index.js'
 
 describe('discoverUris', () => {
@@ -20,9 +21,11 @@ describe('discoverUris', () => {
       feed: {
         content,
         options: {
-          extractUrls: ({ feed }) => {
-            const record = feed as Record<string, unknown>
-            return [record.favicon as string].filter(Boolean)
+          extractUrls: ({ format, feed }) => {
+            if (format === 'json') {
+              return omitEmpty([feed.favicon])
+            }
+            return []
           },
         },
       },

--- a/src/common/uris/index.test.ts
+++ b/src/common/uris/index.test.ts
@@ -9,6 +9,29 @@ describe('discoverUris', () => {
     expect(value).toEqual(expected)
   })
 
+  it('should discover URIs from Feed method', async () => {
+    const content = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Example',
+      favicon: 'https://example.com/favicon.ico',
+      items: [],
+    })
+    const value = await discoverUris({
+      feed: {
+        content,
+        options: {
+          extractUrls: ({ feed }) => {
+            const record = feed as Record<string, unknown>
+            return [record.favicon as string].filter(Boolean)
+          },
+        },
+      },
+    })
+    const expected = { feed: [{ uri: 'https://example.com/favicon.ico' }] }
+
+    expect(value).toEqual(expected)
+  })
+
   it('should discover URIs from HTML method', async () => {
     const value = await discoverUris({
       html: {

--- a/src/common/uris/index.ts
+++ b/src/common/uris/index.ts
@@ -3,6 +3,7 @@ import type {
   DiscoverMethodsConfigInternal,
   DiscoverUrisResult,
 } from '../types.js'
+import { discoverUrisFromFeed } from './feed/index.js'
 import { discoverUrisFromGuess } from './guess/index.js'
 import { discoverUrisFromHeaders } from './headers/index.js'
 import { discoverUrisFromHtml } from './html/index.js'
@@ -24,6 +25,14 @@ export const discoverUris = async (
 
     if (uris.length > 0) {
       result.platform = uris
+    }
+  }
+
+  if (config.feed) {
+    const uris = discoverUrisFromFeed(config.feed.content, config.feed.options)
+
+    if (uris.length > 0) {
+      result.feed = uris.map((uri) => ({ uri }))
     }
   }
 

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -11,6 +11,7 @@ import {
   matchesAnyOfLinkSelectors,
   normalizeMimeType,
   normalizeUrl,
+  omitEmpty,
   processConcurrently,
 } from './utils.js'
 
@@ -451,6 +452,71 @@ describe('isAnyOf', () => {
     const patterns = ['', 'application/rss+xml']
 
     expect(isAnyOf(value, patterns)).toBe(true)
+  })
+})
+
+describe('omitEmpty', () => {
+  it('should remove undefined values', () => {
+    const value = ['a', undefined, 'b']
+    const expected = ['a', 'b']
+
+    expect(omitEmpty(value)).toEqual(expected)
+  })
+
+  it('should remove null values', () => {
+    const value = ['a', null, 'b']
+    const expected = ['a', 'b']
+
+    expect(omitEmpty(value)).toEqual(expected)
+  })
+
+  it('should remove empty strings', () => {
+    const value = ['a', '', 'b']
+    const expected = ['a', 'b']
+
+    expect(omitEmpty(value)).toEqual(expected)
+  })
+
+  it('should remove mixed empty values', () => {
+    const value = [undefined, 'a', null, '', 'b', undefined]
+    const expected = ['a', 'b']
+
+    expect(omitEmpty(value)).toEqual(expected)
+  })
+
+  it('should return empty array when all values are empty', () => {
+    const value = [undefined, null, '']
+    const expected: Array<string> = []
+
+    expect(omitEmpty(value)).toEqual(expected)
+  })
+
+  it('should return empty array for empty input', () => {
+    const value: Array<string | undefined> = []
+    const expected: Array<string> = []
+
+    expect(omitEmpty(value)).toEqual(expected)
+  })
+
+  it('should preserve all values when none are empty', () => {
+    const value = ['a', 'b', 'c']
+    const expected = ['a', 'b', 'c']
+
+    expect(omitEmpty(value)).toEqual(expected)
+  })
+
+  it('should work with number arrays', () => {
+    const value = [1, undefined, 0, null, 3]
+    const expected = [1, 0, 3]
+
+    expect(omitEmpty(value)).toEqual(expected)
+  })
+
+  it('should preserve order of remaining values', () => {
+    const value = ['c', undefined, 'a', null, 'b']
+    const expected = ['c', 'a', 'b']
+
+    expect(omitEmpty(value)).toEqual(expected)
   })
 })
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -67,6 +67,10 @@ export const isOfAllowedMimeType = (
   return isAnyOf(type, allowedTypes, normalizeMimeType)
 }
 
+export const omitEmpty = <T>(array: Array<T | null | undefined>): Array<T> => {
+  return array.filter((item): item is T => item != null && item !== '')
+}
+
 export const normalizeUrl = (url: string, baseUrl: string | undefined): string => {
   return baseUrl ? new URL(url, baseUrl).href : url
 }

--- a/src/exports/methods.ts
+++ b/src/exports/methods.ts
@@ -1,3 +1,4 @@
+export { discoverUrisFromFeed } from '../common/uris/feed/index.js'
 export { discoverUrisFromGuess } from '../common/uris/guess/index.js'
 export {
   generateUrlCombinations,

--- a/src/favicons/defaults.ts
+++ b/src/favicons/defaults.ts
@@ -1,8 +1,10 @@
 import type { LinkSelector } from '../common/types.js'
+import type { FeedMethodOptions } from '../common/uris/feed/types.js'
 import type { GuessMethodOptions } from '../common/uris/guess/types.js'
 import type { HeadersMethodOptions } from '../common/uris/headers/types.js'
 import type { HtmlMethodOptions } from '../common/uris/html/types.js'
 import type { PlatformMethodOptions } from '../common/uris/platform/types.js'
+import { omitEmpty } from '../common/utils.js'
 import { blueskyHandler } from './platform/handlers/bluesky.js'
 import { codebergHandler } from './platform/handlers/codeberg.js'
 import { deviantartHandler } from './platform/handlers/deviantart.js'
@@ -30,6 +32,20 @@ export const defaultGuessPaths = [
 ]
 
 export const linkSelectors: Array<LinkSelector> = defaultIconRels.map((rel) => ({ rel }))
+
+export const defaultFeedOptions: FeedMethodOptions = {
+  extractUrls: ({ format, feed }) => {
+    if (format === 'atom') {
+      return omitEmpty([feed.icon])
+    }
+
+    if (format === 'json') {
+      return omitEmpty([feed.favicon, feed.icon])
+    }
+
+    return []
+  },
+}
 
 export const defaultHtmlOptions: Omit<HtmlMethodOptions, 'baseUrl'> = {
   linkSelectors,

--- a/src/favicons/index.test.ts
+++ b/src/favicons/index.test.ts
@@ -237,6 +237,62 @@ describe('discoverFavicons', () => {
     expect(value).toEqual(expected)
   })
 
+  it('should discover favicon from Atom feed content', async () => {
+    const atomContent = `<?xml version="1.0" encoding="utf-8"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Example</title>
+        <icon>https://example.com/icon.png</icon>
+        <id>urn:uuid:1</id>
+        <updated>2024-01-01T00:00:00Z</updated>
+      </feed>`
+    const mockFetch = createMockFetch({
+      'https://example.com/icon.png': 'binary',
+    })
+    const value = await discoverFavicons(
+      { url: 'https://example.com/feed.xml', content: atomContent },
+      { methods: ['feed'], fetchFn: mockFetch },
+    )
+    const expected: Array<DiscoverResult<FaviconResult>> = [
+      { url: 'https://example.com/icon.png', isValid: true, method: 'feed' },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should discover favicon from JSON Feed content', async () => {
+    const jsonContent = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Example',
+      favicon: 'https://example.com/favicon.ico',
+      icon: 'https://example.com/icon.png',
+      items: [],
+    })
+    const mockFetch = createMockFetch({
+      'https://example.com/favicon.ico': 'binary',
+      'https://example.com/icon.png': 'binary',
+    })
+    const value = await discoverFavicons(
+      { url: 'https://example.com/feed.json', content: jsonContent },
+      { methods: ['feed'], fetchFn: mockFetch },
+    )
+    const expected: Array<DiscoverResult<FaviconResult>> = [
+      { url: 'https://example.com/favicon.ico', isValid: true, method: 'feed' },
+      { url: 'https://example.com/icon.png', isValid: true, method: 'feed' },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should return empty array from feed method for non-feed content', async () => {
+    const mockFetch = createMockFetch({})
+    const value = await discoverFavicons(
+      { url: 'https://example.com', content: '<html></html>' },
+      { methods: ['feed'], fetchFn: mockFetch },
+    )
+
+    expect(value).toEqual([])
+  })
+
   it('should return empty array for invalid URLs', async () => {
     const mockFetch = createMockFetch({})
     const value = await discoverFavicons('not-a-valid-url', {

--- a/src/favicons/index.test.ts
+++ b/src/favicons/index.test.ts
@@ -283,10 +283,17 @@ describe('discoverFavicons', () => {
     expect(value).toEqual(expected)
   })
 
-  it('should return empty array from feed method for non-feed content', async () => {
+  it('should return empty array from feed method for RSS content', async () => {
+    const rssContent = `<?xml version="1.0"?>
+      <rss version="2.0">
+        <channel>
+          <title>Example</title>
+          <link>https://example.com</link>
+        </channel>
+      </rss>`
     const mockFetch = createMockFetch({})
     const value = await discoverFavicons(
-      { url: 'https://example.com', content: '<html></html>' },
+      { url: 'https://example.com/feed.xml', content: rssContent },
       { methods: ['feed'], fetchFn: mockFetch },
     )
 

--- a/src/favicons/index.ts
+++ b/src/favicons/index.ts
@@ -3,6 +3,7 @@ import { defaultFetchFn } from '../common/discover/utils.js'
 import type { DiscoverInput, DiscoverOptions, DiscoverResult } from '../common/types.js'
 import { normalizeUrl } from '../common/utils.js'
 import {
+  defaultFeedOptions,
   defaultGuessOptions,
   defaultHeadersOptions,
   defaultHtmlOptions,
@@ -19,13 +20,14 @@ export const discoverFavicons = async <TValid extends FaviconResult = FaviconRes
     input,
     {
       ...options,
-      methods: options.methods ?? ['platform', 'html', 'headers', 'guess'],
+      methods: options.methods ?? ['platform', 'feed', 'html', 'headers', 'guess'],
       fetchFn: options.fetchFn ?? defaultFetchFn,
       extractFn: options.extractFn ?? defaultExtractor,
       normalizeUrlFn: options.normalizeUrlFn ?? normalizeUrl,
     },
     {
       platform: defaultPlatformOptions,
+      feed: defaultFeedOptions,
       html: defaultHtmlOptions,
       headers: defaultHeadersOptions,
       guess: defaultGuessOptions,


### PR DESCRIPTION
This PR adds `feed` as a discovery method for favicons, and reverts #65 in favour of it.

- Reverts PR #65 (`feat/feed-icon-extraction`) which added `icon` to `FeedResult`: icon extraction is now handled by the `feed` discover method instead
- Adds `feed` as a new method to the common discover pipeline, sitting between `platform` and `html` in method order
- Implements favicon extraction from Atom `<icon>` and JSON Feed `favicon`/`icon` fields via a declarative `extractUrls` callback
- Feeds and blogrolls get no-op feed defaults (`extractUrls: () => []`)
