### PR TITLE
refactor: Add TMethods generic to discovery types

### DIFF
--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -46,8 +46,8 @@ type DiscoverInputObject = {
 Options for `discoverFeeds` and `discoverBlogrolls`. All fields are optional for simple usage:
 
 ```typescript
-type DiscoverOptions<TValid> = {
-  methods?: DiscoverMethodsConfig
+type DiscoverOptions<TValid, TMethods extends DiscoverMethod = DiscoverMethod> = {
+  methods?: DiscoverMethodsConfig<TMethods>
   fetchFn?: DiscoverFetchFn
   extractFn?: DiscoverExtractFn<TValid>
   normalizeUrlFn?: DiscoverNormalizeUrlFn
@@ -72,13 +72,17 @@ type DiscoverMethod = 'platform' | 'html' | 'headers' | 'guess'
 Configuration for discovery methods:
 
 ```typescript
-type DiscoverMethodsConfig =
-  | Array<'html' | 'headers' | 'guess'>
-  | {
-      html?: true | Partial<Omit<HtmlMethodOptions, 'baseUrl'>>
-      headers?: true | Partial<Omit<HeadersMethodOptions, 'baseUrl'>>
-      guess?: true | Partial<Omit<GuessMethodOptions, 'baseUrl'>>
-    }
+type DiscoverMethodsConfig<TMethods extends DiscoverMethod = DiscoverMethod> =
+  | Array<TMethods>
+  | Pick<
+      {
+        platform?: true | Partial<PlatformMethodOptions>
+        html?: true | Partial<Omit<HtmlMethodOptions, 'baseUrl'>>
+        headers?: true | Partial<Omit<HeadersMethodOptions, 'baseUrl'>>
+        guess?: true | Partial<Omit<GuessMethodOptions, 'baseUrl'>>
+      },
+      TMethods
+    >
 ```
 
 The `baseUrl` is omitted because it's automatically derived from the input URL.

--- a/src/blogrolls/index.ts
+++ b/src/blogrolls/index.ts
@@ -20,7 +20,6 @@ export const discoverBlogrolls = async <TValid extends BlogrollResult = Blogroll
       normalizeUrlFn: options.normalizeUrlFn ?? normalizeUrl,
     },
     {
-      platform: { handlers: [] }, // Blogrolls do not use platform-specific discovery.
       html: defaultHtmlOptions,
       headers: defaultHeadersOptions,
       guess: defaultGuessOptions,

--- a/src/blogrolls/index.ts
+++ b/src/blogrolls/index.ts
@@ -8,7 +8,7 @@ import type { BlogrollResult } from './types.js'
 
 export const discoverBlogrolls = async <TValid extends BlogrollResult = BlogrollResult>(
   input: DiscoverInput,
-  options: DiscoverOptions<TValid> = {},
+  options: DiscoverOptions<TValid, 'html' | 'headers' | 'guess'> = {},
 ): Promise<Array<DiscoverResult<TValid>>> => {
   return discover<TValid>(
     input,

--- a/src/common/discover/utils.ts
+++ b/src/common/discover/utils.ts
@@ -71,7 +71,7 @@ export const normalizeMethodsConfig = (
   // Step 2: Build internal methods config.
   const methodsConfig: DiscoverMethodsConfigInternal = {}
 
-  if (methodsObj.platform) {
+  if (methodsObj.platform && defaults.platform) {
     if (!input.url || input.url === '') {
       throw new Error(locales.errors.platformMethodRequiresUrl)
     }
@@ -89,7 +89,7 @@ export const normalizeMethodsConfig = (
     }
   }
 
-  if (methodsObj.html) {
+  if (methodsObj.html && defaults.html) {
     if (input.content === undefined) {
       throw new Error(locales.errors.htmlMethodRequiresContent)
     }
@@ -106,7 +106,7 @@ export const normalizeMethodsConfig = (
     }
   }
 
-  if (methodsObj.headers) {
+  if (methodsObj.headers && defaults.headers) {
     if (input.headers === undefined) {
       throw new Error(locales.errors.headersMethodRequiresHeaders)
     }
@@ -123,7 +123,7 @@ export const normalizeMethodsConfig = (
     }
   }
 
-  if (methodsObj.guess) {
+  if (methodsObj.guess && defaults.guess) {
     if (!input.url || input.url === '') {
       throw new Error(locales.errors.guessMethodRequiresUrl)
     }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -90,14 +90,17 @@ export type DiscoverInputObject = {
 export type DiscoverInput = string | DiscoverInputObject
 
 // User-facing config - partial options (users override only what they need).
-export type DiscoverMethodsConfig =
-  | Array<DiscoverMethod>
-  | {
-      platform?: true | Partial<PlatformMethodOptions>
-      html?: true | Partial<Omit<HtmlMethodOptions, 'baseUrl'>>
-      headers?: true | Partial<Omit<HeadersMethodOptions, 'baseUrl'>>
-      guess?: true | Partial<Omit<GuessMethodOptions, 'baseUrl'>>
-    }
+export type DiscoverMethodsConfig<TMethods extends DiscoverMethod = DiscoverMethod> =
+  | Array<TMethods>
+  | Pick<
+      {
+        platform?: true | Partial<PlatformMethodOptions>
+        html?: true | Partial<Omit<HtmlMethodOptions, 'baseUrl'>>
+        headers?: true | Partial<Omit<HeadersMethodOptions, 'baseUrl'>>
+        guess?: true | Partial<Omit<GuessMethodOptions, 'baseUrl'>>
+      },
+      TMethods
+    >
 
 // Defaults for method options (without baseUrl which comes from input).
 export type DiscoverMethodsConfigDefaults = {
@@ -128,8 +131,8 @@ export type DiscoverMethodsConfigInternal = {
 }
 
 // User-facing options - all fields optional for simple usage.
-export type DiscoverOptions<TValid> = {
-  methods?: DiscoverMethodsConfig
+export type DiscoverOptions<TValid, TMethods extends DiscoverMethod = DiscoverMethod> = {
+  methods?: DiscoverMethodsConfig<TMethods>
   fetchFn?: DiscoverFetchFn
   extractFn?: DiscoverExtractFn<TValid>
   normalizeUrlFn?: DiscoverNormalizeUrlFn

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -104,10 +104,10 @@ export type DiscoverMethodsConfig<TMethods extends DiscoverMethod = DiscoverMeth
 
 // Defaults for method options (without baseUrl which comes from input).
 export type DiscoverMethodsConfigDefaults = {
-  platform: Omit<PlatformMethodOptions, 'baseUrl'>
-  html: Omit<HtmlMethodOptions, 'baseUrl'>
-  headers: Omit<HeadersMethodOptions, 'baseUrl'>
-  guess: Omit<GuessMethodOptions, 'baseUrl'>
+  platform?: Omit<PlatformMethodOptions, 'baseUrl'>
+  html?: Omit<HtmlMethodOptions, 'baseUrl'>
+  headers?: Omit<HeadersMethodOptions, 'baseUrl'>
+  guess?: Omit<GuessMethodOptions, 'baseUrl'>
 }
 
 // Internal methods config with full options and input data.

--- a/src/feeds/index.ts
+++ b/src/feeds/index.ts
@@ -13,7 +13,7 @@ import type { FeedResult } from './types.js'
 
 export const discoverFeeds = async <TValid extends FeedResult = FeedResult>(
   input: DiscoverInput,
-  options: DiscoverOptions<TValid> = {},
+  options: DiscoverOptions<TValid, 'platform' | 'html' | 'headers' | 'guess'> = {},
 ): Promise<Array<DiscoverResult<TValid>>> => {
   return discover<TValid>(
     input,


### PR DESCRIPTION
This PR adds a `TMethods` generic to the discovery types, so each discoverer only accepts the methods it actually supports.

- Add `TMethods` generic parameter to `DiscoverMethodsConfig` and `DiscoverOptions` to restrict which methods each discoverer accepts
- Make all fields in `DiscoverMethodsConfigDefaults` optional so discoverers only provide defaults for methods they support
- Add `&& defaults.X` guards in `normalizeMethodsConfig` to skip methods without defaults
- `discoverFeeds` now accepts `'platform' | 'html' | 'headers' | 'guess'` methods only
- `discoverBlogrolls` now accepts `'html' | 'headers' | 'guess'` methods only
- `discoverFavicons` accepts all methods (default)
- Remove `platform: { handlers: [] }` workaround from blogrolls
