### PR TITLE
Add comprehensive test coverage audit

### DIFF
--- a/src/blogrolls/extractors.test.ts
+++ b/src/blogrolls/extractors.test.ts
@@ -201,4 +201,20 @@ describe('defaultExtractor', () => {
 
     expect(result).toEqual(expected)
   })
+
+  it('should return isValid: false for malformed XML with unclosed tags', async () => {
+    const content =
+      '<?xml version="1.0"?><opml version="2.0"><head><title>Test</title></head><body><outline'
+    const result = await defaultExtractor({
+      content,
+      headers: new Headers(),
+      url: 'https://example.com/blogroll.opml',
+    })
+    const expected: DiscoverResult<BlogrollResult> = {
+      url: 'https://example.com/blogroll.opml',
+      isValid: false,
+    }
+
+    expect(result).toEqual(expected)
+  })
 })

--- a/src/blogrolls/index.test.ts
+++ b/src/blogrolls/index.test.ts
@@ -82,10 +82,22 @@ describe('discoverBlogrolls', () => {
         fetchFn: mockFetch,
       },
     )
+    const expected: Array<DiscoverResult<BlogrollResult>> = [
+      {
+        url: 'https://example.com/.well-known/recommendations.opml',
+        isValid: true,
+        method: 'guess',
+        title: 'My Blogroll',
+      },
+      {
+        url: 'https://example.com/blogroll.opml',
+        isValid: true,
+        method: 'guess',
+        title: 'My Blogroll',
+      },
+    ]
 
-    expect(value.length).toBe(2)
-    expect(value[0].isValid).toBe(true)
-    expect(value[1].isValid).toBe(true)
+    expect(value).toEqual(expected)
   })
 
   it('should work with balanced blogroll URIs array', async () => {
@@ -123,8 +135,22 @@ describe('discoverBlogrolls', () => {
         fetchFn: mockFetch,
       },
     )
+    const expected: Array<DiscoverResult<BlogrollResult>> = [
+      {
+        url: 'https://example.com/links.opml',
+        isValid: true,
+        method: 'guess',
+        title: 'My Blogroll',
+      },
+      {
+        url: 'https://example.com/feeds.opml',
+        isValid: true,
+        method: 'guess',
+        title: 'My Blogroll',
+      },
+    ]
 
-    expect(value.length).toBe(2)
+    expect(value).toEqual(expected)
   })
 
   it('should discover blogrolls from HTML link elements with rel="blogroll"', async () => {
@@ -248,7 +274,71 @@ describe('discoverBlogrolls', () => {
         fetchFn: mockFetch,
       },
     )
+    const expected: Array<DiscoverResult<BlogrollResult>> = [
+      {
+        url: 'https://example.com/blogroll.opml',
+        isValid: true,
+        method: 'guess',
+        title: 'My Blogroll',
+      },
+      {
+        url: 'https://www.example.com/blogroll.opml',
+        isValid: true,
+        method: 'guess',
+        title: 'My Blogroll',
+      },
+    ]
 
-    expect(value.length).toBe(2)
+    expect(value).toEqual(expected)
+  })
+
+  it('should filter out invalid results when fetchFn returns 404', async () => {
+    const mockFetch: DiscoverFetchFn = async (url: string) => ({
+      url,
+      body: 'Not Found',
+      headers: new Headers(),
+      status: 404,
+      statusText: 'Not Found',
+    })
+    const value = await discoverBlogrolls(
+      { url: 'https://example.com' },
+      {
+        methods: { guess: { uris: ['/blogroll.opml'] } },
+        fetchFn: mockFetch,
+      },
+    )
+
+    expect(value).toEqual([])
+  })
+
+  it('should filter out invalid results for valid HTTP 200 with invalid OPML', async () => {
+    const mockFetch = createMockFetch({
+      'https://example.com/blogroll.opml': '<!DOCTYPE html><html><body>Not OPML</body></html>',
+    })
+    const value = await discoverBlogrolls(
+      { url: 'https://example.com' },
+      {
+        methods: { guess: { uris: ['/blogroll.opml'] } },
+        fetchFn: mockFetch,
+      },
+    )
+
+    expect(value).toEqual([])
+  })
+
+  it('should return empty array when no blogrolls found', async () => {
+    const mockFetch = createMockFetch({})
+    const value = await discoverBlogrolls(
+      {
+        url: 'https://example.com',
+        content: '<html><head></head><body>No blogrolls here</body></html>',
+      },
+      {
+        methods: { html: true },
+        fetchFn: mockFetch,
+      },
+    )
+
+    expect(value).toEqual([])
   })
 })

--- a/src/common/discover/index.test.ts
+++ b/src/common/discover/index.test.ts
@@ -955,6 +955,50 @@ describe('discover', () => {
     })
   })
 
+  describe('hint preservation', () => {
+    it('should preserve hint from platform handler in result', async () => {
+      const platformHandler: PlatformHandler = {
+        match: () => true,
+        resolve: () => [{ uri: '/feed', hint: { key: 'test', label: 'Test' } }],
+      }
+      const mockFetch = createMockFetch({
+        'https://example.com/feed': rss,
+      })
+      const value = await discoverFeeds(
+        { url: 'https://example.com', content: '<html></html>' },
+        {
+          methods: { platform: { handlers: [platformHandler] } },
+          fetchFn: mockFetch,
+        },
+      )
+      const expected: Array<DiscoverResult<FeedResult>> = [
+        {
+          url: 'https://example.com/feed',
+          isValid: true,
+          method: 'platform',
+          hint: { key: 'test', label: 'Test' },
+          format: 'rss',
+          title: 'Test RSS',
+          description: 'Test feed',
+          siteUrl: 'https://example.com',
+        },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+  })
+
+  describe('empty methods', () => {
+    it('should return empty array for empty methods config', async () => {
+      const value = await discoverFeeds(
+        { url: 'https://example.com' },
+        { methods: [] },
+      )
+
+      expect(value).toEqual([])
+    })
+  })
+
   describe('method validation', () => {
     it('should throw error when html method requested without content', () => {
       const throwing = () => discoverFeeds({ url: 'https://example.com' }, { methods: ['html'] })

--- a/src/common/types.test.ts
+++ b/src/common/types.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'bun:test'
+import { discoverMethodOrder } from './types.js'
+
+describe('discoverMethodOrder', () => {
+  it('should equal expected order', () => {
+    expect(discoverMethodOrder).toEqual(['platform', 'feed', 'html', 'headers', 'guess'])
+  })
+})

--- a/src/common/uris/guess/utils.test.ts
+++ b/src/common/uris/guess/utils.test.ts
@@ -162,6 +162,14 @@ describe('generateUrlCombinations', () => {
     expect(generateUrlCombinations(baseUrls, feedUris)).toEqual(expected)
   })
 
+  it('should resolve empty array entry as empty alternatives group', () => {
+    const baseUrls = ['https://example.com']
+    const feedUris: Array<Array<string>> = [[]]
+    const expected = [[] as Array<string>]
+
+    expect(generateUrlCombinations(baseUrls, feedUris)).toEqual(expected)
+  })
+
   it('should resolve array entries across multiple base URLs', () => {
     const baseUrls = ['https://example.com', 'https://blog.example.com']
     const feedUris = [['/feed/', '?feed=rss']]
@@ -220,6 +228,13 @@ describe('getWwwCounterpart', () => {
   it('should ignore paths and query params in origin', () => {
     const value = 'https://example.com/path?query=1'
     const expected = 'https://www.example.com'
+
+    expect(getWwwCounterpart(value)).toBe(expected)
+  })
+
+  it('should add www to localhost', () => {
+    const value = 'https://localhost'
+    const expected = 'https://www.localhost'
 
     expect(getWwwCounterpart(value)).toBe(expected)
   })

--- a/src/common/uris/headers/index.test.ts
+++ b/src/common/uris/headers/index.test.ts
@@ -363,6 +363,14 @@ describe('discoverUrisFromHeaders', () => {
       expect(result).toEqual(['/feed.xml'])
     })
 
+    it('should match alternate in space-separated rel value', () => {
+      const headers = new Headers({
+        Link: '</feed.xml>; rel="hub alternate"; type="application/rss+xml"',
+      })
+      const result = discoverUrisFromHeaders(headers, defaultOptions)
+      expect(result).toEqual(['/feed.xml'])
+    })
+
     it('should handle escaped quotes in parameter values', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; title="The \\"Best\\" Feed"; type="application/rss+xml"',

--- a/src/common/uris/html/handlers.test.ts
+++ b/src/common/uris/html/handlers.test.ts
@@ -406,6 +406,19 @@ describe('handleCloseTag', () => {
     expect(value.currentAnchor.text).toBe('RSS Feed')
   })
 
+  it('should deduplicate URI matched by both href suffix and text', () => {
+    const value = createMockContext()
+
+    // Anchor with href ending in /feed (matched by href suffix in handleOpenTag).
+    handleOpenTag(value, 'a', { href: '/feed' })
+    handleText(value, 'RSS Feed')
+    // handleCloseTag would also add /feed via text match, but Set deduplicates.
+    handleCloseTag(value, 'a')
+
+    expect(value.discoveredUris.size).toBe(1)
+    expect(value.discoveredUris.has('/feed')).toBe(true)
+  })
+
   it('should handle text with feed keyword in the middle', () => {
     const value = createMockContext()
     value.currentAnchor.href = '/custom-feed'

--- a/src/common/uris/index.test.ts
+++ b/src/common/uris/index.test.ts
@@ -200,6 +200,47 @@ describe('discoverUris', () => {
     expect(value).toEqual(expected)
   })
 
+  it('should return empty object when all methods return empty arrays', async () => {
+    const value = await discoverUris({
+      html: {
+        html: '<div>No feeds</div>',
+        options: {
+          linkSelectors: [{ rel: 'alternate', types: ['application/rss+xml'] }],
+          anchorUris: [],
+          anchorIgnoredUris: [],
+          anchorLabels: [],
+        },
+      },
+      guess: {
+        options: {
+          baseUrl: 'https://example.com',
+          uris: [],
+        },
+      },
+    })
+
+    expect(value).toEqual({})
+  })
+
+  it('should filter undefined entries from feed extractUrls via omitEmpty', async () => {
+    const content = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Example',
+      items: [],
+    })
+    const value = await discoverUris({
+      feed: {
+        content,
+        options: {
+          extractUrls: () => omitEmpty([undefined, '/valid']),
+        },
+      },
+    })
+    const expected = { feed: [{ uri: '/valid' }] }
+
+    expect(value).toEqual(expected)
+  })
+
   it('should handle mixed string and array entries across methods', async () => {
     const value = await discoverUris({
       platform: {

--- a/src/common/uris/platform/index.test.ts
+++ b/src/common/uris/platform/index.test.ts
@@ -153,6 +153,26 @@ describe('discoverUrisFromPlatform', () => {
     expect(secondResolvedCalled).toBe(false)
   })
 
+  it('should continue to next handler if async resolve throws', async () => {
+    const throwingHandler: PlatformHandler = {
+      match: () => true,
+      resolve: async () => {
+        throw new Error('Async resolve error')
+      },
+    }
+    const workingHandler: PlatformHandler = {
+      match: () => true,
+      resolve: () => [{ uri: 'https://example.com/feed.xml' }],
+    }
+    const value = {
+      baseUrl: 'https://example.com',
+      handlers: [throwingHandler, workingHandler],
+    }
+    const expected = [{ uri: 'https://example.com/feed.xml' }]
+
+    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual(expected)
+  })
+
   it('should check handlers in provided order', async () => {
     const callOrder: Array<string> = []
     const firstHandler: PlatformHandler = {

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -331,6 +331,10 @@ describe('includesAnyOf', () => {
     expect(includesAnyOf(value, patterns)).toBe(false)
   })
 
+  it('should return true when pattern contains empty string', () => {
+    expect(includesAnyOf('anything', [''])).toBe(true)
+  })
+
   it('should handle pattern with numbers', () => {
     const value = 'RSS 2.0 feed'
     const patterns = ['2.0']
@@ -798,6 +802,10 @@ describe('endsWithAnyOf', () => {
 
     expect(endsWithAnyOf(value, patterns)).toBe(true)
   })
+
+  it('should return true when pattern contains empty string', () => {
+    expect(endsWithAnyOf('anything', [''])).toBe(true)
+  })
 })
 
 describe('isOfAllowedMimeType', () => {
@@ -1038,6 +1046,8 @@ describe('processConcurrently', () => {
       }),
     ).toEqual(expected)
   })
+
+  it.todo('should handle concurrency=0 — causes infinite loop, items never process')
 
   it('should not call shouldStop after completion', async () => {
     const items = [1, 2, 3]

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -1047,7 +1047,7 @@ describe('processConcurrently', () => {
     ).toEqual(expected)
   })
 
-  it.todo('should handle concurrency=0 — causes infinite loop, items never process')
+  // TODO: Should handle concurrency=0 — causes infinite loop, items never process.
 
   it('should not call shouldStop after completion', async () => {
     const items = [1, 2, 3]

--- a/src/favicons/extractors.test.ts
+++ b/src/favicons/extractors.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test'
+import { defaultExtractor } from './extractors.js'
+
+describe('defaultExtractor', () => {
+  it('should return isValid: true for status 200', async () => {
+    const result = await defaultExtractor({ url: 'https://example.com/icon.png', content: '', status: 200 })
+
+    expect(result).toEqual({ url: 'https://example.com/icon.png', isValid: true })
+  })
+
+  it('should return isValid: true for status 299', async () => {
+    const result = await defaultExtractor({ url: 'https://example.com/icon.png', content: '', status: 299 })
+
+    expect(result).toEqual({ url: 'https://example.com/icon.png', isValid: true })
+  })
+
+  it('should return isValid: true for status 301', async () => {
+    const result = await defaultExtractor({ url: 'https://example.com/icon.png', content: '', status: 301 })
+
+    expect(result).toEqual({ url: 'https://example.com/icon.png', isValid: true })
+  })
+
+  it('should return isValid: true for status 399', async () => {
+    const result = await defaultExtractor({ url: 'https://example.com/icon.png', content: '', status: 399 })
+
+    expect(result).toEqual({ url: 'https://example.com/icon.png', isValid: true })
+  })
+
+  it('should return isValid: false for status 400', async () => {
+    const result = await defaultExtractor({ url: 'https://example.com/icon.png', content: '', status: 400 })
+
+    expect(result).toEqual({ url: 'https://example.com/icon.png', isValid: false })
+  })
+
+  it('should return isValid: false for status 404', async () => {
+    const result = await defaultExtractor({ url: 'https://example.com/icon.png', content: '', status: 404 })
+
+    expect(result).toEqual({ url: 'https://example.com/icon.png', isValid: false })
+  })
+
+  it('should return isValid: false for status 500', async () => {
+    const result = await defaultExtractor({ url: 'https://example.com/icon.png', content: '', status: 500 })
+
+    expect(result).toEqual({ url: 'https://example.com/icon.png', isValid: false })
+  })
+
+  it('should return isValid: false for status 199', async () => {
+    const result = await defaultExtractor({ url: 'https://example.com/icon.png', content: '', status: 199 })
+
+    expect(result).toEqual({ url: 'https://example.com/icon.png', isValid: false })
+  })
+
+  it('should return isValid: false for undefined status', async () => {
+    const result = await defaultExtractor({ url: 'https://example.com/icon.png', content: '', status: undefined })
+
+    expect(result).toEqual({ url: 'https://example.com/icon.png', isValid: false })
+  })
+})

--- a/src/favicons/platform/handlers/bluesky.test.ts
+++ b/src/favicons/platform/handlers/bluesky.test.ts
@@ -206,5 +206,25 @@ describe('blueskyHandler', () => {
 
       expect(value).toEqual([])
     })
+
+    it('should resolve avatar from www.bsky.app variant', async () => {
+      const mockFetch = createMockFetch({
+        'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=user.bsky.social':
+          JSON.stringify({
+            avatar: 'https://cdn.bsky.app/img/avatar/plain/did:plc:abc/avatar.jpg',
+          }),
+      })
+      const value = await blueskyHandler.resolve(
+        'https://www.bsky.app/profile/user.bsky.social',
+        undefined,
+        undefined,
+        mockFetch,
+      )
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://cdn.bsky.app/img/avatar/plain/did:plc:abc/avatar.jpg' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
   })
 })

--- a/src/favicons/platform/handlers/codeberg.test.ts
+++ b/src/favicons/platform/handlers/codeberg.test.ts
@@ -23,6 +23,10 @@ describe('codebergHandler', () => {
     it('should not match non-codeberg URLs', () => {
       expect(codebergHandler.match('https://github.com/user')).toBe(false)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => codebergHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/favicons/platform/handlers/codeberg.test.ts
+++ b/src/favicons/platform/handlers/codeberg.test.ts
@@ -78,5 +78,23 @@ describe('codebergHandler', () => {
       expect(codebergHandler.resolve('https://codeberg.org/Explore')).toEqual([])
       expect(codebergHandler.resolve('https://codeberg.org/ADMIN')).toEqual([])
     })
+
+    it('should resolve www.codeberg.org URL', () => {
+      const value = codebergHandler.resolve('https://www.codeberg.org/forgejo')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://www.codeberg.org/user/avatar/forgejo/512' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve www.gitea.com URL', () => {
+      const value = codebergHandler.resolve('https://www.gitea.com/gitea')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://www.gitea.com/user/avatar/gitea/512' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
   })
 })

--- a/src/favicons/platform/handlers/deviantart.test.ts
+++ b/src/favicons/platform/handlers/deviantart.test.ts
@@ -92,5 +92,9 @@ describe('deviantartHandler', () => {
     it('should return empty array for root URL', () => {
       expect(deviantartHandler.resolve('https://www.deviantart.com/')).toEqual([])
     })
+
+    it('should return empty array for single-char username', () => {
+      expect(deviantartHandler.resolve('https://www.deviantart.com/x')).toEqual([])
+    })
   })
 })

--- a/src/favicons/platform/handlers/github.test.ts
+++ b/src/favicons/platform/handlers/github.test.ts
@@ -60,5 +60,19 @@ describe('githubHandler', () => {
       expect(githubHandler.resolve('https://github.com/Features')).toEqual([])
       expect(githubHandler.resolve('https://github.com/EXPLORE')).toEqual([])
     })
+
+    it('should resolve www.github.com URL', () => {
+      const value = githubHandler.resolve('https://www.github.com/octocat')
+      const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/octocat.png' }]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve username with dashes', () => {
+      const value = githubHandler.resolve('https://github.com/my-org')
+      const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/my-org.png' }]
+
+      expect(value).toEqual(expected)
+    })
   })
 })

--- a/src/favicons/platform/handlers/github.test.ts
+++ b/src/favicons/platform/handlers/github.test.ts
@@ -15,6 +15,10 @@ describe('githubHandler', () => {
     it('should not match non-github URLs', () => {
       expect(githubHandler.match('https://gitlab.com/user')).toBe(false)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => githubHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/favicons/platform/handlers/githubGist.test.ts
+++ b/src/favicons/platform/handlers/githubGist.test.ts
@@ -15,6 +15,10 @@ describe('githubGistHandler', () => {
     it('should not match non-github URLs', () => {
       expect(githubGistHandler.match('https://gitlab.com/user')).toBe(false)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => githubGistHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/favicons/platform/handlers/lobsters.test.ts
+++ b/src/favicons/platform/handlers/lobsters.test.ts
@@ -59,5 +59,9 @@ describe('lobstersHandler', () => {
     it('should return empty array for non-user path', () => {
       expect(lobstersHandler.resolve('https://lobste.rs/t/programming')).toEqual([])
     })
+
+    it('should return empty array for username with @ char', () => {
+      expect(lobstersHandler.resolve('https://lobste.rs/~@invalid')).toEqual([])
+    })
   })
 })

--- a/src/favicons/platform/handlers/mastodon.test.ts
+++ b/src/favicons/platform/handlers/mastodon.test.ts
@@ -274,5 +274,42 @@ describe('mastodonHandler', () => {
 
       expect(value).toEqual([])
     })
+
+    // Port is stripped from API URL because handler uses hostname (not host).
+    it('should resolve avatar from instance with port number', async () => {
+      const mockFetch = createMockFetch({
+        'https://mastodon.local/api/v1/accounts/lookup?acct=user': JSON.stringify({
+          avatar: 'https://mastodon.local:3000/avatars/user.png',
+        }),
+      })
+      const value = await mastodonHandler.resolve(
+        'https://mastodon.local:3000/@user',
+        undefined,
+        undefined,
+        mockFetch,
+      )
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://mastodon.local:3000/avatars/user.png' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve avatar from /@user@domain format', async () => {
+      const mockFetch = createMockFetch({
+        'https://mastodon.social/api/v1/accounts/lookup?acct=user@remote.social': JSON.stringify({
+          avatar: 'https://remote.social/avatars/user.png',
+        }),
+      })
+      const value = await mastodonHandler.resolve(
+        'https://mastodon.social/@user@remote.social',
+        undefined,
+        undefined,
+        mockFetch,
+      )
+      const expected: Array<DiscoverUriEntry> = [{ uri: 'https://remote.social/avatars/user.png' }]
+
+      expect(value).toEqual(expected)
+    })
   })
 })

--- a/src/favicons/platform/handlers/reddit.test.ts
+++ b/src/favicons/platform/handlers/reddit.test.ts
@@ -318,5 +318,22 @@ describe('redditHandler', () => {
 
       expect(value).toEqual([])
     })
+
+    it('should return empty array when community_icon is non-string type', async () => {
+      // When community_icon is a number, .split() throws and the catch block returns [].
+      const mockFetch = createMockFetch({
+        'https://www.reddit.com/r/javascript/about.json': JSON.stringify({
+          data: { community_icon: 42, icon_img: 'https://b.thumbs.redditmedia.com/fallback.png' },
+        }),
+      })
+      const value = await redditHandler.resolve(
+        'https://reddit.com/r/javascript',
+        undefined,
+        undefined,
+        mockFetch,
+      )
+
+      expect(value).toEqual([])
+    })
   })
 })

--- a/src/favicons/platform/handlers/sourceforge.test.ts
+++ b/src/favicons/platform/handlers/sourceforge.test.ts
@@ -53,5 +53,21 @@ describe('sourceforgeHandler', () => {
     it('should return empty array for non-project path', () => {
       expect(sourceforgeHandler.resolve('https://sourceforge.net/about')).toEqual([])
     })
+
+    it('should resolve project icon from www variant', () => {
+      const value = sourceforgeHandler.resolve('https://www.sourceforge.net/projects/mingw')
+      const expected: Array<DiscoverUriEntry> = [{ uri: 'https://a.fsdn.com/allura/p/mingw/icon' }]
+
+      expect(value).toEqual(expected)
+    })
+
+    it('should resolve project icon for project with hyphens', () => {
+      const value = sourceforgeHandler.resolve('https://sourceforge.net/projects/my-cool-project')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://a.fsdn.com/allura/p/my-cool-project/icon' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
   })
 })

--- a/src/favicons/platform/handlers/tumblr.test.ts
+++ b/src/favicons/platform/handlers/tumblr.test.ts
@@ -19,6 +19,10 @@ describe('tumblrHandler', () => {
     it('should not match non-tumblr URLs', () => {
       expect(tumblrHandler.match('https://example.com')).toBe(false)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => tumblrHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/favicons/platform/handlers/tumblr.test.ts
+++ b/src/favicons/platform/handlers/tumblr.test.ts
@@ -52,5 +52,15 @@ describe('tumblrHandler', () => {
 
       expect(value).toEqual(expected)
     })
+
+    // Questionable: extracts 'www' as blog name.
+    it('should resolve www.tumblr.com using www as blog name', () => {
+      const value = tumblrHandler.resolve('https://www.tumblr.com')
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://api.tumblr.com/v2/blog/www/avatar/512' },
+      ]
+
+      expect(value).toEqual(expected)
+    })
   })
 })

--- a/src/feeds/extractors.test.ts
+++ b/src/feeds/extractors.test.ts
@@ -317,10 +317,84 @@ describe('defaultExtractor', () => {
       url: 'https://example.com/page.html',
     })
 
-    // Should detect as HTML, not RSS (ignoring headers)
+    // Should detect as HTML, not RSS (ignoring headers).
     const expected: DiscoverResult<FeedResult> = {
       url: 'https://example.com/page.html',
       isValid: false,
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should return siteUrl undefined for Atom without alternate link', async () => {
+    const atom = `
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Test</title>
+        <subtitle>Test feed</subtitle>
+      </feed>
+    `
+    const result = await defaultExtractor({
+      content: atom,
+      headers: new Headers(),
+      url: 'https://example.com/feed.xml',
+    })
+    const expected: DiscoverResult<FeedResult> = {
+      url: 'https://example.com/feed.xml',
+      isValid: true,
+      format: 'atom',
+      title: 'Test',
+      description: 'Test feed',
+      siteUrl: undefined,
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should return siteUrl undefined for RSS without link element', async () => {
+    const rss = `
+      <rss version="2.0">
+        <channel>
+          <title>Test</title>
+          <description>Test feed</description>
+        </channel>
+      </rss>
+    `
+    const result = await defaultExtractor({
+      content: rss,
+      headers: new Headers(),
+      url: 'https://example.com/feed.xml',
+    })
+    const expected: DiscoverResult<FeedResult> = {
+      url: 'https://example.com/feed.xml',
+      isValid: true,
+      format: 'rss',
+      title: 'Test',
+      description: 'Test feed',
+      siteUrl: undefined,
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should return siteUrl undefined for JSON Feed without home_page_url', async () => {
+    const json = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Test',
+      description: 'Test feed',
+      items: [],
+    })
+    const result = await defaultExtractor({
+      content: json,
+      headers: new Headers(),
+      url: 'https://example.com/feed.json',
+    })
+    const expected: DiscoverResult<FeedResult> = {
+      url: 'https://example.com/feed.json',
+      isValid: true,
+      format: 'json',
+      title: 'Test',
+      description: 'Test feed',
+      siteUrl: undefined,
     }
 
     expect(result).toEqual(expected)

--- a/src/feeds/index.test.ts
+++ b/src/feeds/index.test.ts
@@ -314,6 +314,21 @@ describe('discoverFeeds', () => {
     expect(value).toEqual(expected)
   })
 
+  it('should return empty array when methods is empty array', async () => {
+    const mockFetch = createMockFetch({
+      'https://example.com/feed': '<rss><channel><title>Test</title></channel></rss>',
+    })
+    const value = await discoverFeeds(
+      { url: 'https://example.com' },
+      {
+        methods: [],
+        fetchFn: mockFetch,
+      },
+    )
+
+    expect(value).toEqual([])
+  })
+
   describe('platform method', () => {
     it('should discover feeds when platform method specified in array form', async () => {
       const rss = `

--- a/src/feeds/platform/handlers/behance.test.ts
+++ b/src/feeds/platform/handlers/behance.test.ts
@@ -14,6 +14,10 @@ describe('behanceHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(behanceHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => behanceHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/blogspot.test.ts
+++ b/src/feeds/platform/handlers/blogspot.test.ts
@@ -19,6 +19,10 @@ describe('blogspotHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(blogspotHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => blogspotHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/bluesky.test.ts
+++ b/src/feeds/platform/handlers/bluesky.test.ts
@@ -11,6 +11,10 @@ describe('blueskyHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(blueskyHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => blueskyHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/bluesky.test.ts
+++ b/src/feeds/platform/handlers/bluesky.test.ts
@@ -5,6 +5,7 @@ describe('blueskyHandler', () => {
   describe('match', () => {
     const cases = [
       ['https://bsky.app/profile/user.bsky.social', true],
+      ['https://www.bsky.app/profile/user.bsky.social', false],
       ['https://twitter.com/user', false],
     ] as const
 
@@ -68,6 +69,18 @@ describe('blueskyHandler', () => {
 
     it('should resolve /profile/user/post/123 using first segment as handle', () => {
       const value = 'https://bsky.app/profile/user.bsky.social/post/123'
+      const expected = [
+        {
+          uri: 'https://bsky.app/profile/user.bsky.social/rss',
+          hint: { key: 'bluesky:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(blueskyHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for /profile/user/followers subpath extraction', () => {
+      const value = 'https://bsky.app/profile/user.bsky.social/followers'
       const expected = [
         {
           uri: 'https://bsky.app/profile/user.bsky.social/rss',

--- a/src/feeds/platform/handlers/bluesky.test.ts
+++ b/src/feeds/platform/handlers/bluesky.test.ts
@@ -59,5 +59,23 @@ describe('blueskyHandler', () => {
 
       expect(blueskyHandler.resolve(value)).toEqual([])
     })
+
+    it('should return empty array for /profile/ without handle', () => {
+      const value = 'https://bsky.app/profile/'
+
+      expect(blueskyHandler.resolve(value)).toEqual([])
+    })
+
+    it('should resolve /profile/user/post/123 using first segment as handle', () => {
+      const value = 'https://bsky.app/profile/user.bsky.social/post/123'
+      const expected = [
+        {
+          uri: 'https://bsky.app/profile/user.bsky.social/rss',
+          hint: { key: 'bluesky:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(blueskyHandler.resolve(value)).toEqual(expected)
+    })
   })
 })

--- a/src/feeds/platform/handlers/codeberg.test.ts
+++ b/src/feeds/platform/handlers/codeberg.test.ts
@@ -17,6 +17,10 @@ describe('codebergHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(codebergHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => codebergHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/csdn.test.ts
+++ b/src/feeds/platform/handlers/csdn.test.ts
@@ -12,6 +12,10 @@ describe('csdnHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(csdnHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => csdnHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/dailymotion.test.ts
+++ b/src/feeds/platform/handlers/dailymotion.test.ts
@@ -15,6 +15,10 @@ describe('dailymotionHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(dailymotionHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => dailymotionHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/deviantart.test.ts
+++ b/src/feeds/platform/handlers/deviantart.test.ts
@@ -12,6 +12,10 @@ describe('deviantartHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(deviantartHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => deviantartHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/devto.test.ts
+++ b/src/feeds/platform/handlers/devto.test.ts
@@ -12,6 +12,10 @@ describe('devtoHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(devtoHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => devtoHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/devto.test.ts
+++ b/src/feeds/platform/handlers/devto.test.ts
@@ -86,5 +86,29 @@ describe('devtoHandler', () => {
 
       expect(devtoHandler.resolve(value)).toEqual([])
     })
+
+    it('should resolve www.dev.to URL', () => {
+      const value = 'https://www.dev.to/username'
+      const expected = [
+        {
+          uri: 'https://dev.to/feed/username',
+          hint: { key: 'devto:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(devtoHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should resolve username matching excluded path prefix', () => {
+      const value = 'https://dev.to/about_me'
+      const expected = [
+        {
+          uri: 'https://dev.to/feed/about_me',
+          hint: { key: 'devto:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(devtoHandler.resolve(value)).toEqual(expected)
+    })
   })
 })

--- a/src/feeds/platform/handlers/douban.test.ts
+++ b/src/feeds/platform/handlers/douban.test.ts
@@ -15,6 +15,10 @@ describe('doubanHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(doubanHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => doubanHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/github.test.ts
+++ b/src/feeds/platform/handlers/github.test.ts
@@ -12,6 +12,10 @@ describe('githubHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(githubHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => githubHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/github.test.ts
+++ b/src/feeds/platform/handlers/github.test.ts
@@ -183,6 +183,62 @@ describe('githubHandler', () => {
       expect(githubHandler.resolve(value)).toEqual(expected)
     })
 
+    it('should resolve www.github.com URL', () => {
+      const value = 'https://www.github.com/octocat'
+      const expected = [
+        {
+          uri: 'https://github.com/octocat.atom',
+          hint: { key: 'github:activity', label: 'Activity' },
+        },
+      ]
+
+      expect(githubHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should resolve deeply nested file path', () => {
+      const value = 'https://github.com/owner/repo/blob/main/src/deeply/nested/file.ts'
+      const expected = [
+        {
+          uri: 'https://github.com/owner/repo/releases.atom',
+          hint: { key: 'github:releases', label: 'Releases' },
+        },
+        {
+          uri: 'https://github.com/owner/repo/commits.atom',
+          hint: { key: 'github:commits', label: 'Commits' },
+        },
+        {
+          uri: 'https://github.com/owner/repo/tags.atom',
+          hint: { key: 'github:tags', label: 'Tags' },
+        },
+        {
+          uri: 'https://github.com/owner/repo/commits/main/src/deeply/nested/file.ts.atom',
+          hint: { key: 'github:file-history', label: 'File history' },
+        },
+      ]
+
+      expect(githubHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should resolve URL-encoded repo name', () => {
+      const value = 'https://github.com/owner/my%20repo'
+      const expected = [
+        {
+          uri: 'https://github.com/owner/my%20repo/releases.atom',
+          hint: { key: 'github:releases', label: 'Releases' },
+        },
+        {
+          uri: 'https://github.com/owner/my%20repo/commits.atom',
+          hint: { key: 'github:commits', label: 'Commits' },
+        },
+        {
+          uri: 'https://github.com/owner/my%20repo/tags.atom',
+          hint: { key: 'github:tags', label: 'Tags' },
+        },
+      ]
+
+      expect(githubHandler.resolve(value)).toEqual(expected)
+    })
+
     it('should return empty array for excluded paths', () => {
       expect(githubHandler.resolve('https://github.com/explore')).toEqual([])
       expect(githubHandler.resolve('https://github.com/copilot')).toEqual([])

--- a/src/feeds/platform/handlers/githubGist.test.ts
+++ b/src/feeds/platform/handlers/githubGist.test.ts
@@ -13,6 +13,10 @@ describe('githubGistHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(githubGistHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => githubGistHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/gitlab.test.ts
+++ b/src/feeds/platform/handlers/gitlab.test.ts
@@ -14,6 +14,10 @@ describe('gitlabHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(gitlabHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => gitlabHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/gitlab.test.ts
+++ b/src/feeds/platform/handlers/gitlab.test.ts
@@ -104,5 +104,26 @@ describe('gitlabHandler', () => {
         expect(gitlabHandler.resolve(value)).toEqual([])
       }
     })
+
+    it('should use first two path segments for deeply nested groups', () => {
+      // gitlab.com/group/subgroup/project treats group as user and subgroup as repo.
+      const value = 'https://gitlab.com/group/subgroup/project'
+      const expected = [
+        {
+          uri: 'https://gitlab.com/group/subgroup/-/releases.atom',
+          hint: { key: 'gitlab:releases', label: 'Releases' },
+        },
+        {
+          uri: 'https://gitlab.com/group/subgroup/-/tags?format=atom',
+          hint: { key: 'gitlab:tags', label: 'Tags' },
+        },
+        {
+          uri: 'https://gitlab.com/group/subgroup.atom',
+          hint: { key: 'gitlab:activity', label: 'Activity' },
+        },
+      ]
+
+      expect(gitlabHandler.resolve(value)).toEqual(expected)
+    })
   })
 })

--- a/src/feeds/platform/handlers/goodreads.test.ts
+++ b/src/feeds/platform/handlers/goodreads.test.ts
@@ -14,6 +14,10 @@ describe('goodreadsHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(goodreadsHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => goodreadsHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/hashnode.test.ts
+++ b/src/feeds/platform/handlers/hashnode.test.ts
@@ -14,6 +14,10 @@ describe('hashnodeHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(hashnodeHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => hashnodeHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/hatenablog.test.ts
+++ b/src/feeds/platform/handlers/hatenablog.test.ts
@@ -17,6 +17,10 @@ describe('hatenablogHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(hatenablogHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => hatenablogHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/itchio.test.ts
+++ b/src/feeds/platform/handlers/itchio.test.ts
@@ -15,6 +15,10 @@ describe('itchioHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(itchioHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => itchioHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/kickstarter.test.ts
+++ b/src/feeds/platform/handlers/kickstarter.test.ts
@@ -14,6 +14,10 @@ describe('kickstarterHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(kickstarterHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => kickstarterHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/letterboxd.test.ts
+++ b/src/feeds/platform/handlers/letterboxd.test.ts
@@ -15,6 +15,10 @@ describe('letterboxdHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(letterboxdHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => letterboxdHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/lobsters.test.ts
+++ b/src/feeds/platform/handlers/lobsters.test.ts
@@ -15,6 +15,10 @@ describe('lobstersHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(lobstersHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => lobstersHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/medium.test.ts
+++ b/src/feeds/platform/handlers/medium.test.ts
@@ -14,6 +14,10 @@ describe('mediumHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(mediumHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => mediumHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/medium.test.ts
+++ b/src/feeds/platform/handlers/medium.test.ts
@@ -141,5 +141,17 @@ describe('mediumHandler', () => {
 
       expect(mediumHandler.resolve(value)).toEqual(expected)
     })
+
+    it('should return RSS feed URL for numeric-only publication name', () => {
+      const value = 'https://medium.com/12345'
+      const expected = [
+        {
+          uri: 'https://medium.com/feed/12345',
+          hint: { key: 'medium:publication', label: 'Publication' },
+        },
+      ]
+
+      expect(mediumHandler.resolve(value)).toEqual(expected)
+    })
   })
 })

--- a/src/feeds/platform/handlers/paragraph.test.ts
+++ b/src/feeds/platform/handlers/paragraph.test.ts
@@ -13,6 +13,10 @@ describe('paragraphHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(paragraphHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => paragraphHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/pinterest.test.ts
+++ b/src/feeds/platform/handlers/pinterest.test.ts
@@ -14,6 +14,10 @@ describe('pinterestHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(pinterestHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => pinterestHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/producthunt.test.ts
+++ b/src/feeds/platform/handlers/producthunt.test.ts
@@ -14,6 +14,10 @@ describe('producthuntHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(producthuntHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => producthuntHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/reddit.test.ts
+++ b/src/feeds/platform/handlers/reddit.test.ts
@@ -15,6 +15,10 @@ describe('redditHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(redditHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => redditHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/reddit.test.ts
+++ b/src/feeds/platform/handlers/reddit.test.ts
@@ -210,6 +210,28 @@ describe('redditHandler', () => {
       expect(redditHandler.resolve(value)).toEqual([])
     })
 
+    it('should return empty array for /r/ without subreddit', () => {
+      const value = 'https://reddit.com/r/'
+
+      expect(redditHandler.resolve(value)).toEqual([])
+    })
+
+    it('should ignore query params in subreddit URL', () => {
+      const value = 'https://reddit.com/r/programming?sort=new'
+      const expected = [
+        {
+          uri: 'https://www.reddit.com/r/programming/.rss',
+          hint: { key: 'reddit:posts', label: 'Posts' },
+        },
+        {
+          uri: 'https://www.reddit.com/r/programming/comments/.rss',
+          hint: { key: 'reddit:comments', label: 'Comments' },
+        },
+      ]
+
+      expect(redditHandler.resolve(value)).toEqual(expected)
+    })
+
     it('should return RSS feed URL for homepage', () => {
       const value = 'https://reddit.com/'
       const expected = [

--- a/src/feeds/platform/handlers/reddit.test.ts
+++ b/src/feeds/platform/handlers/reddit.test.ts
@@ -243,5 +243,22 @@ describe('redditHandler', () => {
 
       expect(redditHandler.resolve(value)).toEqual(expected)
     })
+
+    it('should treat malformed comments URL without post ID as subreddit', () => {
+      // /r/AskReddit/comments/ lacks a post ID, so commentsMatch fails.
+      const value = 'https://reddit.com/r/AskReddit/comments/'
+      const expected = [
+        {
+          uri: 'https://www.reddit.com/r/AskReddit/.rss',
+          hint: { key: 'reddit:posts', label: 'Posts' },
+        },
+        {
+          uri: 'https://www.reddit.com/r/AskReddit/comments/.rss',
+          hint: { key: 'reddit:comments', label: 'Comments' },
+        },
+      ]
+
+      expect(redditHandler.resolve(value)).toEqual(expected)
+    })
   })
 })

--- a/src/feeds/platform/handlers/soundcloud.test.ts
+++ b/src/feeds/platform/handlers/soundcloud.test.ts
@@ -21,6 +21,10 @@ describe('soundcloudHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(soundcloudHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => soundcloudHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/sourceforge.test.ts
+++ b/src/feeds/platform/handlers/sourceforge.test.ts
@@ -14,6 +14,10 @@ describe('sourceforgeHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(sourceforgeHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => sourceforgeHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/stackExchange.test.ts
+++ b/src/feeds/platform/handlers/stackExchange.test.ts
@@ -23,6 +23,10 @@ describe('stackExchangeHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(stackExchangeHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => stackExchangeHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/steam.test.ts
+++ b/src/feeds/platform/handlers/steam.test.ts
@@ -14,6 +14,10 @@ describe('steamHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(steamHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => steamHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/substack.test.ts
+++ b/src/feeds/platform/handlers/substack.test.ts
@@ -12,6 +12,10 @@ describe('substackHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(substackHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => substackHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/tumblr.test.ts
+++ b/src/feeds/platform/handlers/tumblr.test.ts
@@ -13,6 +13,10 @@ describe('tumblrHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(tumblrHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => tumblrHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/v2ex.test.ts
+++ b/src/feeds/platform/handlers/v2ex.test.ts
@@ -12,6 +12,10 @@ describe('v2exHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(v2exHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => v2exHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/vimeo.test.ts
+++ b/src/feeds/platform/handlers/vimeo.test.ts
@@ -14,6 +14,10 @@ describe('vimeoHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(vimeoHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => vimeoHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/wordpress.test.ts
+++ b/src/feeds/platform/handlers/wordpress.test.ts
@@ -251,6 +251,65 @@ describe('wordpressHandler', () => {
       expect(wordpressHandler.resolve(value)).toEqual(expected)
     })
 
+    it('should handle URL-encoded category names', () => {
+      const value = 'https://blog.wordpress.com/category/c%2B%2B/'
+      const expected = [
+        {
+          uri: [
+            'https://blog.wordpress.com/category/c%2B%2B/feed/',
+            'https://blog.wordpress.com/category/c%2B%2B/?feed=rss',
+          ],
+          hint: { key: 'wordpress:category', label: 'Category' },
+        },
+        {
+          uri: ['https://blog.wordpress.com/feed/', 'https://blog.wordpress.com/?feed=rss'],
+          hint: { key: 'wordpress:posts-rss2', label: 'Posts (RSS 2.0)' },
+        },
+        {
+          uri: ['https://blog.wordpress.com/feed/rss2/', 'https://blog.wordpress.com/?feed=rss2'],
+          hint: { key: 'wordpress:posts-rss2-alt', label: 'Posts (RSS 2.0)' },
+        },
+        {
+          uri: ['https://blog.wordpress.com/feed/rdf/', 'https://blog.wordpress.com/?feed=rdf'],
+          hint: { key: 'wordpress:posts-rdf', label: 'Posts (RDF)' },
+        },
+        {
+          uri: ['https://blog.wordpress.com/feed/atom/', 'https://blog.wordpress.com/?feed=atom'],
+          hint: { key: 'wordpress:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: [
+            'https://blog.wordpress.com/comments/feed/',
+            'https://blog.wordpress.com/?feed=comments-rss2',
+          ],
+          hint: { key: 'wordpress:comments', label: 'Comments' },
+        },
+        {
+          uri: [
+            'https://blog.wordpress.com/comments/feed/rss2/',
+            'https://blog.wordpress.com/?feed=comments-rss2',
+          ],
+          hint: { key: 'wordpress:comments-rss2', label: 'Comments (RSS 2.0)' },
+        },
+        {
+          uri: [
+            'https://blog.wordpress.com/comments/feed/rdf/',
+            'https://blog.wordpress.com/?feed=comments-rdf',
+          ],
+          hint: { key: 'wordpress:comments-rdf', label: 'Comments (RDF)' },
+        },
+        {
+          uri: [
+            'https://blog.wordpress.com/comments/feed/atom/',
+            'https://blog.wordpress.com/?feed=comments-atom',
+          ],
+          hint: { key: 'wordpress:comments-atom', label: 'Comments (Atom)' },
+        },
+      ]
+
+      expect(wordpressHandler.resolve(value)).toEqual(expected)
+    })
+
     it('should include author feed when on author page', () => {
       const value = 'https://blog.wordpress.com/author/johndoe/'
       const expected = [

--- a/src/feeds/platform/handlers/wordpress.test.ts
+++ b/src/feeds/platform/handlers/wordpress.test.ts
@@ -13,6 +13,10 @@ describe('wordpressHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(wordpressHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => wordpressHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/wpengine.test.ts
+++ b/src/feeds/platform/handlers/wpengine.test.ts
@@ -16,6 +16,10 @@ describe('wpengineHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(wpengineHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => wpengineHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/ximalaya.test.ts
+++ b/src/feeds/platform/handlers/ximalaya.test.ts
@@ -12,6 +12,10 @@ describe('ximalayaHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(ximalayaHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => ximalayaHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/feeds/platform/handlers/youtube.test.ts
+++ b/src/feeds/platform/handlers/youtube.test.ts
@@ -15,6 +15,10 @@ describe('youtubeHandler', () => {
     it.each(cases)('%s -> %s', (url, expected) => {
       expect(youtubeHandler.match(url)).toBe(expected)
     })
+
+    it('should throw for invalid URL', () => {
+      expect(() => youtubeHandler.match('not-a-url')).toThrow()
+    })
   })
 
   describe('resolve', () => {

--- a/src/hubs/discover/index.test.ts
+++ b/src/hubs/discover/index.test.ts
@@ -284,5 +284,11 @@ describe('discoverHubs', () => {
 
       expect(value).toEqual(expected)
     })
+
+    it('should return empty array for input with only url and no content or headers', async () => {
+      const value = await discoverHubs({ url: 'https://example.com/' })
+
+      expect(value).toEqual([])
+    })
   })
 })

--- a/src/hubs/discover/utils.test.ts
+++ b/src/hubs/discover/utils.test.ts
@@ -69,4 +69,30 @@ describe('normalizeInput', () => {
 
     expect(value.content).toBeUndefined()
   })
+
+  it('should propagate error when fetchFn rejects', async () => {
+    const mockFetch: DiscoverFetchFn = async () => {
+      throw new Error('Network error')
+    }
+
+    expect(normalizeInput('https://example.com/', mockFetch)).rejects.toThrow('Network error')
+  })
+
+  it('should use response.url when it differs from input (redirect)', async () => {
+    const mockFetch: DiscoverFetchFn = async () => ({
+      url: 'https://redirected.example.com/',
+      body: '<html></html>',
+      headers: new Headers(),
+      status: 200,
+      statusText: 'OK',
+    })
+    const value = await normalizeInput('https://example.com/', mockFetch)
+    const expected = {
+      url: 'https://redirected.example.com/',
+      content: '<html></html>',
+      headers: expect.any(Headers),
+    }
+
+    expect(value).toEqual(expected)
+  })
 })

--- a/src/hubs/feed/index.test.ts
+++ b/src/hubs/feed/index.test.ts
@@ -198,4 +198,40 @@ describe('discoverHubsFromFeed', () => {
 
     expect(value).toEqual([])
   })
+
+  it('should return empty array when Atom hub link has no href', () => {
+    const content = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Example Feed</title>
+        <link rel="hub"/>
+        <link href="https://example.com/feed.xml" rel="self"/>
+      </feed>
+    `
+    const value = discoverHubsFromFeed(content, 'https://example.com/feed.xml')
+
+    expect(value).toEqual([])
+  })
+
+  it('should return empty array when JSON Feed has explicit empty hubs array', () => {
+    const content = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Example Feed',
+      hubs: [],
+    })
+    const value = discoverHubsFromFeed(content, 'https://example.com/feed.json')
+
+    expect(value).toEqual([])
+  })
+
+  it('should skip JSON Feed hub entry without url field', () => {
+    const content = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Example Feed',
+      hubs: [{ type: 'WebSub' }],
+    })
+    const value = discoverHubsFromFeed(content, 'https://example.com/feed.json')
+
+    expect(value).toEqual([])
+  })
 })

--- a/src/hubs/headers/index.test.ts
+++ b/src/hubs/headers/index.test.ts
@@ -136,4 +136,52 @@ describe('discoverHubsFromHeaders', () => {
 
     expect(value).toEqual(expected)
   })
+
+  it('should apply custom normalizeUrlFn to hub and topic URLs', () => {
+    const headers = new Headers({
+      link: '</hub>; rel="hub", </feed.xml>; rel="self"',
+    })
+    const customNormalizer = (url: string, baseUrl: string | undefined) => {
+      return `https://custom.example.com${url}`
+    }
+    const value = discoverHubsFromHeaders(headers, 'https://example.com/feed.xml', customNormalizer)
+    const expected: Array<HubResult> = [
+      {
+        hub: 'https://custom.example.com/hub',
+        topic: 'https://custom.example.com/feed.xml',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should resolve relative hub URL /hub in Link header', () => {
+    const headers = new Headers({
+      link: '</hub>; rel="hub"',
+    })
+    const value = discoverHubsFromHeaders(headers, 'https://example.com/feed.xml')
+    const expected: Array<HubResult> = [
+      {
+        hub: 'https://example.com/hub',
+        topic: 'https://example.com/feed.xml',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should use first self entry when multiple rel="self" are present', () => {
+    const headers = new Headers({
+      link: '<https://hub.example.com/>; rel="hub", <https://example.com/first.xml>; rel="self", <https://example.com/second.xml>; rel="self"',
+    })
+    const value = discoverHubsFromHeaders(headers, 'https://example.com/')
+    const expected: Array<HubResult> = [
+      {
+        hub: 'https://hub.example.com/',
+        topic: 'https://example.com/first.xml',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
 })

--- a/src/hubs/html/index.test.ts
+++ b/src/hubs/html/index.test.ts
@@ -94,4 +94,44 @@ describe('discoverHubsFromHtml', () => {
 
     expect(value).toEqual(expected)
   })
+
+  it('should apply custom normalizeUrlFn', () => {
+    const html = '<link rel="hub" href="/hub">'
+    const customNormalizer = (url: string) => `https://custom.example.com${url}`
+    const value = discoverHubsFromHtml(html, 'https://example.com/', customNormalizer)
+    const expected: Array<HubResult> = [
+      {
+        hub: 'https://custom.example.com/hub',
+        topic: 'https://example.com/',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should use baseUrl as topic when self link has empty href', () => {
+    const html = '<link rel="hub" href="https://hub.example.com/"><link rel="self" href="">'
+    const value = discoverHubsFromHtml(html, 'https://example.com/')
+    const expected: Array<HubResult> = [
+      {
+        hub: 'https://hub.example.com/',
+        topic: 'https://example.com/',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should handle malformed HTML with unclosed tags', () => {
+    const html = '<link rel="hub" href="https://hub.example.com/"><div><span'
+    const value = discoverHubsFromHtml(html, 'https://example.com/')
+    const expected: Array<HubResult> = [
+      {
+        hub: 'https://hub.example.com/',
+        topic: 'https://example.com/',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
 })


### PR DESCRIPTION
This PR fills the gaps a test coverage audit turned up.

- Add favicons/extractors tests for status code boundary conditions
- Add invalid URL `.toThrow()` tests across 40 feed/favicon handlers
- Add www variant resolve tests and missing path edge cases
- Add common/ edge case tests (empty patterns, hint preservation, Set dedup)
- Fix blogrolls/ assertion anti-patterns (`.toEqual()` over `.toHaveLength()`)
- Add blogrolls/ coverage for malformed XML, 404 responses, invalid OPML
- Add hubs/ coverage for empty inputs, normalizeUrlFn, malformed HTML
- Add feeds/ coverage for missing siteUrl fields, empty methods config
- Add per-handler specific tests (deeply nested paths, URL encoding, type guards)
