### PR TITLE
fix: Guard processConcurrently against zero concurrency

### DIFF
--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -1058,4 +1058,16 @@ describe('processConcurrently', () => {
 
     expect(shouldStopCallCount).toBeGreaterThan(0)
   })
+
+  it('should not process items when concurrency is 0', async () => {
+    const items = [1, 2, 3]
+    const processed: Array<number> = []
+    const processFn = async (item: number) => {
+      processed.push(item)
+    }
+
+    await processConcurrently(items, processFn, { concurrency: 0 })
+
+    expect(processed).toEqual([])
+  })
 })

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -101,6 +101,10 @@ export const processConcurrently = async <T>(
     shouldStop?: () => boolean
   },
 ): Promise<void> => {
+  if (options.concurrency < 1) {
+    return
+  }
+
   const active = new Set<Promise<void>>()
 
   let index = 0


### PR DESCRIPTION
`processConcurrently` with `concurrency: 0` causes an infinite synchronous loop: inner while never enters, index never advances, outer while never exits. Add early return for `concurrency < 1`.