### PR TITLE
feat: Resolve site URL from feed input

### DIFF
--- a/src/blogrolls/index.ts
+++ b/src/blogrolls/index.ts
@@ -1,5 +1,5 @@
 import { discover } from '../common/discover/index.js'
-import { defaultFetchFn } from '../common/discover/utils.js'
+import { defaultFetchFn, defaultResolveSiteUrlFn } from '../common/discover/utils.js'
 import type { DiscoverInput, DiscoverOptions, DiscoverResult } from '../common/types.js'
 import { normalizeUrl } from '../common/utils.js'
 import { defaultGuessOptions, defaultHeadersOptions, defaultHtmlOptions } from './defaults.js'
@@ -18,6 +18,7 @@ export const discoverBlogrolls = async <TValid extends BlogrollResult = Blogroll
       fetchFn: options.fetchFn ?? defaultFetchFn,
       extractFn: options.extractFn ?? defaultExtractor,
       normalizeUrlFn: options.normalizeUrlFn ?? normalizeUrl,
+      resolveSiteUrlFn: options.resolveSiteUrlFn ?? defaultResolveSiteUrlFn,
     },
     {
       html: defaultHtmlOptions,

--- a/src/common/discover/index.ts
+++ b/src/common/discover/index.ts
@@ -1,5 +1,6 @@
 import {
   type DiscoverInput,
+  type DiscoverInputObject,
   type DiscoverMethod,
   type DiscoverMethodsConfigDefaults,
   type DiscoverOptionsInternal,
@@ -21,6 +22,7 @@ export const discover = async <TValid>(
     fetchFn,
     extractFn,
     normalizeUrlFn,
+    resolveSiteUrlFn,
     stopOnFirstMethod = false,
     stopOnFirstResult = false,
     concurrency = 3,
@@ -29,14 +31,14 @@ export const discover = async <TValid>(
   } = options
 
   // Normalize input: string → fetch URL, object → use provided content.
-  const normalizedInput = await normalizeInput(input, fetchFn)
+  const sourceInput = await normalizeInput(input, fetchFn)
 
   // Step 1: Check if content is already valid (only if content is provided).
-  if (normalizedInput.content) {
+  if (sourceInput.content) {
     const result = await extractFn({
-      url: normalizedInput.url,
-      content: normalizedInput.content,
-      headers: normalizedInput.headers,
+      url: sourceInput.url,
+      content: sourceInput.content,
+      headers: sourceInput.headers,
     })
 
     if (result.isValid) {
@@ -44,8 +46,27 @@ export const discover = async <TValid>(
     }
   }
 
+  // Step 1.5: Resolve site input if resolveSiteUrlFn is provided.
+  let siteInput: DiscoverInputObject | undefined
+
+  if (resolveSiteUrlFn) {
+    const siteUrl = resolveSiteUrlFn(sourceInput)
+
+    if (siteUrl) {
+      try {
+        const response = await fetchFn(siteUrl)
+
+        siteInput = {
+          url: response.url,
+          content: typeof response.body === 'string' ? response.body : '',
+          headers: response.headers,
+        }
+      } catch {}
+    }
+  }
+
   // Step 2: Build methods config from input and selected methods.
-  const methodsConfig = normalizeMethodsConfig(normalizedInput, methods, defaults)
+  const methodsConfig = normalizeMethodsConfig(sourceInput, siteInput, methods, defaults)
 
   // Step 3: Discover URIs using selected methods.
   const urisByMethod = await discoverUris(methodsConfig, fetchFn)
@@ -62,7 +83,7 @@ export const discover = async <TValid>(
     }
 
     const normalized = rawUris.map((entry) => {
-      return normalizeUriEntry(entry, normalizeUrlFn, normalizedInput.url)
+      return normalizeUriEntry(entry, normalizeUrlFn, sourceInput.url)
     })
 
     const unique = normalized.filter((entry) => {

--- a/src/common/discover/utils.test.ts
+++ b/src/common/discover/utils.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it, spyOn } from 'bun:test'
+import { parseFeed } from 'feedsmith'
 import locales from '../locales.json' with { type: 'json' }
 import type { DiscoverFetchFn, DiscoverNormalizeUrlFn } from '../types.js'
 import {
   defaultFetchFn,
+  defaultResolveSiteUrlFn,
+  getFeedSiteUrl,
   normalizeInput,
   normalizeMethodsConfig,
   normalizeUriEntry,
@@ -466,7 +469,7 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '<html></html>',
     }
-    const result = normalizeMethodsConfig(value, ['html'], defaults)
+    const result = normalizeMethodsConfig(value, undefined, ['html'], defaults)
     const expected = {
       html: {
         html: '<html></html>',
@@ -490,7 +493,7 @@ describe('normalizeMethodsConfig', () => {
       content: '<html></html>',
       headers,
     }
-    const result = normalizeMethodsConfig(value, ['html', 'headers', 'guess'], defaults)
+    const result = normalizeMethodsConfig(value, undefined, ['html', 'headers', 'guess'], defaults)
     const expected = {
       html: {
         html: '<html></html>',
@@ -525,7 +528,7 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '<html></html>',
     }
-    const result = normalizeMethodsConfig(value, { html: true }, defaults)
+    const result = normalizeMethodsConfig(value, undefined, { html: true }, defaults)
     const expected = {
       html: {
         html: '<html></html>',
@@ -546,7 +549,12 @@ describe('normalizeMethodsConfig', () => {
     const value = {
       url: 'https://example.com',
     }
-    const result = normalizeMethodsConfig(value, { guess: { uris: ['/custom-feed'] } }, defaults)
+    const result = normalizeMethodsConfig(
+      value,
+      undefined,
+      { guess: { uris: ['/custom-feed'] } },
+      defaults,
+    )
     const expected = {
       guess: {
         options: {
@@ -566,6 +574,7 @@ describe('normalizeMethodsConfig', () => {
     }
     const result = normalizeMethodsConfig(
       value,
+      undefined,
       { html: true, guess: { uris: ['/custom'] } },
       defaults,
     )
@@ -598,6 +607,7 @@ describe('normalizeMethodsConfig', () => {
     }
     const result = normalizeMethodsConfig(
       value,
+      undefined,
       { html: { anchorLabels: ['custom-label'] } },
       defaults,
     )
@@ -621,7 +631,7 @@ describe('normalizeMethodsConfig', () => {
     const value = {
       url: 'https://example.com',
     }
-    const result = normalizeMethodsConfig(value, [], defaults)
+    const result = normalizeMethodsConfig(value, undefined, [], defaults)
     const expected = {}
 
     expect(result).toEqual(expected)
@@ -631,7 +641,7 @@ describe('normalizeMethodsConfig', () => {
     const value = {
       url: 'https://example.com',
     }
-    const result = normalizeMethodsConfig(value, {}, defaults)
+    const result = normalizeMethodsConfig(value, undefined, {}, defaults)
     const expected = {}
 
     expect(result).toEqual(expected)
@@ -644,7 +654,7 @@ describe('normalizeMethodsConfig', () => {
       content: '<html></html>',
       headers,
     }
-    const result = normalizeMethodsConfig(value, ['html', 'headers', 'guess'], defaults)
+    const result = normalizeMethodsConfig(value, undefined, ['html', 'headers', 'guess'], defaults)
     const expected = {
       html: {
         html: '<html></html>',
@@ -680,7 +690,7 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       headers,
     }
-    const result = normalizeMethodsConfig(value, ['headers'], defaults)
+    const result = normalizeMethodsConfig(value, undefined, ['headers'], defaults)
     const expected = {
       headers: {
         headers,
@@ -701,7 +711,7 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: htmlContent,
     }
-    const result = normalizeMethodsConfig(value, ['html'], defaults)
+    const result = normalizeMethodsConfig(value, undefined, ['html'], defaults)
     const expected = {
       html: {
         html: htmlContent,
@@ -727,7 +737,7 @@ describe('normalizeMethodsConfig', () => {
       anchorLabels: ['custom1', 'custom2'],
       anchorUris: ['/custom-feed'],
     }
-    const result = normalizeMethodsConfig(value, { html: customOptions }, defaults)
+    const result = normalizeMethodsConfig(value, undefined, { html: customOptions }, defaults)
     const expected = {
       html: {
         html: '<html></html>',
@@ -751,7 +761,7 @@ describe('normalizeMethodsConfig', () => {
       content: '<html></html>',
       headers,
     }
-    const result = normalizeMethodsConfig(value, ['html', 'headers', 'guess'], defaults)
+    const result = normalizeMethodsConfig(value, undefined, ['html', 'headers', 'guess'], defaults)
     const expected = {
       html: {
         html: '<html></html>',
@@ -790,6 +800,7 @@ describe('normalizeMethodsConfig', () => {
     }
     const result = normalizeMethodsConfig(
       value,
+      undefined,
       { html: true, headers: true, guess: true },
       defaults,
     )
@@ -827,7 +838,7 @@ describe('normalizeMethodsConfig', () => {
       url: '',
       content: '<html></html>',
     }
-    const throwing = () => normalizeMethodsConfig(value, ['platform'], defaults)
+    const throwing = () => normalizeMethodsConfig(value, undefined, ['platform'], defaults)
 
     expect(throwing).toThrow(locales.errors.platformMethodRequiresUrl)
   })
@@ -837,7 +848,7 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '<feed>content</feed>',
     }
-    const result = normalizeMethodsConfig(value, ['feed'], defaults)
+    const result = normalizeMethodsConfig(value, undefined, ['feed'], defaults)
     const expected = {
       feed: {
         content: '<feed>content</feed>',
@@ -858,6 +869,7 @@ describe('normalizeMethodsConfig', () => {
     }
     const result = normalizeMethodsConfig(
       value,
+      undefined,
       { feed: { extractUrls: customExtractUrls } },
       defaults,
     )
@@ -877,7 +889,7 @@ describe('normalizeMethodsConfig', () => {
     const value = {
       url: 'https://example.com',
     }
-    const throwing = () => normalizeMethodsConfig(value, ['feed'], defaults)
+    const throwing = () => normalizeMethodsConfig(value, undefined, ['feed'], defaults)
 
     expect(throwing).toThrow(locales.errors.feedMethodRequiresContent)
   })
@@ -886,7 +898,7 @@ describe('normalizeMethodsConfig', () => {
     const value = {
       url: 'https://example.com',
     }
-    const throwing = () => normalizeMethodsConfig(value, { feed: true }, defaults)
+    const throwing = () => normalizeMethodsConfig(value, undefined, { feed: true }, defaults)
 
     expect(throwing).toThrow(locales.errors.feedMethodRequiresContent)
   })
@@ -895,7 +907,7 @@ describe('normalizeMethodsConfig', () => {
     const value = {
       url: 'https://example.com',
     }
-    const throwing = () => normalizeMethodsConfig(value, ['html'], defaults)
+    const throwing = () => normalizeMethodsConfig(value, undefined, ['html'], defaults)
 
     expect(throwing).toThrow(locales.errors.htmlMethodRequiresContent)
   })
@@ -904,7 +916,7 @@ describe('normalizeMethodsConfig', () => {
     const value = {
       url: 'https://example.com',
     }
-    const throwing = () => normalizeMethodsConfig(value, ['headers'], defaults)
+    const throwing = () => normalizeMethodsConfig(value, undefined, ['headers'], defaults)
 
     expect(throwing).toThrow(locales.errors.headersMethodRequiresHeaders)
   })
@@ -914,7 +926,7 @@ describe('normalizeMethodsConfig', () => {
       url: '',
       content: '<html></html>',
     }
-    const throwing = () => normalizeMethodsConfig(value, ['guess'], defaults)
+    const throwing = () => normalizeMethodsConfig(value, undefined, ['guess'], defaults)
 
     expect(throwing).toThrow(locales.errors.guessMethodRequiresUrl)
   })
@@ -924,7 +936,7 @@ describe('normalizeMethodsConfig', () => {
       url: '',
       content: '<html></html>',
     }
-    const throwing = () => normalizeMethodsConfig(value, { platform: true }, defaults)
+    const throwing = () => normalizeMethodsConfig(value, undefined, { platform: true }, defaults)
 
     expect(throwing).toThrow(locales.errors.platformMethodRequiresUrl)
   })
@@ -933,7 +945,7 @@ describe('normalizeMethodsConfig', () => {
     const value = {
       url: 'https://example.com',
     }
-    const throwing = () => normalizeMethodsConfig(value, { html: true }, defaults)
+    const throwing = () => normalizeMethodsConfig(value, undefined, { html: true }, defaults)
 
     expect(throwing).toThrow(locales.errors.htmlMethodRequiresContent)
   })
@@ -942,7 +954,7 @@ describe('normalizeMethodsConfig', () => {
     const value = {
       url: 'https://example.com',
     }
-    const throwing = () => normalizeMethodsConfig(value, { headers: true }, defaults)
+    const throwing = () => normalizeMethodsConfig(value, undefined, { headers: true }, defaults)
 
     expect(throwing).toThrow(locales.errors.headersMethodRequiresHeaders)
   })
@@ -951,7 +963,7 @@ describe('normalizeMethodsConfig', () => {
     const value = {
       url: '',
     }
-    const throwing = () => normalizeMethodsConfig(value, { guess: true }, defaults)
+    const throwing = () => normalizeMethodsConfig(value, undefined, { guess: true }, defaults)
 
     expect(throwing).toThrow(locales.errors.guessMethodRequiresUrl)
   })
@@ -961,7 +973,7 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '<html></html>',
     }
-    const result = normalizeMethodsConfig(value, ['html'], defaults)
+    const result = normalizeMethodsConfig(value, undefined, ['html'], defaults)
     const expected = {
       html: {
         html: '<html></html>',
@@ -984,7 +996,7 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       headers,
     }
-    const result = normalizeMethodsConfig(value, ['headers'], defaults)
+    const result = normalizeMethodsConfig(value, undefined, ['headers'], defaults)
     const expected = {
       headers: {
         headers,
@@ -1002,7 +1014,7 @@ describe('normalizeMethodsConfig', () => {
     const value = {
       url: 'https://example.com',
     }
-    const result = normalizeMethodsConfig(value, ['guess'], defaults)
+    const result = normalizeMethodsConfig(value, undefined, ['guess'], defaults)
     const expected = {
       guess: {
         options: {
@@ -1022,6 +1034,7 @@ describe('normalizeMethodsConfig', () => {
     }
     const result = normalizeMethodsConfig(
       value,
+      undefined,
       { html: { anchorLabels: ['custom-label'] } },
       defaults,
     )
@@ -1048,6 +1061,7 @@ describe('normalizeMethodsConfig', () => {
     }
     const result = normalizeMethodsConfig(
       value,
+      undefined,
       { html: { anchorUris: ['/custom-feed'] } },
       defaults,
     )
@@ -1074,6 +1088,7 @@ describe('normalizeMethodsConfig', () => {
     }
     const result = normalizeMethodsConfig(
       value,
+      undefined,
       { html: { anchorIgnoredUris: ['custom-ignore'] } },
       defaults,
     )
@@ -1101,6 +1116,7 @@ describe('normalizeMethodsConfig', () => {
     const customSelectors = [{ rel: 'custom', types: ['custom/mime'] }]
     const result = normalizeMethodsConfig(
       value,
+      undefined,
       { html: { linkSelectors: customSelectors } },
       defaults,
     )
@@ -1124,7 +1140,12 @@ describe('normalizeMethodsConfig', () => {
     const value = {
       url: 'https://example.com',
     }
-    const result = normalizeMethodsConfig(value, { guess: { uris: ['/custom-feed'] } }, defaults)
+    const result = normalizeMethodsConfig(
+      value,
+      undefined,
+      { guess: { uris: ['/custom-feed'] } },
+      defaults,
+    )
     const expected = {
       guess: {
         options: {
@@ -1146,6 +1167,7 @@ describe('normalizeMethodsConfig', () => {
     const customSelectors = [{ rel: 'custom', types: ['custom/mime'] }]
     const result = normalizeMethodsConfig(
       value,
+      undefined,
       { headers: { linkSelectors: customSelectors } },
       defaults,
     )
@@ -1167,7 +1189,7 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '',
     }
-    const result = normalizeMethodsConfig(value, ['html'], defaults)
+    const result = normalizeMethodsConfig(value, undefined, ['html'], defaults)
     const expected = {
       html: {
         html: '',
@@ -1189,7 +1211,7 @@ describe('normalizeMethodsConfig', () => {
       content: '<html></html>',
     }
     // @ts-expect-error: This is for testing purposes.
-    const throwing = () => normalizeMethodsConfig(value, ['guess'], defaults)
+    const throwing = () => normalizeMethodsConfig(value, undefined, ['guess'], defaults)
 
     expect(throwing).toThrow(locales.errors.guessMethodRequiresUrl)
   })
@@ -1201,7 +1223,7 @@ describe('normalizeMethodsConfig', () => {
       content: '<html></html>',
       headers,
     }
-    const result = normalizeMethodsConfig(value, ['html', 'headers', 'guess'], defaults)
+    const result = normalizeMethodsConfig(value, undefined, ['html', 'headers', 'guess'], defaults)
     const expected = {
       html: {
         html: '<html></html>',
@@ -1229,6 +1251,273 @@ describe('normalizeMethodsConfig', () => {
     }
 
     expect(result).toEqual(expected)
+  })
+})
+
+describe('getFeedSiteUrl', () => {
+  it('should return site URL from RSS feed with channel link', () => {
+    const value = parseFeed('<?xml version="1.0"?><rss version="2.0"><channel><link>https://example.com</link></channel></rss>')
+    const expected = 'https://example.com'
+
+    expect(getFeedSiteUrl(value)).toBe(expected)
+  })
+
+  it('should return site URL from RSS feed with atom:link alternate', () => {
+    const value = parseFeed('<?xml version="1.0"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><atom:link rel="alternate" href="https://example.com"/></channel></rss>')
+    const expected = 'https://example.com'
+
+    expect(getFeedSiteUrl(value)).toBe(expected)
+  })
+
+  it('should prefer atom:link alternate over channel link in RSS', () => {
+    const value = parseFeed('<?xml version="1.0"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><link>https://fallback.com</link><atom:link rel="alternate" href="https://preferred.com"/></channel></rss>')
+    const expected = 'https://preferred.com'
+
+    expect(getFeedSiteUrl(value)).toBe(expected)
+  })
+
+  it('should return site URL from Atom feed with alternate link', () => {
+    const value = parseFeed('<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><link rel="alternate" href="https://example.com"/></feed>')
+    const expected = 'https://example.com'
+
+    expect(getFeedSiteUrl(value)).toBe(expected)
+  })
+
+  it('should return undefined from Atom feed without alternate link', () => {
+    const value = parseFeed('<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><link rel="self" href="https://example.com/feed.xml"/></feed>')
+
+    expect(getFeedSiteUrl(value)).toBeUndefined()
+  })
+
+  it('should return site URL from JSON Feed with home_page_url', () => {
+    const value = parseFeed(JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Example',
+      home_page_url: 'https://example.com',
+      items: [],
+    }))
+    const expected = 'https://example.com'
+
+    expect(getFeedSiteUrl(value)).toBe(expected)
+  })
+
+  it('should return undefined from JSON Feed without home_page_url', () => {
+    const value = parseFeed(JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Example',
+      items: [],
+    }))
+
+    expect(getFeedSiteUrl(value)).toBeUndefined()
+  })
+
+  it('should return undefined from RSS feed without link', () => {
+    const value = parseFeed('<?xml version="1.0"?><rss version="2.0"><channel><title>Example</title></channel></rss>')
+
+    expect(getFeedSiteUrl(value)).toBeUndefined()
+  })
+})
+
+describe('defaultResolveSiteUrlFn', () => {
+  it('should return site URL from RSS feed with channel link', () => {
+    const value = {
+      url: 'https://example.com/feed.xml',
+      content:
+        '<?xml version="1.0"?><rss version="2.0"><channel><link>https://example.com</link></channel></rss>',
+    }
+    const expected = 'https://example.com'
+
+    expect(defaultResolveSiteUrlFn(value)).toBe(expected)
+  })
+
+  it('should return site URL from Atom feed with alternate link', () => {
+    const value = {
+      url: 'https://example.com/feed.xml',
+      content:
+        '<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><link rel="alternate" href="https://example.com"/></feed>',
+    }
+    const expected = 'https://example.com'
+
+    expect(defaultResolveSiteUrlFn(value)).toBe(expected)
+  })
+
+  it('should return site URL from JSON Feed with home_page_url', () => {
+    const value = {
+      url: 'https://example.com/feed.json',
+      content: JSON.stringify({
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Example',
+        home_page_url: 'https://example.com',
+        items: [],
+      }),
+    }
+    const expected = 'https://example.com'
+
+    expect(defaultResolveSiteUrlFn(value)).toBe(expected)
+  })
+
+  it('should fall back to origin when feed has no site URL', () => {
+    const value = {
+      url: 'https://example.com/feed.xml',
+      content:
+        '<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><title>Test</title></feed>',
+    }
+    const expected = 'https://example.com'
+
+    expect(defaultResolveSiteUrlFn(value)).toBe(expected)
+  })
+
+  it('should return undefined when resolved URL equals input URL', () => {
+    const value = {
+      url: 'https://example.com',
+      content:
+        '<?xml version="1.0"?><rss version="2.0"><channel><link>https://example.com</link></channel></rss>',
+    }
+
+    expect(defaultResolveSiteUrlFn(value)).toBeUndefined()
+  })
+
+  it('should return undefined for non-feed content', () => {
+    const value = {
+      url: 'https://example.com',
+      content: '<html><head></head><body></body></html>',
+    }
+
+    expect(defaultResolveSiteUrlFn(value)).toBeUndefined()
+  })
+
+  it('should return undefined for empty content', () => {
+    const value = {
+      url: 'https://example.com',
+      content: '',
+    }
+
+    expect(defaultResolveSiteUrlFn(value)).toBeUndefined()
+  })
+
+  it('should return undefined for undefined content', () => {
+    const value = {
+      url: 'https://example.com',
+    }
+
+    expect(defaultResolveSiteUrlFn(value)).toBeUndefined()
+  })
+
+  it('should return site URL from RSS feed with atom:link alternate', () => {
+    const value = {
+      url: 'https://cdn.example.com/feed.xml',
+      content:
+        '<?xml version="1.0"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><atom:link rel="alternate" href="https://example.com"/></channel></rss>',
+    }
+    const expected = 'https://example.com'
+
+    expect(defaultResolveSiteUrlFn(value)).toBe(expected)
+  })
+})
+
+describe('normalizeMethodsConfig with siteInput', () => {
+  const defaults = {
+    feed: { extractUrls: () => [] as Array<string> },
+    html: {
+      linkSelectors: [{ rel: 'icon' }],
+      anchorUris: [] as Array<string>,
+      anchorIgnoredUris: [] as Array<string>,
+      anchorLabels: [] as Array<string>,
+    },
+    headers: { linkSelectors: [{ rel: 'icon' }] },
+    guess: { uris: ['/favicon.ico'] },
+  }
+
+  it('should use siteInput for html, headers, and guess methods', () => {
+    const siteHeaders = new Headers({ 'content-type': 'text/html' })
+    const value = {
+      url: 'https://example.com/feed.xml',
+      content: '<rss>feed content</rss>',
+      headers: new Headers({ 'content-type': 'application/rss+xml' }),
+    }
+    const siteValue = {
+      url: 'https://example.com',
+      content: '<html><link rel="icon" href="/favicon.ico"></html>',
+      headers: siteHeaders,
+    }
+    const expected = {
+      html: {
+        html: '<html><link rel="icon" href="/favicon.ico"></html>',
+        options: {
+          linkSelectors: [{ rel: 'icon' }],
+          anchorUris: [],
+          anchorIgnoredUris: [],
+          anchorLabels: [],
+          baseUrl: 'https://example.com',
+        },
+      },
+      headers: {
+        headers: siteHeaders,
+        options: {
+          linkSelectors: [{ rel: 'icon' }],
+          baseUrl: 'https://example.com',
+        },
+      },
+      guess: {
+        options: {
+          uris: ['/favicon.ico'],
+          baseUrl: 'https://example.com',
+        },
+      },
+    }
+
+    expect(normalizeMethodsConfig(value, siteValue, ['html', 'headers', 'guess'], defaults)).toEqual(expected)
+  })
+
+  it('should use original input for feed method when siteInput provided', () => {
+    const value = {
+      url: 'https://example.com/feed.xml',
+      content: '<rss>feed content</rss>',
+      headers: new Headers(),
+    }
+    const siteValue = {
+      url: 'https://example.com',
+      content: '<html>site content</html>',
+      headers: new Headers(),
+    }
+    const expected = {
+      feed: {
+        content: '<rss>feed content</rss>',
+        options: {
+          extractUrls: expect.any(Function),
+        },
+      },
+    }
+
+    expect(normalizeMethodsConfig(value, siteValue, ['feed'], defaults)).toEqual(expected)
+  })
+
+  it('should fall back to sourceInput when siteInput is undefined', () => {
+    const value = {
+      url: 'https://example.com',
+      content: '<html>content</html>',
+      headers: new Headers(),
+    }
+    const expected = {
+      html: {
+        html: '<html>content</html>',
+        options: {
+          linkSelectors: [{ rel: 'icon' }],
+          anchorUris: [],
+          anchorIgnoredUris: [],
+          anchorLabels: [],
+          baseUrl: 'https://example.com',
+        },
+      },
+      guess: {
+        options: {
+          uris: ['/favicon.ico'],
+          baseUrl: 'https://example.com',
+        },
+      },
+    }
+
+    expect(normalizeMethodsConfig(value, undefined, ['html', 'guess'], defaults)).toEqual(expected)
   })
 })
 

--- a/src/common/discover/utils.ts
+++ b/src/common/discover/utils.ts
@@ -1,3 +1,5 @@
+import { parseFeed } from 'feedsmith'
+import type { Atom, DeepPartial } from 'feedsmith/types'
 import locales from '../locales.json' with { type: 'json' }
 import type {
   DiscoverFetchFn,
@@ -7,6 +9,7 @@ import type {
   DiscoverMethodsConfigDefaults,
   DiscoverMethodsConfigInternal,
   DiscoverNormalizeUrlFn,
+  DiscoverResolveSiteUrlFn,
   DiscoverUriEntry,
 } from '../types.js'
 
@@ -43,6 +46,52 @@ export const normalizeInput = async (
   }
 }
 
+const getLinkOfType = (links: Array<DeepPartial<Atom.Link<string>>> | undefined, rel: string) => {
+  return links?.find((link) => link.rel === rel)
+}
+
+export const getFeedSiteUrl = (parsed: ReturnType<typeof parseFeed>): string | undefined => {
+  const { format, feed } = parsed
+
+  if (format === 'rss' || format === 'rdf') {
+    return getLinkOfType(feed.atom?.links, 'alternate')?.href ?? feed.link
+  }
+
+  if (format === 'atom') {
+    return getLinkOfType(feed.links, 'alternate')?.href
+  }
+
+  if (format === 'json') {
+    return feed.home_page_url
+  }
+}
+
+// TODO: parseFeed is called here and again in discoverUrisFromFeed for the favicons
+// discoverer. Consider caching the parsed result to avoid double parsing.
+export const defaultResolveSiteUrlFn: DiscoverResolveSiteUrlFn = (input) => {
+  if (!input.content) {
+    return
+  }
+
+  try {
+    let siteUrl = getFeedSiteUrl(parseFeed(input.content))
+
+    // Fall back to origin if no site URL found in feed metadata.
+    if (!siteUrl) {
+      try {
+        siteUrl = new URL(input.url).origin
+      } catch {}
+    }
+
+    // Avoid re-fetching the same URL.
+    if (siteUrl === input.url) {
+      return
+    }
+
+    return siteUrl
+  } catch {}
+}
+
 export const normalizeUriEntry = (
   entry: DiscoverUriEntry,
   normalizeUrlFn: DiscoverNormalizeUrlFn,
@@ -59,10 +108,13 @@ export const normalizeUriEntry = (
 }
 
 export const normalizeMethodsConfig = (
-  input: DiscoverInputObject,
+  sourceInput: DiscoverInputObject,
+  siteInput: DiscoverInputObject | undefined,
   methods: DiscoverMethodsConfig,
   defaults: DiscoverMethodsConfigDefaults,
 ): DiscoverMethodsConfigInternal => {
+  const resolvedInput = siteInput ?? sourceInput
+
   // Step 1: Normalize methods (array → object, true → {}).
   const methodsObj = Array.isArray(methods)
     ? Object.fromEntries(methods.map((method) => [method, true]))
@@ -72,32 +124,32 @@ export const normalizeMethodsConfig = (
   const methodsConfig: DiscoverMethodsConfigInternal = {}
 
   if (methodsObj.platform && defaults.platform) {
-    if (!input.url || input.url === '') {
+    if (!resolvedInput.url || resolvedInput.url === '') {
       throw new Error(locales.errors.platformMethodRequiresUrl)
     }
 
     const platformOptions = methodsObj.platform === true ? {} : methodsObj.platform
 
     methodsConfig.platform = {
-      content: input.content,
-      headers: input.headers,
+      content: resolvedInput.content,
+      headers: resolvedInput.headers,
       options: {
         ...defaults.platform,
         ...platformOptions,
-        baseUrl: input.url,
+        baseUrl: resolvedInput.url,
       },
     }
   }
 
   if (methodsObj.feed && defaults.feed) {
-    if (input.content === undefined) {
+    if (sourceInput.content === undefined) {
       throw new Error(locales.errors.feedMethodRequiresContent)
     }
 
     const feedOptions = methodsObj.feed === true ? {} : methodsObj.feed
 
     methodsConfig.feed = {
-      content: input.content,
+      content: sourceInput.content,
       options: {
         ...defaults.feed,
         ...feedOptions,
@@ -106,41 +158,41 @@ export const normalizeMethodsConfig = (
   }
 
   if (methodsObj.html && defaults.html) {
-    if (input.content === undefined) {
+    if (resolvedInput.content === undefined) {
       throw new Error(locales.errors.htmlMethodRequiresContent)
     }
 
     const htmlOptions = methodsObj.html === true ? {} : methodsObj.html
 
     methodsConfig.html = {
-      html: input.content,
+      html: resolvedInput.content,
       options: {
         ...defaults.html,
         ...htmlOptions,
-        baseUrl: input.url,
+        baseUrl: resolvedInput.url,
       },
     }
   }
 
   if (methodsObj.headers && defaults.headers) {
-    if (input.headers === undefined) {
+    if (resolvedInput.headers === undefined) {
       throw new Error(locales.errors.headersMethodRequiresHeaders)
     }
 
     const headersOptions = methodsObj.headers === true ? {} : methodsObj.headers
 
     methodsConfig.headers = {
-      headers: input.headers,
+      headers: resolvedInput.headers,
       options: {
         ...defaults.headers,
         ...headersOptions,
-        baseUrl: input.url,
+        baseUrl: resolvedInput.url,
       },
     }
   }
 
   if (methodsObj.guess && defaults.guess) {
-    if (!input.url || input.url === '') {
+    if (!resolvedInput.url || resolvedInput.url === '') {
       throw new Error(locales.errors.guessMethodRequiresUrl)
     }
 
@@ -150,7 +202,7 @@ export const normalizeMethodsConfig = (
       options: {
         ...defaults.guess,
         ...guessOptions,
-        baseUrl: input.url,
+        baseUrl: resolvedInput.url,
       },
     }
   }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -31,6 +31,8 @@ export type LinkSelector = {
 
 export type DiscoverNormalizeUrlFn = (url: string, baseUrl: string | undefined) => string
 
+export type DiscoverResolveSiteUrlFn = (input: DiscoverInputObject) => string | undefined
+
 export type DiscoverFetchFnOptions = {
   method?: 'GET' | 'HEAD'
   headers?: Record<string, string>
@@ -143,6 +145,7 @@ export type DiscoverOptions<TValid, TMethods extends DiscoverMethod = DiscoverMe
   fetchFn?: DiscoverFetchFn
   extractFn?: DiscoverExtractFn<TValid>
   normalizeUrlFn?: DiscoverNormalizeUrlFn
+  resolveSiteUrlFn?: DiscoverResolveSiteUrlFn
   stopOnFirstMethod?: boolean
   stopOnFirstResult?: boolean
   concurrency?: number
@@ -156,6 +159,7 @@ export type DiscoverOptionsInternal<TValid> = {
   fetchFn: DiscoverFetchFn
   extractFn: DiscoverExtractFn<TValid>
   normalizeUrlFn: DiscoverNormalizeUrlFn
+  resolveSiteUrlFn?: DiscoverResolveSiteUrlFn
   stopOnFirstMethod?: boolean
   stopOnFirstResult?: boolean
   concurrency?: number

--- a/src/exports/index.ts
+++ b/src/exports/index.ts
@@ -1,4 +1,5 @@
 export { discoverBlogrolls } from '../blogrolls/index.js'
+export { defaultResolveSiteUrlFn, getFeedSiteUrl } from '../common/discover/utils.js'
 export type {
   DiscoverExtractFn,
   DiscoverFetchFn,
@@ -12,6 +13,7 @@ export type {
   DiscoverOnProgressFn,
   DiscoverOptions,
   DiscoverProgress,
+  DiscoverResolveSiteUrlFn,
   DiscoverResult,
   DiscoverUriEntry,
   DiscoverUriHint,

--- a/src/favicons/extractors.test.ts
+++ b/src/favicons/extractors.test.ts
@@ -126,6 +126,16 @@ describe('defaultExtractor', () => {
       expect(await defaultExtractor(value)).toEqual(expected)
     })
 
+    it('should return isValid: false for RSS feed with svg in entry content', async () => {
+      const value = {
+        url: 'https://example.com/feed.xml',
+        content: '<?xml version="1.0"?><rss><channel><item><description>&lt;svg xmlns="http://www.w3.org/2000/svg"&gt;&lt;/svg&gt;</description></item></channel></rss>',
+      }
+      const expected = { url: 'https://example.com/feed.xml', isValid: false }
+
+      expect(await defaultExtractor(value)).toEqual(expected)
+    })
+
     it('should return isValid: false for <?xml without <svg', async () => {
       const value = {
         url: 'https://example.com/feed.xml',

--- a/src/favicons/extractors.ts
+++ b/src/favicons/extractors.ts
@@ -14,10 +14,11 @@ const isImageContent = (content: string): boolean => {
   }
 
   const trimmed = content.trimStart()
+  const head = trimmed.slice(0, 200)
 
   return (
     trimmed.startsWith('<svg') ||
-    (trimmed.startsWith('<?xml') && trimmed.includes('<svg')) ||
+    (trimmed.startsWith('<?xml') && head.includes('<svg')) ||
     content.slice(1, 4) === 'PNG' ||
     content.startsWith('GIF8') ||
     (content.startsWith('RIFF') && content.includes('WEBP'))

--- a/src/favicons/index.test.ts
+++ b/src/favicons/index.test.ts
@@ -368,4 +368,169 @@ describe('discoverFavicons', () => {
 
     expect(value).toEqual([])
   })
+
+  it('should discover favicons from site HTML when given RSS feed URL', async () => {
+    const rssContent = `<?xml version="1.0"?>
+      <rss version="2.0">
+        <channel>
+          <title>Example</title>
+          <link>https://example.com</link>
+        </channel>
+      </rss>`
+    const siteHtml = '<link rel="icon" href="/favicon.ico">'
+    const mockFetch = createMockFetch({
+      'https://example.com/feed.xml': rssContent,
+      'https://example.com': siteHtml,
+      'https://example.com/favicon.ico': 'binary',
+    })
+    const value = await discoverFavicons('https://example.com/feed.xml', {
+      methods: ['html'],
+      fetchFn: mockFetch,
+    })
+    const expected: Array<DiscoverResult<FaviconResult>> = [
+      { url: 'https://example.com/favicon.ico', isValid: true, method: 'html' },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should discover favicons from site HTML when given Atom feed URL', async () => {
+    const atomContent = `<?xml version="1.0"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Example</title>
+        <link rel="alternate" href="https://example.com"/>
+      </feed>`
+    const siteHtml = '<link rel="icon" href="/icon.png">'
+    const mockFetch = createMockFetch({
+      'https://example.com/feed.xml': atomContent,
+      'https://example.com': siteHtml,
+      'https://example.com/icon.png': 'binary',
+    })
+    const value = await discoverFavicons('https://example.com/feed.xml', {
+      methods: ['html'],
+      fetchFn: mockFetch,
+    })
+    const expected: Array<DiscoverResult<FaviconResult>> = [
+      { url: 'https://example.com/icon.png', isValid: true, method: 'html' },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should discover favicons from site HTML when given JSON Feed URL', async () => {
+    const jsonContent = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Example',
+      home_page_url: 'https://example.com',
+      items: [],
+    })
+    const siteHtml = '<link rel="icon" href="/favicon.svg">'
+    const mockFetch = createMockFetch({
+      'https://example.com/feed.json': jsonContent,
+      'https://example.com': siteHtml,
+      'https://example.com/favicon.svg': 'binary',
+    })
+    const value = await discoverFavicons('https://example.com/feed.json', {
+      methods: ['html'],
+      fetchFn: mockFetch,
+    })
+    const expected: Array<DiscoverResult<FaviconResult>> = [
+      { url: 'https://example.com/favicon.svg', isValid: true, method: 'html' },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should fall back to origin when feed has no site URL', async () => {
+    const atomContent = `<?xml version="1.0"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Example</title>
+      </feed>`
+    const siteHtml = '<link rel="icon" href="/favicon.ico">'
+    const mockFetch = createMockFetch({
+      'https://example.com/feed.xml': atomContent,
+      'https://example.com': siteHtml,
+      'https://example.com/favicon.ico': 'binary',
+    })
+    const value = await discoverFavicons('https://example.com/feed.xml', {
+      methods: ['html'],
+      fetchFn: mockFetch,
+    })
+    const expected: Array<DiscoverResult<FaviconResult>> = [
+      { url: 'https://example.com/favicon.ico', isValid: true, method: 'html' },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should return results from both feed and html methods when given feed URL', async () => {
+    const atomContent = `<?xml version="1.0"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Example</title>
+        <icon>https://example.com/feed-icon.png</icon>
+        <link rel="alternate" href="https://example.com"/>
+      </feed>`
+    const siteHtml = '<link rel="icon" href="/site-icon.png">'
+    const mockFetch = createMockFetch({
+      'https://example.com/feed.xml': atomContent,
+      'https://example.com': siteHtml,
+      'https://example.com/feed-icon.png': 'binary',
+      'https://example.com/site-icon.png': 'binary',
+    })
+    const value = await discoverFavicons('https://example.com/feed.xml', {
+      methods: ['feed', 'html'],
+      fetchFn: mockFetch,
+    })
+    const expected: Array<DiscoverResult<FaviconResult>> = [
+      { url: 'https://example.com/feed-icon.png', isValid: true, method: 'feed' },
+      { url: 'https://example.com/site-icon.png', isValid: true, method: 'html' },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should not trigger site resolution for non-feed input', async () => {
+    const html = '<link rel="icon" href="/favicon.ico">'
+    const mockFetch = createMockFetch({
+      'https://example.com': html,
+      'https://example.com/favicon.ico': 'binary',
+    })
+    const value = await discoverFavicons('https://example.com', {
+      methods: ['html'],
+      fetchFn: mockFetch,
+    })
+    const expected: Array<DiscoverResult<FaviconResult>> = [
+      { url: 'https://example.com/favicon.ico', isValid: true, method: 'html' },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should proceed gracefully when site URL fetch fails', async () => {
+    const rssContent = `<?xml version="1.0"?>
+      <rss version="2.0">
+        <channel>
+          <link>https://dead-site.com</link>
+        </channel>
+      </rss>`
+    const fetchFn: DiscoverFetchFn = async (url: string) => {
+      if (url === 'https://dead-site.com') {
+        throw new Error('Connection refused')
+      }
+
+      return {
+        url,
+        body: url === 'https://example.com/feed.xml' ? rssContent : '',
+        headers: new Headers(),
+        status: 200,
+        statusText: 'OK',
+      }
+    }
+    const value = await discoverFavicons('https://example.com/feed.xml', {
+      methods: ['html'],
+      fetchFn,
+    })
+
+    expect(value).toEqual([])
+  })
 })

--- a/src/favicons/index.ts
+++ b/src/favicons/index.ts
@@ -1,5 +1,5 @@
 import { discover } from '../common/discover/index.js'
-import { defaultFetchFn } from '../common/discover/utils.js'
+import { defaultFetchFn, defaultResolveSiteUrlFn } from '../common/discover/utils.js'
 import type { DiscoverInput, DiscoverOptions, DiscoverResult } from '../common/types.js'
 import { normalizeUrl } from '../common/utils.js'
 import {
@@ -24,6 +24,7 @@ export const discoverFavicons = async <TValid extends FaviconResult = FaviconRes
       fetchFn: options.fetchFn ?? defaultFetchFn,
       extractFn: options.extractFn ?? defaultExtractor,
       normalizeUrlFn: options.normalizeUrlFn ?? normalizeUrl,
+      resolveSiteUrlFn: options.resolveSiteUrlFn ?? defaultResolveSiteUrlFn,
     },
     {
       platform: defaultPlatformOptions,

--- a/src/feeds/extractors.ts
+++ b/src/feeds/extractors.ts
@@ -1,11 +1,7 @@
 import { parseFeed } from 'feedsmith'
-import type { Atom, DeepPartial } from 'feedsmith/types'
+import { getFeedSiteUrl } from '../common/discover/utils.js'
 import type { DiscoverExtractFn } from '../common/types.js'
 import type { FeedResult } from './types.js'
-
-const getLinkOfType = (links: Array<DeepPartial<Atom.Link<string>>> | undefined, rel: string) => {
-  return links?.find((link) => link.rel === rel)
-}
 
 export const defaultExtractor: DiscoverExtractFn<FeedResult> = async ({ content, url }) => {
   if (!content) {
@@ -13,7 +9,9 @@ export const defaultExtractor: DiscoverExtractFn<FeedResult> = async ({ content,
   }
 
   try {
-    const { format, feed } = parseFeed(content)
+    const parsed = parseFeed(content)
+    const { format, feed } = parsed
+    const siteUrl = getFeedSiteUrl(parsed)
 
     if (format === 'rss' || format === 'rdf') {
       return {
@@ -22,7 +20,7 @@ export const defaultExtractor: DiscoverExtractFn<FeedResult> = async ({ content,
         format,
         title: feed.title,
         description: feed.description,
-        siteUrl: getLinkOfType(feed.atom?.links, 'alternate')?.href || feed.link,
+        siteUrl,
       }
     }
 
@@ -33,7 +31,7 @@ export const defaultExtractor: DiscoverExtractFn<FeedResult> = async ({ content,
         format,
         title: feed.title,
         description: feed.subtitle,
-        siteUrl: getLinkOfType(feed.links, 'alternate')?.href,
+        siteUrl,
       }
     }
 
@@ -44,7 +42,7 @@ export const defaultExtractor: DiscoverExtractFn<FeedResult> = async ({ content,
         format,
         title: feed.title,
         description: feed.description,
-        siteUrl: feed.home_page_url,
+        siteUrl,
       }
     }
   } catch {

--- a/src/feeds/index.ts
+++ b/src/feeds/index.ts
@@ -23,6 +23,7 @@ export const discoverFeeds = async <TValid extends FeedResult = FeedResult>(
       fetchFn: options.fetchFn ?? defaultFetchFn,
       extractFn: options.extractFn ?? defaultExtractor,
       normalizeUrlFn: options.normalizeUrlFn ?? normalizeUrl,
+      // No resolveSiteUrlFn — feeds discoverer early-returns in extractFn before site resolution.
     },
     {
       platform: defaultPlatformOptions,


### PR DESCRIPTION
When a feed URL is passed to discoverers (favicons, blogrolls), the `html` method receives feed XML instead of site HTML, making it unable to find `<link>` tags. This also affects `headers`, `platform`, and `guess` methods.

- Add `defaultResolveSiteUrl` in common discover utils that parses feed content and extracts site URL (RSS `<link>`, Atom `<link rel="alternate">`, JSON Feed `home_page_url`), falling back to origin
- Add customizable `resolveSiteUrlFn` option to `DiscoverOptions`
- Update `normalizeMethodsConfig` to accept `siteInput`: uses site data for `html`/`headers`/`platform`/`guess`, keeps original feed content for `feed` method
- Enable by default in favicons, blogrolls, and feeds discoverers
- 1 extra fetch (site HTML) can save up to 5 wasted guess requests that would return 404