### PR TITLE
fix: Apply biome lint and formatting fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
       },
       "devDependencies": {
         "@types/bun": "^1.3.11",
-        "kvalita": "1.12.1",
+        "kvalita": "1.12.2",
         "tsdown": "^0.21.7",
         "vitepress": "^2.0.0-alpha.17",
       },
@@ -659,7 +659,7 @@
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
-    "kvalita": ["kvalita@1.12.1", "", { "peerDependencies": { "@biomejs/biome": ">=2.4.9", "@commitlint/cli": ">=20.5.0", "@commitlint/config-conventional": ">=20.5.0", "conventional-changelog-conventionalcommits": ">=9.3.1", "lefthook": ">=2.1.4", "semantic-release": ">=25.0.3", "typescript": ">=6.0.2" } }, "sha512-VfVaXCJIlWOQ4992niYlhCk4T4Q1xqiBTfMYU0jpLz1yt5DpWmF9GItd4EsWwg7a1ktRU6yWkVcba8OYrHQg/Q=="],
+    "kvalita": ["kvalita@1.12.2", "", { "peerDependencies": { "@biomejs/biome": ">=2.4.9", "@commitlint/cli": ">=20.5.0", "@commitlint/config-conventional": ">=20.5.0", "conventional-changelog-conventionalcommits": ">=9.3.1", "lefthook": ">=2.1.4", "semantic-release": ">=25.0.3", "typescript": ">=6.0.2" } }, "sha512-f7jPm3YT2C/PY5xJErlhMtoXS7MmcHjhwD0urdMkWKtLB1geSf0Z2IKiaI6RxlGkwB72eX4PipBPc3OLDiUGOg=="],
 
     "lefthook": ["lefthook@2.1.4", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.4", "lefthook-darwin-x64": "2.1.4", "lefthook-freebsd-arm64": "2.1.4", "lefthook-freebsd-x64": "2.1.4", "lefthook-linux-arm64": "2.1.4", "lefthook-linux-x64": "2.1.4", "lefthook-openbsd-arm64": "2.1.4", "lefthook-openbsd-x64": "2.1.4", "lefthook-windows-arm64": "2.1.4", "lefthook-windows-x64": "2.1.4" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w=="],
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.11",
-    "kvalita": "1.12.1",
+    "kvalita": "1.12.2",
     "tsdown": "^0.21.7",
     "vitepress": "^2.0.0-alpha.17"
   }

--- a/src/blogrolls/extractors.ts
+++ b/src/blogrolls/extractors.ts
@@ -2,7 +2,7 @@ import { parseOpml } from 'feedsmith'
 import type { DiscoverExtractFn } from '../common/types.js'
 import type { BlogrollResult } from './types.js'
 
-export const defaultExtractor: DiscoverExtractFn<BlogrollResult> = async ({ content, url }) => {
+export const defaultExtractor: DiscoverExtractFn<BlogrollResult> = ({ content, url }) => {
   if (!content) {
     return { url, isValid: false }
   }

--- a/src/blogrolls/index.ts
+++ b/src/blogrolls/index.ts
@@ -6,7 +6,7 @@ import { defaultGuessOptions, defaultHeadersOptions, defaultHtmlOptions } from '
 import { defaultExtractor } from './extractors.js'
 import type { BlogrollResult } from './types.js'
 
-export const discoverBlogrolls = async <TValid extends BlogrollResult = BlogrollResult>(
+export const discoverBlogrolls = <TValid extends BlogrollResult = BlogrollResult>(
   input: DiscoverInput,
   options: DiscoverOptions<TValid, 'html' | 'headers' | 'guess'> = {},
 ): Promise<Array<DiscoverResult<TValid>>> => {

--- a/src/common/discover/index.test.ts
+++ b/src/common/discover/index.test.ts
@@ -76,7 +76,7 @@ describe('discover', () => {
         match: () => true,
         resolve: () => [{ uri: '/platform-feed' }],
       }
-      const mockFetch: DiscoverFetchFn = async (url) => {
+      const mockFetch: DiscoverFetchFn = (url) => {
         fetchedUrls.push(url)
 
         return {
@@ -121,7 +121,7 @@ describe('discover', () => {
         match: () => true,
         resolve: () => [{ uri: '/shared-feed' }],
       }
-      const mockFetch: DiscoverFetchFn = async (url) => {
+      const mockFetch: DiscoverFetchFn = (url) => {
         fetchedUrls.push(url)
 
         return {
@@ -169,7 +169,7 @@ describe('discover', () => {
         match: () => true,
         resolve: () => [{ uri: '/invalid-feed' }],
       }
-      const mockFetch: DiscoverFetchFn = async (url) => {
+      const mockFetch: DiscoverFetchFn = (url) => {
         fetchedUrls.push(url)
 
         return {
@@ -248,7 +248,7 @@ describe('discover', () => {
   describe('stopOnFirstResult', () => {
     it('should stop on first valid result when stopOnFirstResult is true', async () => {
       let fetchCount = 0
-      const mockFetch: DiscoverFetchFn = async (url) => {
+      const mockFetch: DiscoverFetchFn = (url) => {
         fetchCount++
         return {
           url,
@@ -287,7 +287,7 @@ describe('discover', () => {
   describe('alternatives', () => {
     it('should stop trying alternatives when first alternative is valid', async () => {
       const fetchedUrls: Array<string> = []
-      const mockFetch: DiscoverFetchFn = async (url) => {
+      const mockFetch: DiscoverFetchFn = (url) => {
         fetchedUrls.push(url)
         return {
           url,
@@ -322,7 +322,7 @@ describe('discover', () => {
 
     it('should try second alternative when first alternative is not valid', async () => {
       const fetchedUrls: Array<string> = []
-      const mockFetch: DiscoverFetchFn = async (url) => {
+      const mockFetch: DiscoverFetchFn = (url) => {
         fetchedUrls.push(url)
         return {
           url,
@@ -423,7 +423,7 @@ describe('discover', () => {
 
   describe('error handling', () => {
     it('should handle fetch errors gracefully', async () => {
-      const mockFetch: DiscoverFetchFn = async () => {
+      const mockFetch: DiscoverFetchFn = () => {
         throw new Error('Network error')
       }
       const value = await discoverFeeds(
@@ -438,7 +438,7 @@ describe('discover', () => {
     })
 
     it('should include errors when includeInvalid is true', async () => {
-      const mockFetch: DiscoverFetchFn = async () => {
+      const mockFetch: DiscoverFetchFn = () => {
         throw new Error('Network error')
       }
       const value = await discoverFeeds(
@@ -683,7 +683,7 @@ describe('discover', () => {
       const mockFetch = createMockFetch({
         'https://example.com/feed': 'custom feed content',
       })
-      const customExtractor: DiscoverExtractFn<FeedResult> = async ({ url, content }) => {
+      const customExtractor: DiscoverExtractFn<FeedResult> = ({ url, content }) => {
         const isValid = content.includes('custom feed')
         if (isValid) {
           return {
@@ -725,7 +725,7 @@ describe('discover', () => {
       const mockFetch = createMockFetch({
         'https://example.com/feed': 'custom feed with 42 items updated 2024-01-15',
       })
-      const customExtractor: DiscoverExtractFn<ExtendedFeedResult> = async ({ url, content }) => {
+      const customExtractor: DiscoverExtractFn<ExtendedFeedResult> = ({ url, content }) => {
         const isValid = content.includes('custom feed')
         if (isValid) {
           return {
@@ -774,7 +774,7 @@ describe('discover', () => {
         'https://example.com/feed1': 'feed by John',
         'https://example.com/feed2': 'anonymous feed',
       })
-      const customExtractor: DiscoverExtractFn<ExtendedFeedResult> = async ({ url, content }) => {
+      const customExtractor: DiscoverExtractFn<ExtendedFeedResult> = ({ url, content }) => {
         const hasAuthor = content.includes('by John')
         return {
           url,
@@ -815,7 +815,7 @@ describe('discover', () => {
       const mockFetch = createMockFetch({
         'https://example.com/feed': 'invalid content',
       })
-      const customExtractor: DiscoverExtractFn<FeedResult> = async ({ url }) => {
+      const customExtractor: DiscoverExtractFn<FeedResult> = ({ url }) => {
         return {
           url,
           isValid: false,
@@ -854,7 +854,7 @@ describe('discover', () => {
         status: 200,
         statusText: 'OK',
       })
-      const customExtractor: DiscoverExtractFn<ExtendedFeedResult> = async ({
+      const customExtractor: DiscoverExtractFn<ExtendedFeedResult> = ({
         url,
         content,
         headers,
@@ -1025,7 +1025,7 @@ describe('discover', () => {
       let receivedStatus: number | undefined
       let receivedHeaders: Headers | undefined
       const responseHeaders = new Headers({ 'content-type': 'application/rss+xml' })
-      const customExtractor: DiscoverExtractFn<FeedResult> = async ({ url, status, headers }) => {
+      const customExtractor: DiscoverExtractFn<FeedResult> = ({ url, status, headers }) => {
         if (status !== undefined) {
           receivedStatus = status
           receivedHeaders = headers
@@ -1057,7 +1057,7 @@ describe('discover', () => {
 
     it('should pass headers to extractFn during initial content check', async () => {
       let receivedHeaders: Headers | undefined
-      const customExtractor: DiscoverExtractFn<FeedResult> = async ({ url, headers }) => {
+      const customExtractor: DiscoverExtractFn<FeedResult> = ({ url, headers }) => {
         receivedHeaders = headers
 
         return { url, isValid: true, format: 'rss' }

--- a/src/common/discover/index.test.ts
+++ b/src/common/discover/index.test.ts
@@ -990,10 +990,7 @@ describe('discover', () => {
 
   describe('empty methods', () => {
     it('should return empty array for empty methods config', async () => {
-      const value = await discoverFeeds(
-        { url: 'https://example.com' },
-        { methods: [] },
-      )
+      const value = await discoverFeeds({ url: 'https://example.com' }, { methods: [] })
 
       expect(value).toEqual([])
     })

--- a/src/common/discover/index.ts
+++ b/src/common/discover/index.ts
@@ -78,7 +78,7 @@ export const discover = async <TValid>(
   for (const method of discoverMethodOrder) {
     const rawUris = urisByMethod[method]
 
-    if (!rawUris?.length) {
+    if (!rawUris || rawUris.length === 0) {
       continue
     }
 

--- a/src/common/discover/utils.test.ts
+++ b/src/common/discover/utils.test.ts
@@ -1256,63 +1256,79 @@ describe('normalizeMethodsConfig', () => {
 
 describe('getFeedSiteUrl', () => {
   it('should return site URL from RSS feed with channel link', () => {
-    const value = parseFeed('<?xml version="1.0"?><rss version="2.0"><channel><link>https://example.com</link></channel></rss>')
+    const value = parseFeed(
+      '<?xml version="1.0"?><rss version="2.0"><channel><link>https://example.com</link></channel></rss>',
+    )
     const expected = 'https://example.com'
 
     expect(getFeedSiteUrl(value)).toBe(expected)
   })
 
   it('should return site URL from RSS feed with atom:link alternate', () => {
-    const value = parseFeed('<?xml version="1.0"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><atom:link rel="alternate" href="https://example.com"/></channel></rss>')
+    const value = parseFeed(
+      '<?xml version="1.0"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><atom:link rel="alternate" href="https://example.com"/></channel></rss>',
+    )
     const expected = 'https://example.com'
 
     expect(getFeedSiteUrl(value)).toBe(expected)
   })
 
   it('should prefer atom:link alternate over channel link in RSS', () => {
-    const value = parseFeed('<?xml version="1.0"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><link>https://fallback.com</link><atom:link rel="alternate" href="https://preferred.com"/></channel></rss>')
+    const value = parseFeed(
+      '<?xml version="1.0"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><link>https://fallback.com</link><atom:link rel="alternate" href="https://preferred.com"/></channel></rss>',
+    )
     const expected = 'https://preferred.com'
 
     expect(getFeedSiteUrl(value)).toBe(expected)
   })
 
   it('should return site URL from Atom feed with alternate link', () => {
-    const value = parseFeed('<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><link rel="alternate" href="https://example.com"/></feed>')
+    const value = parseFeed(
+      '<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><link rel="alternate" href="https://example.com"/></feed>',
+    )
     const expected = 'https://example.com'
 
     expect(getFeedSiteUrl(value)).toBe(expected)
   })
 
   it('should return undefined from Atom feed without alternate link', () => {
-    const value = parseFeed('<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><link rel="self" href="https://example.com/feed.xml"/></feed>')
+    const value = parseFeed(
+      '<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><link rel="self" href="https://example.com/feed.xml"/></feed>',
+    )
 
     expect(getFeedSiteUrl(value)).toBeUndefined()
   })
 
   it('should return site URL from JSON Feed with home_page_url', () => {
-    const value = parseFeed(JSON.stringify({
-      version: 'https://jsonfeed.org/version/1.1',
-      title: 'Example',
-      home_page_url: 'https://example.com',
-      items: [],
-    }))
+    const value = parseFeed(
+      JSON.stringify({
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Example',
+        home_page_url: 'https://example.com',
+        items: [],
+      }),
+    )
     const expected = 'https://example.com'
 
     expect(getFeedSiteUrl(value)).toBe(expected)
   })
 
   it('should return undefined from JSON Feed without home_page_url', () => {
-    const value = parseFeed(JSON.stringify({
-      version: 'https://jsonfeed.org/version/1.1',
-      title: 'Example',
-      items: [],
-    }))
+    const value = parseFeed(
+      JSON.stringify({
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Example',
+        items: [],
+      }),
+    )
 
     expect(getFeedSiteUrl(value)).toBeUndefined()
   })
 
   it('should return undefined from RSS feed without link', () => {
-    const value = parseFeed('<?xml version="1.0"?><rss version="2.0"><channel><title>Example</title></channel></rss>')
+    const value = parseFeed(
+      '<?xml version="1.0"?><rss version="2.0"><channel><title>Example</title></channel></rss>',
+    )
 
     expect(getFeedSiteUrl(value)).toBeUndefined()
   })
@@ -1466,7 +1482,9 @@ describe('normalizeMethodsConfig with siteInput', () => {
       },
     }
 
-    expect(normalizeMethodsConfig(value, siteValue, ['html', 'headers', 'guess'], defaults)).toEqual(expected)
+    expect(
+      normalizeMethodsConfig(value, siteValue, ['html', 'headers', 'guess'], defaults),
+    ).toEqual(expected)
   })
 
   it('should use original input for feed method when siteInput provided', () => {

--- a/src/common/discover/utils.test.ts
+++ b/src/common/discover/utils.test.ts
@@ -39,7 +39,7 @@ describe('defaultFetchFn', () => {
 
   it('should call native fetch with correct URL', async () => {
     fetchSpy.mockImplementation(
-      createFetchMock(async (url: string) => {
+      createFetchMock((url: string) => {
         return createMockResponse({
           url,
           text: async () => 'response body',
@@ -61,7 +61,7 @@ describe('defaultFetchFn', () => {
   it('should default to GET method when not specified', async () => {
     let capturedOptions: RequestInit | undefined
     fetchSpy.mockImplementation(
-      createFetchMock(async (_url: string, options?: RequestInit) => {
+      createFetchMock((_url: string, options?: RequestInit) => {
         capturedOptions = options
         return createMockResponse({})
       }),
@@ -75,7 +75,7 @@ describe('defaultFetchFn', () => {
   it('should use specified method from options', async () => {
     let capturedOptions: RequestInit | undefined
     fetchSpy.mockImplementation(
-      createFetchMock(async (_url: string, options?: RequestInit) => {
+      createFetchMock((_url: string, options?: RequestInit) => {
         capturedOptions = options
         return createMockResponse({})
       }),
@@ -89,7 +89,7 @@ describe('defaultFetchFn', () => {
   it('should pass headers to fetch', async () => {
     let capturedOptions: RequestInit | undefined
     fetchSpy.mockImplementation(
-      createFetchMock(async (_url: string, options?: RequestInit) => {
+      createFetchMock((_url: string, options?: RequestInit) => {
         capturedOptions = options
         return createMockResponse({})
       }),
@@ -104,7 +104,7 @@ describe('defaultFetchFn', () => {
 
   it('should return response with correct structure', async () => {
     fetchSpy.mockImplementation(
-      createFetchMock(async () => {
+      createFetchMock(() => {
         return createMockResponse({
           headers: new Headers({ 'content-type': 'application/rss+xml' }),
           text: async () => 'feed content',
@@ -129,7 +129,7 @@ describe('defaultFetchFn', () => {
 
   it('should preserve response URL for redirect handling', async () => {
     fetchSpy.mockImplementation(
-      createFetchMock(async () => {
+      createFetchMock(() => {
         return createMockResponse({
           url: 'https://redirect.example.com/feed.xml',
         })
@@ -149,7 +149,7 @@ describe('defaultFetchFn', () => {
 
   it('should convert response body to text', async () => {
     fetchSpy.mockImplementation(
-      createFetchMock(async () => {
+      createFetchMock(() => {
         return createMockResponse({
           text: async () => '<rss>feed content</rss>',
         })
@@ -169,7 +169,7 @@ describe('defaultFetchFn', () => {
 
   it('should pass through status and statusText', async () => {
     fetchSpy.mockImplementation(
-      createFetchMock(async () => {
+      createFetchMock(() => {
         return createMockResponse({
           status: 404,
           statusText: 'Not Found',
@@ -190,7 +190,7 @@ describe('defaultFetchFn', () => {
 })
 
 describe('normalizeInput', () => {
-  const fetchFn: DiscoverFetchFn = async (url) => {
+  const fetchFn: DiscoverFetchFn = (url) => {
     return {
       url,
       body: '<html>content</html>',
@@ -211,7 +211,7 @@ describe('normalizeInput', () => {
   })
 
   it('should preserve redirected URL from fetch response', async () => {
-    const redirectFetchFn: DiscoverFetchFn = async () => {
+    const redirectFetchFn: DiscoverFetchFn = () => {
       return {
         url: 'https://example.com/redirected',
         body: '<html>content</html>',
@@ -230,7 +230,7 @@ describe('normalizeInput', () => {
   })
 
   it('should handle ReadableStream body by converting to empty string', async () => {
-    const streamFetchFn: DiscoverFetchFn = async (url) => {
+    const streamFetchFn: DiscoverFetchFn = (url) => {
       return {
         url,
         body: new ReadableStream(),
@@ -250,7 +250,7 @@ describe('normalizeInput', () => {
 
   it('should preserve headers from fetch response', async () => {
     const headers = new Headers({ 'content-type': 'text/html', link: '</feed>; rel="alternate"' })
-    const headersFetchFn: DiscoverFetchFn = async (url) => {
+    const headersFetchFn: DiscoverFetchFn = (url) => {
       return {
         url,
         body: '<html></html>',
@@ -318,7 +318,7 @@ describe('normalizeInput', () => {
   })
 
   it('should handle empty string content from fetch', async () => {
-    const emptyFetchFn: DiscoverFetchFn = async (url) => {
+    const emptyFetchFn: DiscoverFetchFn = (url) => {
       return {
         url,
         body: '',
@@ -338,7 +338,7 @@ describe('normalizeInput', () => {
 
   it('should not call fetchFn when object input provided', async () => {
     let fetchCalled = false
-    const trackingFetchFn: DiscoverFetchFn = async (url) => {
+    const trackingFetchFn: DiscoverFetchFn = (url) => {
       fetchCalled = true
       return {
         url,
@@ -359,7 +359,7 @@ describe('normalizeInput', () => {
   })
 
   it('should handle fetch response with different status codes', async () => {
-    const statusFetchFn: DiscoverFetchFn = async (url) => {
+    const statusFetchFn: DiscoverFetchFn = (url) => {
       return {
         url,
         body: '<html>content</html>',

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -82,7 +82,7 @@ export type DiscoverExtractFn<TValid> = (input: {
   content: string
   headers?: Headers
   status?: number
-}) => Promise<DiscoverResult<TValid>>
+}) => Promise<DiscoverResult<TValid>> | DiscoverResult<TValid>
 
 export type DiscoverInputObject = {
   url: string

--- a/src/common/uris/guess/utils.ts
+++ b/src/common/uris/guess/utils.ts
@@ -1,5 +1,7 @@
 import type { UriEntry } from '../../types.js'
 
+const ipAddressRegex = /^\d+\.\d+\.\d+\.\d+$/
+
 const resolveUri = (uri: string, base: string, origin: string, pathname: string): string => {
   if (uri.startsWith('/')) {
     return `${origin}${uri}`
@@ -49,7 +51,7 @@ export const getSubdomainVariants = (baseUrl: string, prefixes: Array<string>): 
   const hostname = url.hostname
 
   // Check if hostname is an IP address (simple check for digits and dots)
-  const isIpAddress = /^\d+\.\d+\.\d+\.\d+$/.test(hostname)
+  const isIpAddress = ipAddressRegex.test(hostname)
 
   // Handle edge cases: localhost, IPs
   if (hostname === 'localhost' || isIpAddress) {

--- a/src/common/uris/headers/index.ts
+++ b/src/common/uris/headers/index.ts
@@ -4,6 +4,7 @@ import type { HeadersMethodOptions } from './types.js'
 const urlRegex = /<([^<>]+)>/
 const relRegex = /rel\s*=\s*["']?([^"';,]+)["']?/i
 const typeRegex = /type\s*=\s*["']?([^"';,]+)["']?/i
+const linkSplitRegex = /,(?=\s*<)/
 
 export const discoverUrisFromHeaders = (
   headers: Headers,
@@ -18,7 +19,7 @@ export const discoverUrisFromHeaders = (
 
   // Split by comma, but not commas inside angle brackets or quotes.
   // Link headers format: <url>; rel="alternate"; type="application/rss+xml".
-  const links = linkHeader.split(/,(?=\s*<)/)
+  const links = linkHeader.split(linkSplitRegex)
 
   for (const link of links) {
     // Parse URL from angle brackets: <URL>.

--- a/src/common/uris/platform/index.test.ts
+++ b/src/common/uris/platform/index.test.ts
@@ -156,7 +156,7 @@ describe('discoverUrisFromPlatform', () => {
   it('should continue to next handler if async resolve throws', async () => {
     const throwingHandler: PlatformHandler = {
       match: () => true,
-      resolve: async () => {
+      resolve: () => {
         throw new Error('Async resolve error')
       },
     }

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -934,6 +934,7 @@ describe('processConcurrently', () => {
   it('should handle errors in processFn', async () => {
     const items = [1, 2, 3, 4, 5]
     const processed: Array<number> = []
+    // biome-ignore lint/suspicious/useAwait: Must return Promise for processConcurrently.
     const processFn = async (item: number) => {
       if (item === 3) {
         throw new Error('Test error')
@@ -953,6 +954,7 @@ describe('processConcurrently', () => {
   it('should handle empty array', async () => {
     const items: Array<number> = []
     const processed: Array<number> = []
+    // biome-ignore lint/suspicious/useAwait: Must return Promise for processConcurrently.
     const processFn = async (item: number) => {
       processed.push(item)
     }
@@ -965,6 +967,7 @@ describe('processConcurrently', () => {
   it('should process single item', async () => {
     const items = [1]
     const processed: Array<number> = []
+    // biome-ignore lint/suspicious/useAwait: Must return Promise for processConcurrently.
     const processFn = async (item: number) => {
       processed.push(item)
     }
@@ -1081,6 +1084,7 @@ describe('processConcurrently', () => {
   it('should not process items when concurrency is 0', async () => {
     const items = [1, 2, 3]
     const processed: Array<number> = []
+    // biome-ignore lint/suspicious/useAwait: Must return Promise for processConcurrently.
     const processFn = async (item: number) => {
       processed.push(item)
     }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,6 +1,8 @@
 import locales from './locales.json' with { type: 'json' }
 import type { DiscoverUriHint } from './types.js'
 
+const whitespaceRegex = /\s+/
+
 export const composeHint = (key: string): DiscoverUriHint => ({
   key,
   label: locales.hints[key as keyof typeof locales.hints],
@@ -48,7 +50,7 @@ export const isAnyOf = (
 }
 
 export const anyWordMatchesAnyOf = (value: string, patterns: Array<string>): boolean => {
-  const words = value.toLowerCase().split(/\s+/)
+  const words = value.toLowerCase().split(whitespaceRegex)
   return words.some((word) => isAnyOf(word, patterns))
 }
 

--- a/src/favicons/extractors.test.ts
+++ b/src/favicons/extractors.test.ts
@@ -129,7 +129,8 @@ describe('defaultExtractor', () => {
     it('should return isValid: false for RSS feed with svg in entry content', async () => {
       const value = {
         url: 'https://example.com/feed.xml',
-        content: '<?xml version="1.0"?><rss><channel><item><description>&lt;svg xmlns="http://www.w3.org/2000/svg"&gt;&lt;/svg&gt;</description></item></channel></rss>',
+        content:
+          '<?xml version="1.0"?><rss><channel><item><description>&lt;svg xmlns="http://www.w3.org/2000/svg"&gt;&lt;/svg&gt;</description></item></channel></rss>',
       }
       const expected = { url: 'https://example.com/feed.xml', isValid: false }
 

--- a/src/favicons/extractors.ts
+++ b/src/favicons/extractors.ts
@@ -29,7 +29,7 @@ const isSuccessStatus = (status?: number): boolean => {
   return status !== undefined && status >= 200 && status < 400
 }
 
-export const defaultExtractor: DiscoverExtractFn<FaviconResult> = async (input) => {
+export const defaultExtractor: DiscoverExtractFn<FaviconResult> = (input) => {
   if (
     isImageContentType(input.headers) ||
     isImageContent(input.content) ||

--- a/src/favicons/index.test.ts
+++ b/src/favicons/index.test.ts
@@ -513,7 +513,7 @@ describe('discoverFavicons', () => {
           <link>https://dead-site.com</link>
         </channel>
       </rss>`
-    const fetchFn: DiscoverFetchFn = async (url: string) => {
+    const fetchFn: DiscoverFetchFn = (url: string) => {
       if (url === 'https://dead-site.com') {
         throw new Error('Connection refused')
       }

--- a/src/favicons/index.ts
+++ b/src/favicons/index.ts
@@ -12,7 +12,7 @@ import {
 import { defaultExtractor } from './extractors.js'
 import type { FaviconResult } from './types.js'
 
-export const discoverFavicons = async <TValid extends FaviconResult = FaviconResult>(
+export const discoverFavicons = <TValid extends FaviconResult = FaviconResult>(
   input: DiscoverInput,
   options: DiscoverOptions<TValid> = {},
 ): Promise<Array<DiscoverResult<TValid>>> => {

--- a/src/favicons/platform/handlers/bluesky.test.ts
+++ b/src/favicons/platform/handlers/bluesky.test.ts
@@ -187,7 +187,7 @@ describe('blueskyHandler', () => {
     })
 
     it('should return empty array when fetch throws', async () => {
-      const mockFetch: DiscoverFetchFn = async () => {
+      const mockFetch: DiscoverFetchFn = () => {
         throw new Error('Network error')
       }
       const value = await blueskyHandler.resolve(

--- a/src/favicons/platform/handlers/mastodon.test.ts
+++ b/src/favicons/platform/handlers/mastodon.test.ts
@@ -255,7 +255,7 @@ describe('mastodonHandler', () => {
     })
 
     it('should return empty array when fetch throws', async () => {
-      const mockFetch: DiscoverFetchFn = async () => {
+      const mockFetch: DiscoverFetchFn = () => {
         throw new Error('Network error')
       }
       const value = await mastodonHandler.resolve(

--- a/src/favicons/platform/handlers/mastodon.ts
+++ b/src/favicons/platform/handlers/mastodon.ts
@@ -2,6 +2,8 @@ import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { hasMetaContent } from '../../../common/utils.js'
 import { isNonEmptyString, parseBodyJson } from '../../utils.js'
 
+const mastodonRegex = /mastodon/i
+
 export const isProfilePath = (pathname: string): boolean => {
   const segments = pathname.split('/').filter(Boolean)
 
@@ -13,7 +15,7 @@ export const isMastodonHtml = (content: string): boolean => {
 }
 
 export const isMastodonHeaders = (headers: Headers): boolean => {
-  return /mastodon/i.test(headers.get('server') ?? '')
+  return mastodonRegex.test(headers.get('server') ?? '')
 }
 
 export const mastodonHandler: PlatformHandler = {

--- a/src/favicons/platform/handlers/reddit.test.ts
+++ b/src/favicons/platform/handlers/reddit.test.ts
@@ -299,7 +299,7 @@ describe('redditHandler', () => {
     })
 
     it('should return empty array when fetch throws', async () => {
-      const mockFetch: DiscoverFetchFn = async () => {
+      const mockFetch: DiscoverFetchFn = () => {
         throw new Error('Network error')
       }
       const value = await redditHandler.resolve(

--- a/src/feeds/extractors.ts
+++ b/src/feeds/extractors.ts
@@ -3,7 +3,7 @@ import { getFeedSiteUrl } from '../common/discover/utils.js'
 import type { DiscoverExtractFn } from '../common/types.js'
 import type { FeedResult } from './types.js'
 
-export const defaultExtractor: DiscoverExtractFn<FeedResult> = async ({ content, url }) => {
+export const defaultExtractor: DiscoverExtractFn<FeedResult> = ({ content, url }) => {
   if (!content) {
     return { url, isValid: false }
   }

--- a/src/feeds/index.ts
+++ b/src/feeds/index.ts
@@ -11,7 +11,7 @@ import {
 import { defaultExtractor } from './extractors.js'
 import type { FeedResult } from './types.js'
 
-export const discoverFeeds = async <TValid extends FeedResult = FeedResult>(
+export const discoverFeeds = <TValid extends FeedResult = FeedResult>(
   input: DiscoverInput,
   options: DiscoverOptions<TValid, 'platform' | 'html' | 'headers' | 'guess'> = {},
 ): Promise<Array<DiscoverResult<TValid>>> => {

--- a/src/feeds/platform/handlers/blogspot.ts
+++ b/src/feeds/platform/handlers/blogspot.ts
@@ -4,6 +4,7 @@ import { composeHint } from '../../../common/utils.js'
 
 // Matches *.blogspot.com and country TLDs like *.blogspot.co.uk, *.blogspot.de, etc.
 const blogspotDomainRegex = /^.+\.blogspot\.(?:com|co\.[a-z]{2}|com\.[a-z]{2}|[a-z]{2,3})$/
+const labelRegex = /^\/search\/label\/([^/]+)/
 
 export const blogspotHandler: PlatformHandler = {
   match: (url) => {
@@ -21,7 +22,7 @@ export const blogspotHandler: PlatformHandler = {
     const uris: Array<DiscoverUriEntry> = []
 
     // Label page: /search/label/{label}
-    const labelMatch = pathname.match(/^\/search\/label\/([^/]+)/)
+    const labelMatch = pathname.match(labelRegex)
 
     if (labelMatch?.[1]) {
       const label = labelMatch[1]

--- a/src/feeds/platform/handlers/bluesky.ts
+++ b/src/feeds/platform/handlers/bluesky.ts
@@ -1,6 +1,8 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isHostOf } from '../../../common/utils.js'
 
+const profileRegex = /^\/profile\/([^/]+)/
+
 const hosts = ['bsky.app', 'www.bsky.app']
 
 export const blueskyHandler: PlatformHandler = {
@@ -10,7 +12,7 @@ export const blueskyHandler: PlatformHandler = {
 
   resolve: (url) => {
     const { pathname } = new URL(url)
-    const profileMatch = pathname.match(/^\/profile\/([^/]+)/)
+    const profileMatch = pathname.match(profileRegex)
     const handle = profileMatch?.[1]
 
     if (!handle) {

--- a/src/feeds/platform/handlers/csdn.ts
+++ b/src/feeds/platform/handlers/csdn.ts
@@ -1,6 +1,8 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isHostOf } from '../../../common/utils.js'
 
+const userRegex = /^\/([^/]+)/
+
 const hosts = ['blog.csdn.net']
 
 export const csdnHandler: PlatformHandler = {
@@ -10,7 +12,7 @@ export const csdnHandler: PlatformHandler = {
 
   resolve: (url) => {
     const { pathname } = new URL(url)
-    const userMatch = pathname.match(/^\/([^/]+)/)
+    const userMatch = pathname.match(userRegex)
     const username = userMatch?.[1]
 
     if (!username) {

--- a/src/feeds/platform/handlers/deviantart.ts
+++ b/src/feeds/platform/handlers/deviantart.ts
@@ -1,6 +1,11 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
 
+const tagRegex = /^\/tag\/([^/]+)/
+const favouritesRegex = /^\/([a-zA-Z0-9_-]+)\/favourites\/?$/
+const folderRegex = /^\/([a-zA-Z0-9_-]+)\/gallery\/(\d+)(?:\/|$)/
+const profileRegex = /^\/([a-zA-Z0-9_-]+)(?:\/gallery(?:\/all)?)?(?:\/|$)/
+
 export const hosts = ['deviantart.com', 'www.deviantart.com']
 const feedBaseUrl = 'https://backend.deviantart.com/rss.xml'
 export const excludedPaths = [
@@ -27,7 +32,7 @@ export const deviantartHandler: PlatformHandler = {
     const { pathname } = new URL(url)
 
     // Match tag page: /tag/{tagname}
-    const tagMatch = pathname.match(/^\/tag\/([^/]+)/)
+    const tagMatch = pathname.match(tagRegex)
 
     if (tagMatch?.[1]) {
       const tag = tagMatch[1]
@@ -41,7 +46,7 @@ export const deviantartHandler: PlatformHandler = {
     }
 
     // Match favourites: /{username}/favourites
-    const favMatch = pathname.match(/^\/([a-zA-Z0-9_-]+)\/favourites\/?$/)
+    const favMatch = pathname.match(favouritesRegex)
 
     if (favMatch?.[1]) {
       const username = favMatch[1]
@@ -57,7 +62,7 @@ export const deviantartHandler: PlatformHandler = {
     }
 
     // Match gallery folder: /{username}/gallery/{folder-id}/{folder-name}.
-    const folderMatch = pathname.match(/^\/([a-zA-Z0-9_-]+)\/gallery\/(\d+)(?:\/|$)/)
+    const folderMatch = pathname.match(folderRegex)
 
     if (folderMatch?.[1] && folderMatch?.[2]) {
       const username = folderMatch[1]
@@ -77,7 +82,7 @@ export const deviantartHandler: PlatformHandler = {
     // /{username}
     // /{username}/gallery
     // /{username}/gallery/all
-    const userMatch = pathname.match(/^\/([a-zA-Z0-9_-]+)(?:\/gallery(?:\/all)?)?(?:\/|$)/)
+    const userMatch = pathname.match(profileRegex)
     const username = userMatch?.[1]
 
     if (!username || isAnyOf(username, excludedPaths)) {

--- a/src/feeds/platform/handlers/douban.ts
+++ b/src/feeds/platform/handlers/douban.ts
@@ -1,6 +1,9 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isHostOf, isSubdomainOf } from '../../../common/utils.js'
 
+const userRegex = /^\/people\/([^/]+)/
+const subjectRegex = /^\/subject\/(\d+)/
+
 export const doubanHandler: PlatformHandler = {
   match: (url) => {
     return isHostOf(url, 'douban.com') || isSubdomainOf(url, 'douban.com')
@@ -10,7 +13,7 @@ export const doubanHandler: PlatformHandler = {
     const { pathname } = new URL(url)
 
     // User page: /people/{user}/
-    const userMatch = pathname.match(/^\/people\/([^/]+)/)
+    const userMatch = pathname.match(userRegex)
 
     if (userMatch?.[1]) {
       const user = userMatch[1]
@@ -32,7 +35,7 @@ export const doubanHandler: PlatformHandler = {
     }
 
     // Subject page: /subject/{id}/
-    const subjectMatch = pathname.match(/^\/subject\/(\d+)/)
+    const subjectMatch = pathname.match(subjectRegex)
 
     if (subjectMatch?.[1]) {
       const id = subjectMatch[1]

--- a/src/feeds/platform/handlers/github.ts
+++ b/src/feeds/platform/handlers/github.ts
@@ -2,6 +2,13 @@ import type { DiscoverUriEntry } from '../../../common/types.js'
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
 
+const userRegex = /^\/([^/]+)\/?$/
+const repoRegex = /^\/([^/]+)\/([^/]+)/
+const wikiRegex = /\/wiki(\/|$)/
+const discussionsRegex = /\/discussions(\/|$)/
+const branchRegex = /^\/[^/]+\/[^/]+\/tree\/([^/]+)\/?$/
+const fileRegex = /^\/[^/]+\/[^/]+\/(?:blob|commits)\/([^/]+)\/(.+)/
+
 export const hosts = ['github.com', 'www.github.com']
 export const excludedPaths = [
   'about',
@@ -61,7 +68,7 @@ export const githubHandler: PlatformHandler = {
     const uris: Array<DiscoverUriEntry> = []
 
     // Match /{owner} pattern (user/org profile page).
-    const userMatch = pathname.match(/^\/([^/]+)\/?$/)
+    const userMatch = pathname.match(userRegex)
 
     if (userMatch?.[1] && !isAnyOf(userMatch[1], excludedPaths)) {
       const user = userMatch[1]
@@ -75,7 +82,7 @@ export const githubHandler: PlatformHandler = {
     }
 
     // Match /{owner}/{repo} pattern.
-    const repoMatch = pathname.match(/^\/([^/]+)\/([^/]+)/)
+    const repoMatch = pathname.match(repoRegex)
     const owner = repoMatch?.[1]
     const repo = repoMatch?.[2]
 
@@ -98,7 +105,7 @@ export const githubHandler: PlatformHandler = {
     })
 
     // If on wiki page, add wiki feed.
-    if (/\/wiki(\/|$)/.test(pathname)) {
+    if (wikiRegex.test(pathname)) {
       uris.push({
         uri: `https://github.com/${owner}/${repo}/wiki.atom`,
         hint: composeHint('github:wiki'),
@@ -106,7 +113,7 @@ export const githubHandler: PlatformHandler = {
     }
 
     // If on discussions page, add discussions feed.
-    if (/\/discussions(\/|$)/.test(pathname)) {
+    if (discussionsRegex.test(pathname)) {
       uris.push({
         uri: `https://github.com/${owner}/${repo}/discussions.atom`,
         hint: composeHint('github:discussions'),
@@ -114,7 +121,7 @@ export const githubHandler: PlatformHandler = {
     }
 
     // If on a specific branch, add branch-specific commits feed.
-    const branchMatch = pathname.match(/^\/[^/]+\/[^/]+\/tree\/([^/]+)\/?$/)
+    const branchMatch = pathname.match(branchRegex)
 
     if (branchMatch?.[1]) {
       const branch = branchMatch[1]
@@ -126,7 +133,7 @@ export const githubHandler: PlatformHandler = {
     }
 
     // If viewing a file (blob) or file history (commits), add file-specific commits feed.
-    const fileMatch = pathname.match(/^\/[^/]+\/[^/]+\/(?:blob|commits)\/([^/]+)\/(.+)/)
+    const fileMatch = pathname.match(fileRegex)
 
     if (fileMatch?.[1] && fileMatch?.[2]) {
       const branch = fileMatch[1]

--- a/src/feeds/platform/handlers/githubGist.ts
+++ b/src/feeds/platform/handlers/githubGist.ts
@@ -1,6 +1,10 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
 
+const gistRegex = /^\/([^/]+)\/([a-f0-9]+)/
+const starredRegex = /^\/([^/]+)\/starred\/?$/
+const userRegex = /^\/([^/]+)\/?$/
+
 export const hosts = ['gist.github.com']
 export const excludedPaths = ['discover', 'search', 'login', 'join', 'settings']
 
@@ -13,7 +17,7 @@ export const githubGistHandler: PlatformHandler = {
     const { pathname } = new URL(url)
 
     // Match /{username}/{gist-id} pattern (specific gist).
-    const gistMatch = pathname.match(/^\/([^/]+)\/([a-f0-9]+)/)
+    const gistMatch = pathname.match(gistRegex)
 
     if (gistMatch?.[1] && gistMatch?.[2]) {
       const username = gistMatch[1]
@@ -31,7 +35,7 @@ export const githubGistHandler: PlatformHandler = {
     }
 
     // Match /{username}/starred pattern (user's starred gists page).
-    const starredMatch = pathname.match(/^\/([^/]+)\/starred\/?$/)
+    const starredMatch = pathname.match(starredRegex)
 
     if (starredMatch?.[1] && !isAnyOf(starredMatch[1], excludedPaths)) {
       const username = starredMatch[1]
@@ -45,7 +49,7 @@ export const githubGistHandler: PlatformHandler = {
     }
 
     // Match /{username} pattern (user's gists page).
-    const userMatch = pathname.match(/^\/([^/]+)\/?$/)
+    const userMatch = pathname.match(userRegex)
 
     if (userMatch?.[1] && !isAnyOf(userMatch[1], excludedPaths)) {
       const username = userMatch[1]

--- a/src/feeds/platform/handlers/lemmy.ts
+++ b/src/feeds/platform/handlers/lemmy.ts
@@ -1,6 +1,8 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, hasMetaContent } from '../../../common/utils.js'
 
+const lemmyPoweredByRegex = /lemmy/i
+
 export const isCommunityPath = (pathname: string): boolean => {
   const segments = pathname.split('/').filter(Boolean)
 
@@ -20,7 +22,7 @@ export const isLemmyHtml = (content: string): boolean => {
 export const isLemmyHeaders = (headers: Headers): boolean => {
   const poweredBy = headers.get('x-powered-by') ?? ''
 
-  return /lemmy/i.test(poweredBy)
+  return lemmyPoweredByRegex.test(poweredBy)
 }
 
 export const lemmyHandler: PlatformHandler = {

--- a/src/feeds/platform/handlers/mastodon.ts
+++ b/src/feeds/platform/handlers/mastodon.ts
@@ -2,6 +2,9 @@ import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint } from '../../../common/utils.js'
 import { isMastodonHeaders, isMastodonHtml } from '../../../favicons/platform/handlers/mastodon.js'
 
+const profilePathRegex = /^\/@([^/]+)/
+const tagPathRegex = /^\/tags\/([^/]+)/
+
 export const isProfilePath = (pathname: string): boolean => {
   const segments = pathname.split('/').filter(Boolean)
 
@@ -38,13 +41,13 @@ export const mastodonHandler: PlatformHandler = {
   resolve: (url) => {
     try {
       const { origin, pathname } = new URL(url)
-      const userMatch = pathname.match(/^\/@([^/]+)/)
+      const userMatch = pathname.match(profilePathRegex)
 
       if (userMatch?.[1]) {
         return [{ uri: `${origin}/@${userMatch[1]}.rss`, hint: composeHint('mastodon:posts') }]
       }
 
-      const tagMatch = pathname.match(/^\/tags\/([^/]+)/)
+      const tagMatch = pathname.match(tagPathRegex)
 
       if (tagMatch?.[1]) {
         return [{ uri: `${origin}/tags/${tagMatch[1]}.rss`, hint: composeHint('mastodon:tag') }]

--- a/src/feeds/platform/handlers/mastodon.ts
+++ b/src/feeds/platform/handlers/mastodon.ts
@@ -8,7 +8,7 @@ const tagPathRegex = /^\/tags\/([^/]+)/
 export const isProfilePath = (pathname: string): boolean => {
   const segments = pathname.split('/').filter(Boolean)
 
-  return segments.length >= 1 && segments[0].startsWith('@')
+  return segments.length > 0 && segments[0].startsWith('@')
 }
 
 export const isTagPath = (pathname: string): boolean => {

--- a/src/feeds/platform/handlers/medium.ts
+++ b/src/feeds/platform/handlers/medium.ts
@@ -1,6 +1,12 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isAnyOf, isHostOf, isSubdomainOf } from '../../../common/utils.js'
 
+const userPathRegex = /^\/@([^/]+)/
+const tagPathRegex = /^\/tag\/([^/]+)/
+const publicationTagPathRegex = /^\/([^/@][^/]+)\/tagged\/([^/]+)/
+const publicationPathRegex = /^\/([^/@][^/]+)/
+const subdomainTagPathRegex = /^\/tagged\/([^/]+)/
+
 const hosts = ['medium.com', 'www.medium.com']
 const excludedPaths = ['search', 'me', 'new-story', 'plans', 'membership']
 
@@ -16,7 +22,7 @@ export const mediumHandler: PlatformHandler = {
     // Medium.com user profiles: /@username.
     if (hosts.includes(lowerHostname)) {
       // User profile: /@username.
-      const userMatch = pathname.match(/^\/@([^/]+)/)
+      const userMatch = pathname.match(userPathRegex)
 
       if (userMatch?.[1]) {
         const username = userMatch[1]
@@ -30,7 +36,7 @@ export const mediumHandler: PlatformHandler = {
       }
 
       // Tag feed: /tag/tag-name.
-      const tagMatch = pathname.match(/^\/tag\/([^/]+)/)
+      const tagMatch = pathname.match(tagPathRegex)
 
       if (tagMatch?.[1]) {
         const tag = tagMatch[1]
@@ -39,7 +45,7 @@ export const mediumHandler: PlatformHandler = {
       }
 
       // Publication tagged feed: /publication/tagged/tag-name.
-      const pubTagMatch = pathname.match(/^\/([^/@][^/]+)\/tagged\/([^/]+)/)
+      const pubTagMatch = pathname.match(publicationTagPathRegex)
 
       if (pubTagMatch?.[1] && pubTagMatch?.[2]) {
         const publication = pubTagMatch[1]
@@ -56,7 +62,7 @@ export const mediumHandler: PlatformHandler = {
       }
 
       // Publication: /publication-name.
-      const pubMatch = pathname.match(/^\/([^/@][^/]+)/)
+      const pubMatch = pathname.match(publicationPathRegex)
 
       if (pubMatch?.[1]) {
         const publication = pubMatch[1]
@@ -81,7 +87,7 @@ export const mediumHandler: PlatformHandler = {
       const subdomain = lowerHostname.replace('.medium.com', '')
 
       // Subdomain tagged feed: subdomain.medium.com/tagged/tag-name.
-      const tagMatch = pathname.match(/^\/tagged\/([^/]+)/)
+      const tagMatch = pathname.match(subdomainTagPathRegex)
 
       if (tagMatch?.[1]) {
         return [

--- a/src/feeds/platform/handlers/reddit.ts
+++ b/src/feeds/platform/handlers/reddit.ts
@@ -2,6 +2,12 @@ import type { DiscoverUriEntry } from '../../../common/types.js'
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
 
+const commentsPathRegex = /^\/r\/([^/]+)\/comments\/([^/]+)/
+const subredditPathRegex = /^\/r\/([^/]+)(?:\/([^/]+))?/
+const multiredditPathRegex = /^\/user\/([^/]+)\/m\/([^/]+)/
+const userPathRegex = /^\/(u|user)\/([^/]+)/
+const domainPathRegex = /^\/domain\/([^/]+)/
+
 export const hosts = ['reddit.com', 'www.reddit.com', 'old.reddit.com', 'new.reddit.com']
 const sortOptions = ['hot', 'new', 'rising', 'controversial', 'top']
 
@@ -24,7 +30,7 @@ export const redditHandler: PlatformHandler = {
     }
 
     // Match /r/subreddit/comments/id pattern (post comments feed).
-    const commentsMatch = pathname.match(/^\/r\/([^/]+)\/comments\/([^/]+)/)
+    const commentsMatch = pathname.match(commentsPathRegex)
 
     if (commentsMatch?.[1] && commentsMatch?.[2]) {
       const subreddit = commentsMatch[1]
@@ -39,7 +45,7 @@ export const redditHandler: PlatformHandler = {
     }
 
     // Match /r/subreddit with optional sort.
-    const subredditMatch = pathname.match(/^\/r\/([^/]+)(?:\/([^/]+))?/)
+    const subredditMatch = pathname.match(subredditPathRegex)
 
     if (subredditMatch?.[1]) {
       const subreddit = subredditMatch[1]
@@ -68,7 +74,7 @@ export const redditHandler: PlatformHandler = {
     }
 
     // Match multireddit: /user/{username}/m/{multireddit}.
-    const multiredditMatch = pathname.match(/^\/user\/([^/]+)\/m\/([^/]+)/)
+    const multiredditMatch = pathname.match(multiredditPathRegex)
 
     if (multiredditMatch?.[1] && multiredditMatch?.[2]) {
       const username = multiredditMatch[1]
@@ -83,7 +89,7 @@ export const redditHandler: PlatformHandler = {
     }
 
     // Match /u/username or /user/username pattern.
-    const userMatch = pathname.match(/^\/(u|user)\/([^/]+)/)
+    const userMatch = pathname.match(userPathRegex)
 
     if (userMatch?.[2]) {
       const username = userMatch[2]
@@ -97,7 +103,7 @@ export const redditHandler: PlatformHandler = {
     }
 
     // Match /domain/site pattern.
-    const domainMatch = pathname.match(/^\/domain\/([^/]+)/)
+    const domainMatch = pathname.match(domainPathRegex)
 
     if (domainMatch?.[1]) {
       const domain = domainMatch[1]

--- a/src/feeds/platform/handlers/soundcloud.ts
+++ b/src/feeds/platform/handlers/soundcloud.ts
@@ -1,11 +1,13 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
 
+const userIdRegex = /soundcloud:\/\/users:(\d+)/
+
 const hosts = ['soundcloud.com', 'www.soundcloud.com', 'm.soundcloud.com']
 const excludedPaths = ['discover', 'stream', 'search', 'upload', 'you', 'settings', 'messages']
 
 const extractUserIdFromContent = (content: string): string | undefined => {
-  const match = content.match(/soundcloud:\/\/users:(\d+)/)
+  const match = content.match(userIdRegex)
 
   return match?.[1]
 }

--- a/src/feeds/platform/handlers/soundcloud.ts
+++ b/src/feeds/platform/handlers/soundcloud.ts
@@ -21,7 +21,7 @@ export const soundcloudHandler: PlatformHandler = {
     const { pathname } = new URL(url)
     const pathSegments = pathname.split('/').filter(Boolean)
 
-    return pathSegments.length >= 1 && !isAnyOf(pathSegments[0], excludedPaths)
+    return pathSegments.length > 0 && !isAnyOf(pathSegments[0], excludedPaths)
   },
 
   resolve: (_url, content) => {

--- a/src/feeds/platform/handlers/stackExchange.ts
+++ b/src/feeds/platform/handlers/stackExchange.ts
@@ -1,6 +1,10 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isHostOf, isSubdomainOf } from '../../../common/utils.js'
 
+const tagPathRegex = /^\/questions\/tagged\/([\w.+-]+)/
+const questionPathRegex = /^\/questions\/(\d+)/
+const userPathRegex = /^\/users\/(\d+)/
+
 // Standalone domains from SE API: https://api.stackexchange.com/2.3/sites
 const domains = [
   'stackoverflow.com',
@@ -20,7 +24,7 @@ export const stackExchangeHandler: PlatformHandler = {
   resolve: (url) => {
     const { origin, pathname } = new URL(url)
 
-    const tagMatch = pathname.match(/^\/questions\/tagged\/([\w.+-]+)/)
+    const tagMatch = pathname.match(tagPathRegex)
 
     if (tagMatch?.[1]) {
       return [
@@ -31,7 +35,7 @@ export const stackExchangeHandler: PlatformHandler = {
       ]
     }
 
-    const questionMatch = pathname.match(/^\/questions\/(\d+)/)
+    const questionMatch = pathname.match(questionPathRegex)
 
     if (questionMatch?.[1]) {
       return [
@@ -42,7 +46,7 @@ export const stackExchangeHandler: PlatformHandler = {
       ]
     }
 
-    const userMatch = pathname.match(/^\/users\/(\d+)/)
+    const userMatch = pathname.match(userPathRegex)
 
     if (userMatch?.[1]) {
       return [

--- a/src/feeds/platform/handlers/steam.ts
+++ b/src/feeds/platform/handlers/steam.ts
@@ -1,6 +1,9 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isHostOf } from '../../../common/utils.js'
 
+const appPathRegex = /^\/(?:news\/)?app\/(\d+)/
+const groupPathRegex = /^\/groups\/([^/]+)/
+
 const hosts = ['store.steampowered.com', 'steamcommunity.com']
 
 export const steamHandler: PlatformHandler = {
@@ -11,7 +14,7 @@ export const steamHandler: PlatformHandler = {
   resolve: (url) => {
     const { hostname, pathname } = new URL(url)
 
-    const appMatch = pathname.match(/^\/(?:news\/)?app\/(\d+)/)
+    const appMatch = pathname.match(appPathRegex)
 
     if (appMatch?.[1]) {
       return [
@@ -23,7 +26,7 @@ export const steamHandler: PlatformHandler = {
     }
 
     if (hostname === 'steamcommunity.com') {
-      const groupMatch = pathname.match(/^\/groups\/([^/]+)/)
+      const groupMatch = pathname.match(groupPathRegex)
 
       if (groupMatch?.[1]) {
         return [

--- a/src/feeds/platform/handlers/v2ex.ts
+++ b/src/feeds/platform/handlers/v2ex.ts
@@ -1,6 +1,9 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isHostOf } from '../../../common/utils.js'
 
+const nodePathRegex = /^\/go\/([^/]+)/
+const memberPathRegex = /^\/member\/([^/]+)/
+
 const hosts = ['www.v2ex.com', 'v2ex.com']
 
 export const v2exHandler: PlatformHandler = {
@@ -12,7 +15,7 @@ export const v2exHandler: PlatformHandler = {
     const { pathname, searchParams } = new URL(url)
 
     // Node page: /go/{node}
-    const nodeMatch = pathname.match(/^\/go\/([^/]+)/)
+    const nodeMatch = pathname.match(nodePathRegex)
 
     if (nodeMatch?.[1]) {
       return [
@@ -24,7 +27,7 @@ export const v2exHandler: PlatformHandler = {
     }
 
     // Member page: /member/{username}
-    const memberMatch = pathname.match(/^\/member\/([^/]+)/)
+    const memberMatch = pathname.match(memberPathRegex)
 
     if (memberMatch?.[1]) {
       return [

--- a/src/feeds/platform/handlers/vimeo.ts
+++ b/src/feeds/platform/handlers/vimeo.ts
@@ -1,6 +1,8 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
 
+const numericPathRegex = /^\d+$/
+
 const hosts = ['vimeo.com', 'www.vimeo.com']
 const excludedPaths = [
   'about',
@@ -72,7 +74,7 @@ export const vimeoHandler: PlatformHandler = {
       const user = pathSegments[0]
 
       // Skip excluded paths and numeric-only segments (video IDs).
-      if (!isAnyOf(user, excludedPaths) && !/^\d+$/.test(user)) {
+      if (!isAnyOf(user, excludedPaths) && !numericPathRegex.test(user)) {
         const feeds = [{ uri: `${origin}/${user}/videos/rss`, hint: composeHint('vimeo:videos') }]
 
         if (pathSegments[1] === 'likes') {

--- a/src/feeds/platform/handlers/vimeo.ts
+++ b/src/feeds/platform/handlers/vimeo.ts
@@ -70,7 +70,7 @@ export const vimeoHandler: PlatformHandler = {
     }
 
     // User page: vimeo.com/{user}
-    if (pathSegments.length >= 1) {
+    if (pathSegments.length > 0) {
       const user = pathSegments[0]
 
       // Skip excluded paths and numeric-only segments (video IDs).

--- a/src/feeds/platform/handlers/ximalaya.ts
+++ b/src/feeds/platform/handlers/ximalaya.ts
@@ -1,6 +1,8 @@
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isHostOf } from '../../../common/utils.js'
 
+const albumPathRegex = /^\/album\/(\d+)/
+
 const hosts = ['www.ximalaya.com', 'ximalaya.com']
 
 export const ximalayaHandler: PlatformHandler = {
@@ -10,7 +12,7 @@ export const ximalayaHandler: PlatformHandler = {
 
   resolve: (url) => {
     const { pathname } = new URL(url)
-    const albumMatch = pathname.match(/^\/album\/(\d+)/)
+    const albumMatch = pathname.match(albumPathRegex)
     const id = albumMatch?.[1]
 
     if (!id) {

--- a/src/feeds/platform/handlers/youtube.ts
+++ b/src/feeds/platform/handlers/youtube.ts
@@ -2,12 +2,14 @@ import type { DiscoverUriEntry } from '../../../common/types.js'
 import type { PlatformHandler } from '../../../common/uris/platform/types.js'
 import { composeHint, isHostOf } from '../../../common/utils.js'
 
-const hosts = ['youtube.com', 'www.youtube.com', 'm.youtube.com', 'youtu.be', 'www.youtu.be']
 const channelIdRegex = /"(?:channelId|externalId)":"(UC[a-zA-Z0-9_-]+)"/
 const channelPathRegex = /^\/channel\/(UC[a-zA-Z0-9_-]+)/
 const handlePathRegex = /^\/@([^/]+)/
 const userPathRegex = /^\/user\/([^/]+)/
 const customPathRegex = /^\/c\/([^/]+)/
+const channelPrefixRegex = /^UC/
+
+const hosts = ['youtube.com', 'www.youtube.com', 'm.youtube.com', 'youtu.be', 'www.youtu.be']
 
 const extractChannelIdFromContent = (content: string): string | undefined => {
   const match = content.match(channelIdRegex)
@@ -18,19 +20,19 @@ const extractChannelIdFromContent = (content: string): string | undefined => {
 // Convert channel ID to playlist IDs for filtered feeds.
 // YouTube playlist prefixes: UU = all (legacy), UULF = videos only, UUSH = shorts only, UULV = live streams only.
 const getAllUploadsPlaylistId = (channelId: string): string => {
-  return channelId.replace(/^UC/, 'UU')
+  return channelId.replace(channelPrefixRegex, 'UU')
 }
 
 const getVideosOnlyPlaylistId = (channelId: string): string => {
-  return channelId.replace(/^UC/, 'UULF')
+  return channelId.replace(channelPrefixRegex, 'UULF')
 }
 
 const getShortsOnlyPlaylistId = (channelId: string): string => {
-  return channelId.replace(/^UC/, 'UUSH')
+  return channelId.replace(channelPrefixRegex, 'UUSH')
 }
 
 const getLiveStreamsOnlyPlaylistId = (channelId: string): string => {
-  return channelId.replace(/^UC/, 'UULV')
+  return channelId.replace(channelPrefixRegex, 'UULV')
 }
 
 const feedUrl = (param: string, value: string): string => {

--- a/src/hubs/discover/utils.test.ts
+++ b/src/hubs/discover/utils.test.ts
@@ -70,8 +70,8 @@ describe('normalizeInput', () => {
     expect(value.content).toBeUndefined()
   })
 
-  it('should propagate error when fetchFn rejects', async () => {
-    const mockFetch: DiscoverFetchFn = async () => {
+  it('should propagate error when fetchFn rejects', () => {
+    const mockFetch: DiscoverFetchFn = () => {
       throw new Error('Network error')
     }
 

--- a/src/hubs/headers/index.test.ts
+++ b/src/hubs/headers/index.test.ts
@@ -141,7 +141,7 @@ describe('discoverHubsFromHeaders', () => {
     const headers = new Headers({
       link: '</hub>; rel="hub", </feed.xml>; rel="self"',
     })
-    const customNormalizer = (url: string, baseUrl: string | undefined) => {
+    const customNormalizer = (url: string) => {
       return `https://custom.example.com${url}`
     }
     const value = discoverHubsFromHeaders(headers, 'https://example.com/feed.xml', customNormalizer)


### PR DESCRIPTION
This PR applies the biome lint and formatting fixes.

- Hoist regex literals to module scope (`useTopLevelRegex`)
- Use explicit length checks (`useExplicitLengthCheck`)
- Remove unnecessary `async` from functions without `await` (`useAwait`)
- Fix unused function parameter and auto-format test files
