### PR TITLE
fix: Resolve relative URLs from feed content

### DIFF
--- a/src/common/discover/index.test.ts
+++ b/src/common/discover/index.test.ts
@@ -63,7 +63,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
       ]
 
@@ -107,7 +107,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
       ]
 
@@ -152,7 +152,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
       ]
 
@@ -201,7 +201,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
       ]
 
@@ -275,7 +275,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
       ]
 
@@ -312,7 +312,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
       ]
 
@@ -347,7 +347,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
       ]
 
@@ -533,7 +533,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
         {
           url: 'https://example.com/feed.xml',
@@ -542,7 +542,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
       ]
 
@@ -588,7 +588,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
         {
           url: 'https://example.com/feed.xml',
@@ -597,7 +597,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
         {
           url: 'https://example.com/rss',
@@ -916,7 +916,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
       ]
 
@@ -947,7 +947,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
       ]
 
@@ -980,7 +980,7 @@ describe('discover', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://example.com',
+          siteUrl: 'https://example.com/',
         },
       ]
 

--- a/src/common/discover/utils.test.ts
+++ b/src/common/discover/utils.test.ts
@@ -1338,10 +1338,16 @@ describe('defaultResolveSiteUrlFn', () => {
   it('should return site URL from RSS feed with channel link', () => {
     const value = {
       url: 'https://example.com/feed.xml',
-      content:
-        '<?xml version="1.0"?><rss version="2.0"><channel><link>https://example.com</link></channel></rss>',
+      content: `
+        <?xml version="1.0"?>
+        <rss version="2.0">
+          <channel>
+            <link>https://example.com</link>
+          </channel>
+        </rss>
+      `,
     }
-    const expected = 'https://example.com'
+    const expected = 'https://example.com/'
 
     expect(defaultResolveSiteUrlFn(value)).toBe(expected)
   })
@@ -1349,10 +1355,14 @@ describe('defaultResolveSiteUrlFn', () => {
   it('should return site URL from Atom feed with alternate link', () => {
     const value = {
       url: 'https://example.com/feed.xml',
-      content:
-        '<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><link rel="alternate" href="https://example.com"/></feed>',
+      content: `
+        <?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <link rel="alternate" href="https://example.com"/>
+        </feed>
+      `,
     }
-    const expected = 'https://example.com'
+    const expected = 'https://example.com/'
 
     expect(defaultResolveSiteUrlFn(value)).toBe(expected)
   })
@@ -1367,7 +1377,7 @@ describe('defaultResolveSiteUrlFn', () => {
         items: [],
       }),
     }
-    const expected = 'https://example.com'
+    const expected = 'https://example.com/'
 
     expect(defaultResolveSiteUrlFn(value)).toBe(expected)
   })
@@ -1375,8 +1385,12 @@ describe('defaultResolveSiteUrlFn', () => {
   it('should fall back to origin when feed has no site URL', () => {
     const value = {
       url: 'https://example.com/feed.xml',
-      content:
-        '<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><title>Test</title></feed>',
+      content: `
+        <?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <title>Test</title>
+        </feed>
+      `,
     }
     const expected = 'https://example.com'
 
@@ -1386,8 +1400,14 @@ describe('defaultResolveSiteUrlFn', () => {
   it('should return undefined when resolved URL equals input URL', () => {
     const value = {
       url: 'https://example.com',
-      content:
-        '<?xml version="1.0"?><rss version="2.0"><channel><link>https://example.com</link></channel></rss>',
+      content: `
+        <?xml version="1.0"?>
+        <rss version="2.0">
+          <channel>
+            <link>https://example.com</link>
+          </channel>
+        </rss>
+      `,
     }
 
     expect(defaultResolveSiteUrlFn(value)).toBeUndefined()
@@ -1422,10 +1442,63 @@ describe('defaultResolveSiteUrlFn', () => {
   it('should return site URL from RSS feed with atom:link alternate', () => {
     const value = {
       url: 'https://cdn.example.com/feed.xml',
-      content:
-        '<?xml version="1.0"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><atom:link rel="alternate" href="https://example.com"/></channel></rss>',
+      content: `
+        <?xml version="1.0"?>
+        <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+          <channel>
+            <atom:link rel="alternate" href="https://example.com"/>
+          </channel>
+        </rss>
+      `,
     }
-    const expected = 'https://example.com'
+    const expected = 'https://example.com/'
+
+    expect(defaultResolveSiteUrlFn(value)).toBe(expected)
+  })
+
+  it('should resolve relative site URL from RSS feed against feed URL', () => {
+    const value = {
+      url: 'https://example.com/feed.xml',
+      content: `
+        <?xml version="1.0"?>
+        <rss version="2.0">
+          <channel>
+            <link>/log/</link>
+          </channel>
+        </rss>
+      `,
+    }
+    const expected = 'https://example.com/log/'
+
+    expect(defaultResolveSiteUrlFn(value)).toBe(expected)
+  })
+
+  it('should resolve relative site URL from Atom feed against feed URL', () => {
+    const value = {
+      url: 'https://example.com/feed.xml',
+      content: `
+        <?xml version="1.0"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <link rel="alternate" href="/blog"/>
+        </feed>
+      `,
+    }
+    const expected = 'https://example.com/blog'
+
+    expect(defaultResolveSiteUrlFn(value)).toBe(expected)
+  })
+
+  it('should resolve relative site URL from JSON Feed against feed URL', () => {
+    const value = {
+      url: 'https://example.com/feed.json',
+      content: JSON.stringify({
+        version: 'https://jsonfeed.org/version/1.1',
+        title: 'Example',
+        home_page_url: '/site/',
+        items: [],
+      }),
+    }
+    const expected = 'https://example.com/site/'
 
     expect(defaultResolveSiteUrlFn(value)).toBe(expected)
   })
@@ -1481,10 +1554,9 @@ describe('normalizeMethodsConfig with siteInput', () => {
         },
       },
     }
+    const result = normalizeMethodsConfig(value, siteValue, ['html', 'headers', 'guess'], defaults)
 
-    expect(
-      normalizeMethodsConfig(value, siteValue, ['html', 'headers', 'guess'], defaults),
-    ).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should use original input for feed method when siteInput provided', () => {
@@ -1506,8 +1578,9 @@ describe('normalizeMethodsConfig with siteInput', () => {
         },
       },
     }
+    const result = normalizeMethodsConfig(value, siteValue, ['feed'], defaults)
 
-    expect(normalizeMethodsConfig(value, siteValue, ['feed'], defaults)).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should fall back to sourceInput when siteInput is undefined', () => {
@@ -1534,8 +1607,9 @@ describe('normalizeMethodsConfig with siteInput', () => {
         },
       },
     }
+    const result = normalizeMethodsConfig(value, undefined, ['html', 'guess'], defaults)
 
-    expect(normalizeMethodsConfig(value, undefined, ['html', 'guess'], defaults)).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 })
 

--- a/src/common/discover/utils.ts
+++ b/src/common/discover/utils.ts
@@ -12,6 +12,7 @@ import type {
   DiscoverResolveSiteUrlFn,
   DiscoverUriEntry,
 } from '../types.js'
+import { normalizeUrl } from '../utils.js'
 
 export const defaultFetchFn: DiscoverFetchFn = async (url, options) => {
   const response = await fetch(url, {
@@ -81,10 +82,13 @@ export const defaultResolveSiteUrlFn: DiscoverResolveSiteUrlFn = (input) => {
       try {
         siteUrl = new URL(input.url).origin
       } catch {}
+    } else {
+      // Resolve relative site URLs against the feed URL.
+      siteUrl = normalizeUrl(siteUrl, input.url)
     }
 
     // Avoid re-fetching the same URL.
-    if (siteUrl === input.url) {
+    if (siteUrl === normalizeUrl(input.url, input.url)) {
       return
     }
 

--- a/src/common/discover/utils.ts
+++ b/src/common/discover/utils.ts
@@ -88,7 +88,7 @@ export const defaultResolveSiteUrlFn: DiscoverResolveSiteUrlFn = (input) => {
     }
 
     // Avoid re-fetching the same URL.
-    if (siteUrl === normalizeUrl(input.url, input.url)) {
+    if (siteUrl && new URL(siteUrl).href === new URL(input.url).href) {
       return
     }
 

--- a/src/favicons/index.test.ts
+++ b/src/favicons/index.test.ts
@@ -380,7 +380,7 @@ describe('discoverFavicons', () => {
     const siteHtml = '<link rel="icon" href="/favicon.ico">'
     const mockFetch = createMockFetch({
       'https://example.com/feed.xml': rssContent,
-      'https://example.com': siteHtml,
+      'https://example.com/': siteHtml,
       'https://example.com/favicon.ico': 'binary',
     })
     const value = await discoverFavicons('https://example.com/feed.xml', {
@@ -403,7 +403,7 @@ describe('discoverFavicons', () => {
     const siteHtml = '<link rel="icon" href="/icon.png">'
     const mockFetch = createMockFetch({
       'https://example.com/feed.xml': atomContent,
-      'https://example.com': siteHtml,
+      'https://example.com/': siteHtml,
       'https://example.com/icon.png': 'binary',
     })
     const value = await discoverFavicons('https://example.com/feed.xml', {
@@ -427,7 +427,7 @@ describe('discoverFavicons', () => {
     const siteHtml = '<link rel="icon" href="/favicon.svg">'
     const mockFetch = createMockFetch({
       'https://example.com/feed.json': jsonContent,
-      'https://example.com': siteHtml,
+      'https://example.com/': siteHtml,
       'https://example.com/favicon.svg': 'binary',
     })
     const value = await discoverFavicons('https://example.com/feed.json', {
@@ -473,7 +473,7 @@ describe('discoverFavicons', () => {
     const siteHtml = '<link rel="icon" href="/site-icon.png">'
     const mockFetch = createMockFetch({
       'https://example.com/feed.xml': atomContent,
-      'https://example.com': siteHtml,
+      'https://example.com/': siteHtml,
       'https://example.com/feed-icon.png': 'binary',
       'https://example.com/site-icon.png': 'binary',
     })

--- a/src/feeds/extractors.test.ts
+++ b/src/feeds/extractors.test.ts
@@ -54,7 +54,7 @@ describe('defaultExtractor', () => {
       format: 'rss',
       title: 'Test',
       description: 'Test feed',
-      siteUrl: 'https://example.com',
+      siteUrl: 'https://example.com/',
     }
 
     expect(result).toEqual(expected)
@@ -79,7 +79,7 @@ describe('defaultExtractor', () => {
       format: 'atom',
       title: 'Test',
       description: 'Test feed',
-      siteUrl: 'https://example.com',
+      siteUrl: 'https://example.com/',
     }
 
     expect(result).toEqual(expected)
@@ -108,7 +108,7 @@ describe('defaultExtractor', () => {
       format: 'rdf',
       title: 'Test',
       description: 'Test feed',
-      siteUrl: 'https://example.com',
+      siteUrl: 'https://example.com/',
     }
 
     expect(result).toEqual(expected)
@@ -133,7 +133,7 @@ describe('defaultExtractor', () => {
       format: 'json',
       title: 'Test',
       description: 'Test feed',
-      siteUrl: 'https://example.com',
+      siteUrl: 'https://example.com/',
     }
 
     expect(result).toEqual(expected)
@@ -174,7 +174,7 @@ describe('defaultExtractor', () => {
       format: 'rss',
       title: 'Test',
       description: 'Test feed',
-      siteUrl: 'https://example.com',
+      siteUrl: 'https://example.com/',
     }
 
     expect(result).toEqual(expected)
@@ -217,7 +217,7 @@ describe('defaultExtractor', () => {
       format: 'rss',
       title: 'Test',
       description: largeDescription,
-      siteUrl: 'https://example.com',
+      siteUrl: 'https://example.com/',
     }
 
     expect(result).toEqual(expected)
@@ -259,7 +259,7 @@ describe('defaultExtractor', () => {
       format: 'rss',
       title: 'Test',
       description: 'Test feed',
-      siteUrl: 'https://example.com',
+      siteUrl: 'https://example.com/',
     }
 
     expect(result).toEqual(expected)
@@ -301,7 +301,7 @@ describe('defaultExtractor', () => {
       format: 'rss',
       title: 'Test',
       description: 'Test feed',
-      siteUrl: 'https://example.com',
+      siteUrl: 'https://example.com/',
     }
 
     expect(result).toEqual(expected)
@@ -395,6 +395,83 @@ describe('defaultExtractor', () => {
       title: 'Test',
       description: 'Test feed',
       siteUrl: undefined,
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should resolve relative siteUrl from RSS feed against feed URL', async () => {
+    const rss = `
+      <rss version="2.0">
+        <channel>
+          <title>Test</title>
+          <link>/log/</link>
+          <description>Test feed</description>
+        </channel>
+      </rss>
+    `
+    const result = await defaultExtractor({
+      content: rss,
+      headers: new Headers(),
+      url: 'https://example.com/feed.xml',
+    })
+    const expected: DiscoverResult<FeedResult> = {
+      url: 'https://example.com/feed.xml',
+      isValid: true,
+      format: 'rss',
+      title: 'Test',
+      description: 'Test feed',
+      siteUrl: 'https://example.com/log/',
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should resolve relative siteUrl from Atom feed against feed URL', async () => {
+    const atom = `
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Test</title>
+        <link rel="alternate" href="/blog"/>
+        <subtitle>Test feed</subtitle>
+      </feed>
+    `
+    const result = await defaultExtractor({
+      content: atom,
+      headers: new Headers(),
+      url: 'https://example.com/feed.xml',
+    })
+    const expected: DiscoverResult<FeedResult> = {
+      url: 'https://example.com/feed.xml',
+      isValid: true,
+      format: 'atom',
+      title: 'Test',
+      description: 'Test feed',
+      siteUrl: 'https://example.com/blog',
+    }
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should resolve relative siteUrl from JSON Feed against feed URL', async () => {
+    const json = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Test',
+      home_page_url: '/site/',
+      description: 'Test feed',
+      items: [],
+    })
+    const result = await defaultExtractor({
+      content: json,
+      headers: new Headers(),
+      url: 'https://example.com/feed.json',
+    })
+    const expected: DiscoverResult<FeedResult> = {
+      url: 'https://example.com/feed.json',
+      isValid: true,
+      format: 'json',
+      title: 'Test',
+      description: 'Test feed',
+      siteUrl: 'https://example.com/site/',
     }
 
     expect(result).toEqual(expected)

--- a/src/feeds/extractors.ts
+++ b/src/feeds/extractors.ts
@@ -1,6 +1,7 @@
 import { parseFeed } from 'feedsmith'
 import { getFeedSiteUrl } from '../common/discover/utils.js'
 import type { DiscoverExtractFn } from '../common/types.js'
+import { normalizeUrl } from '../common/utils.js'
 import type { FeedResult } from './types.js'
 
 export const defaultExtractor: DiscoverExtractFn<FeedResult> = ({ content, url }) => {
@@ -11,7 +12,8 @@ export const defaultExtractor: DiscoverExtractFn<FeedResult> = ({ content, url }
   try {
     const parsed = parseFeed(content)
     const { format, feed } = parsed
-    const siteUrl = getFeedSiteUrl(parsed)
+    const rawSiteUrl = getFeedSiteUrl(parsed)
+    const siteUrl = rawSiteUrl ? normalizeUrl(rawSiteUrl, url) : undefined
 
     if (format === 'rss' || format === 'rdf') {
       return {

--- a/src/feeds/index.test.ts
+++ b/src/feeds/index.test.ts
@@ -38,7 +38,7 @@ describe('discoverFeeds', () => {
         format: 'rss',
         title: 'Test RSS',
         description: 'Test feed',
-        siteUrl: 'https://example.com',
+        siteUrl: 'https://example.com/',
       },
     ]
 
@@ -81,7 +81,7 @@ describe('discoverFeeds', () => {
         format: 'rss',
         title: 'Test RSS',
         description: 'Test feed',
-        siteUrl: 'https://example.com',
+        siteUrl: 'https://example.com/',
       },
       {
         url: 'https://example.com/atom',
@@ -90,7 +90,7 @@ describe('discoverFeeds', () => {
         format: 'atom',
         title: 'Test Atom',
         description: 'Test feed',
-        siteUrl: 'https://example.com',
+        siteUrl: 'https://example.com/',
       },
     ]
 
@@ -125,7 +125,7 @@ describe('discoverFeeds', () => {
         format: 'rss',
         title: 'Test RSS',
         description: 'Test feed',
-        siteUrl: 'https://example.com',
+        siteUrl: 'https://example.com/',
       },
     ]
 
@@ -161,7 +161,7 @@ describe('discoverFeeds', () => {
         format: 'rss',
         title: 'Test RSS',
         description: 'Test feed',
-        siteUrl: 'https://example.com',
+        siteUrl: 'https://example.com/',
       },
       {
         url: 'https://example.com/rss',
@@ -170,7 +170,7 @@ describe('discoverFeeds', () => {
         format: 'rss',
         title: 'Test RSS',
         description: 'Test feed',
-        siteUrl: 'https://example.com',
+        siteUrl: 'https://example.com/',
       },
     ]
 
@@ -202,7 +202,7 @@ describe('discoverFeeds', () => {
         format: 'json',
         title: 'Test JSON Feed',
         description: 'Test feed',
-        siteUrl: 'https://example.com',
+        siteUrl: 'https://example.com/',
       },
     ]
 
@@ -238,7 +238,7 @@ describe('discoverFeeds', () => {
         format: 'rss',
         title: 'Test RSS',
         description: 'Test feed',
-        siteUrl: 'https://example.com',
+        siteUrl: 'https://example.com/',
       },
       {
         url: 'https://example.com/feeds/posts/default',
@@ -247,7 +247,7 @@ describe('discoverFeeds', () => {
         format: 'rss',
         title: 'Test RSS',
         description: 'Test feed',
-        siteUrl: 'https://example.com',
+        siteUrl: 'https://example.com/',
       },
     ]
 
@@ -289,7 +289,7 @@ describe('discoverFeeds', () => {
         format: 'rss',
         title: 'Test RSS',
         description: 'Test feed',
-        siteUrl: 'https://example.com',
+        siteUrl: 'https://example.com/',
       },
       {
         url: 'https://www.example.com/feed',
@@ -298,7 +298,7 @@ describe('discoverFeeds', () => {
         format: 'rss',
         title: 'Test RSS',
         description: 'Test feed',
-        siteUrl: 'https://example.com',
+        siteUrl: 'https://example.com/',
       },
       {
         url: 'https://blog.example.com/feed',
@@ -307,7 +307,7 @@ describe('discoverFeeds', () => {
         format: 'rss',
         title: 'Test RSS',
         description: 'Test feed',
-        siteUrl: 'https://example.com',
+        siteUrl: 'https://example.com/',
       },
     ]
 
@@ -355,7 +355,7 @@ describe('discoverFeeds', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://reddit.com',
+          siteUrl: 'https://reddit.com/',
           hint: { key: 'reddit:posts', label: 'Posts' },
         },
       ]
@@ -434,7 +434,7 @@ describe('discoverFeeds', () => {
           format: 'rss',
           title: 'Custom Feed',
           description: 'Custom feed',
-          siteUrl: 'https://custom.com',
+          siteUrl: 'https://custom.com/',
         },
       ]
 
@@ -470,7 +470,7 @@ describe('discoverFeeds', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://reddit.com',
+          siteUrl: 'https://reddit.com/',
           hint: { key: 'reddit:posts', label: 'Posts' },
         },
         {
@@ -480,7 +480,7 @@ describe('discoverFeeds', () => {
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
-          siteUrl: 'https://reddit.com',
+          siteUrl: 'https://reddit.com/',
         },
       ]
 

--- a/src/hubs/discover/index.ts
+++ b/src/hubs/discover/index.ts
@@ -30,7 +30,11 @@ export const discoverHubs = async (
   }
 
   if (methods.includes('feed') && normalizedInput.content) {
-    const feedHubs = discoverHubsFromFeed(normalizedInput.content, normalizedInput.url)
+    const feedHubs = discoverHubsFromFeed(
+      normalizedInput.content,
+      normalizedInput.url,
+      normalizeUrlFn,
+    )
     results.push(...feedHubs)
   }
 

--- a/src/hubs/feed/index.test.ts
+++ b/src/hubs/feed/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import type { DiscoverNormalizeUrlFn } from '../../common/types.js'
 import type { HubResult } from '../discover/types.js'
 import { discoverHubsFromFeed } from './index.js'
 
@@ -233,5 +234,66 @@ describe('discoverHubsFromFeed', () => {
     const value = discoverHubsFromFeed(content, 'https://example.com/feed.json')
 
     expect(value).toEqual([])
+  })
+
+  it('should resolve relative hub and self links in Atom feed', () => {
+    const content = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Example Feed</title>
+        <link href="/hub" rel="hub"/>
+        <link href="/feed.xml" rel="self"/>
+      </feed>
+    `
+    const value = discoverHubsFromFeed(content, 'https://example.com/feed.xml')
+    const expected: Array<HubResult> = [
+      {
+        hub: 'https://example.com/hub',
+        topic: 'https://example.com/feed.xml',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should resolve relative hub URL and feed_url in JSON Feed', () => {
+    const content = JSON.stringify({
+      version: 'https://jsonfeed.org/version/1.1',
+      title: 'Example Feed',
+      feed_url: '/feed.json',
+      hubs: [{ type: 'WebSub', url: '/hub' }],
+    })
+    const value = discoverHubsFromFeed(content, 'https://example.com/feed.json')
+    const expected: Array<HubResult> = [
+      {
+        hub: 'https://example.com/hub',
+        topic: 'https://example.com/feed.json',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should apply custom normalizeUrlFn to hub and topic URLs', () => {
+    const content = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Example Feed</title>
+        <link href="/hub" rel="hub"/>
+        <link href="/feed.xml" rel="self"/>
+      </feed>
+    `
+    const customNormalizer: DiscoverNormalizeUrlFn = (url) => {
+      return `https://custom.example.com${url}`
+    }
+    const value = discoverHubsFromFeed(content, 'https://example.com/feed.xml', customNormalizer)
+    const expected: Array<HubResult> = [
+      {
+        hub: 'https://custom.example.com/hub',
+        topic: 'https://custom.example.com/feed.xml',
+      },
+    ]
+
+    expect(value).toEqual(expected)
   })
 })

--- a/src/hubs/feed/index.ts
+++ b/src/hubs/feed/index.ts
@@ -1,5 +1,7 @@
 import { parseFeed } from 'feedsmith'
 import type { Atom, DeepPartial } from 'feedsmith/types'
+import type { DiscoverNormalizeUrlFn } from '../../common/types.js'
+import { normalizeUrl } from '../../common/utils.js'
 import type { HubResult } from '../discover/types.js'
 
 const getLinksWithRel = (
@@ -11,16 +13,25 @@ const getLinksWithRel = (
   )
 }
 
-export const discoverHubsFromFeed = (content: string, baseUrl: string): Array<HubResult> => {
+export const discoverHubsFromFeed = (
+  content: string,
+  baseUrl: string,
+  normalizeUrlFn: DiscoverNormalizeUrlFn = normalizeUrl,
+): Array<HubResult> => {
   try {
     const { format, feed } = parseFeed(content)
 
     // JSON Feed has native hubs support.
     if (format === 'json') {
       const hubs = feed.hubs ?? []
-      const topic = feed.feed_url ?? baseUrl
+      const topic = feed.feed_url ? normalizeUrlFn(feed.feed_url, baseUrl) : baseUrl
 
-      return hubs.filter((hub) => hub.url).map((hub) => ({ hub: hub.url as string, topic }))
+      return hubs
+        .filter((hub) => hub.url)
+        .map((hub) => ({
+          hub: normalizeUrlFn(hub.url as string, baseUrl),
+          topic,
+        }))
     }
 
     // Get links array based on format.
@@ -29,9 +40,12 @@ export const discoverHubsFromFeed = (content: string, baseUrl: string): Array<Hu
 
     if (hubUris.length > 0) {
       const selfUris = getLinksWithRel(links, 'self')
-      const topic = selfUris[0] ?? baseUrl
+      const topic = selfUris[0] ? normalizeUrlFn(selfUris[0], baseUrl) : baseUrl
 
-      return hubUris.map((hub) => ({ hub, topic }))
+      return hubUris.map((hub) => ({
+        hub: normalizeUrlFn(hub, baseUrl),
+        topic,
+      }))
     }
   } catch {
     // Silently fail - content is not a valid feed.


### PR DESCRIPTION
When feed content contains relative URLs (e.g., `/log/` as site URL, `/hub` as hub URL), they were returned as-is instead of being resolved against the feed's base URL. This caused silent failures in site URL resolution and incorrect data in feed results.

- `defaultResolveSiteUrlFn`: resolve site URL via `normalizeUrl` (used by favicons/blogrolls discoverers)
- `defaultExtractor`: resolve `FeedResult.siteUrl` via `normalizeUrl` (used by feeds discoverer)
- `discoverHubsFromFeed`: add `normalizeUrlFn` parameter matching `discoverHubsFromHeaders`/`discoverHubsFromHtml` pattern, resolve hub + topic URLs