### PR TITLE
refactor: Rename normalizeUrl to resolveUrl

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -87,7 +87,7 @@ export default defineConfig({
         items: [
           { text: 'Data Fetching', link: '/customization/data-fetching' },
           { text: 'Data Extraction', link: '/customization/data-extraction' },
-          { text: 'URL Normalization', link: '/customization/url-normalization' },
+          { text: 'URL Resolution', link: '/customization/url-resolution' },
         ],
       },
       {

--- a/docs/customization/url-resolution.md
+++ b/docs/customization/url-resolution.md
@@ -1,10 +1,10 @@
 ---
-title: "Customization: URL Normalization"
+title: "Customization: URL Resolution"
 ---
 
-# Customize URL Normalization
+# Customize URL Resolution
 
-Feedscout normalizes discovered URLs before validation to ensure consistent results. You can provide a custom normalization function to change this behavior.
+Feedscout resolves discovered URLs before validation to ensure consistent results. You can provide a custom resolution function to change this behavior.
 
 ## Default Behavior
 
@@ -13,21 +13,21 @@ By default, Feedscout resolves relative URLs against the base URL:
 ```typescript
 // Base URL: https://example.com/blog/
 // Discovered: /feed.xml
-// Normalized: https://example.com/feed.xml
+// Resolved: https://example.com/feed.xml
 
 // Base URL: https://example.com/blog/
 // Discovered: ../rss
-// Normalized: https://example.com/rss
+// Resolved: https://example.com/rss
 ```
 
-## Custom Normalization
+## Custom Resolution
 
-Provide a `normalizeUrlFn` to customize URL normalization:
+Provide a `resolveUrlFn` to customize URL resolution:
 
 ```typescript
-import type { DiscoverNormalizeUrlFn } from 'feedscout'
+import type { DiscoverResolveUrlFn } from 'feedscout'
 
-const customNormalize: DiscoverNormalizeUrlFn = (url, baseUrl) => {
+const customResolve: DiscoverResolveUrlFn = (url, baseUrl) => {
   // Resolve relative URLs
   const resolved = new URL(url, baseUrl).href
 
@@ -42,19 +42,19 @@ const customNormalize: DiscoverNormalizeUrlFn = (url, baseUrl) => {
 
 const feeds = await discoverFeeds(url, {
   methods: ['html', 'guess'],
-  normalizeUrlFn: customNormalize,
+  resolveUrlFn: customResolve,
 })
 
 // Also works with discoverHubs
 const hubs = await discoverHubs(url, {
-  normalizeUrlFn: customNormalize,
+  resolveUrlFn: customResolve,
 })
 ```
 
 ## Interface
 
 ```typescript
-type DiscoverNormalizeUrlFn = (url: string, baseUrl: string | undefined) => string
+type DiscoverResolveUrlFn = (url: string, baseUrl: string | undefined) => string
 ```
 
 ## Use Cases
@@ -64,7 +64,7 @@ type DiscoverNormalizeUrlFn = (url: string, baseUrl: string | undefined) => stri
 Strip unnecessary query parameters:
 
 ```typescript
-const normalizeUrl: DiscoverNormalizeUrlFn = (url, baseUrl) => {
+const resolveUrl: DiscoverResolveUrlFn = (url, baseUrl) => {
   const resolved = new URL(url, baseUrl)
 
   // Keep only essential parameters
@@ -86,7 +86,7 @@ const normalizeUrl: DiscoverNormalizeUrlFn = (url, baseUrl) => {
 Upgrade HTTP URLs to HTTPS:
 
 ```typescript
-const normalizeUrl: DiscoverNormalizeUrlFn = (url, baseUrl) => {
+const resolveUrl: DiscoverResolveUrlFn = (url, baseUrl) => {
   const resolved = new URL(url, baseUrl)
   resolved.protocol = 'https:'
   return resolved.href
@@ -95,10 +95,10 @@ const normalizeUrl: DiscoverNormalizeUrlFn = (url, baseUrl) => {
 
 ### Removing Trailing Slashes
 
-Normalize paths by removing trailing slashes:
+Remove trailing slashes from paths:
 
 ```typescript
-const normalizeUrl: DiscoverNormalizeUrlFn = (url, baseUrl) => {
+const resolveUrl: DiscoverResolveUrlFn = (url, baseUrl) => {
   const resolved = new URL(url, baseUrl)
   resolved.pathname = resolved.pathname.replace(/\/+$/, '')
   return resolved.href
@@ -110,7 +110,7 @@ const normalizeUrl: DiscoverNormalizeUrlFn = (url, baseUrl) => {
 Rewrite URLs for specific domains:
 
 ```typescript
-const normalizeUrl: DiscoverNormalizeUrlFn = (url, baseUrl) => {
+const resolveUrl: DiscoverResolveUrlFn = (url, baseUrl) => {
   const resolved = new URL(url, baseUrl)
 
   // Use feeds subdomain for specific sites
@@ -124,18 +124,18 @@ const normalizeUrl: DiscoverNormalizeUrlFn = (url, baseUrl) => {
 
 ## Combining with Other Options
 
-URL normalization works with `discoverFeeds`, `discoverBlogrolls`, and `discoverHubs`:
+URL resolution works with `discoverFeeds`, `discoverBlogrolls`, and `discoverHubs`:
 
 ```typescript
 const feeds = await discoverFeeds(url, {
   methods: ['html', 'guess'],
-  normalizeUrlFn: customNormalize,
+  resolveUrlFn: customResolve,
   extractFn: customExtractor,
   concurrency: 3,
 })
 
 const hubs = await discoverHubs(url, {
   methods: ['headers', 'html'],
-  normalizeUrlFn: customNormalize,
+  resolveUrlFn: customResolve,
 })
 ```

--- a/docs/reference/discover-blogrolls.md
+++ b/docs/reference/discover-blogrolls.md
@@ -42,7 +42,7 @@ All options are optional. When not provided, sensible defaults are used.
 | `methods` | `DiscoverMethodsConfig` | `['html', 'headers', 'guess']` | Which methods to use |
 | `fetchFn` | `DiscoverFetchFn` | native fetch | Custom fetch function |
 | `extractFn` | `DiscoverExtractFn` | feedsmith | Custom OPML extraction function |
-| `normalizeUrlFn` | `DiscoverNormalizeUrlFn` | | Custom URL normalization function |
+| `resolveUrlFn` | `DiscoverResolveUrlFn` | | Custom URL resolution function |
 | `stopOnFirstMethod` | `boolean` | `false` | Stop URI collection after first method with results |
 | `stopOnFirstResult` | `boolean` | `false` | Stop after first valid blogroll |
 | `concurrency` | `number` | `3` | Max parallel validations |

--- a/docs/reference/discover-favicons.md
+++ b/docs/reference/discover-favicons.md
@@ -42,7 +42,7 @@ All options are optional. When not provided, sensible defaults are used.
 | `methods` | `DiscoverMethodsConfig` | `['platform', 'feed', 'html', 'headers', 'guess']` | Which methods to use |
 | `fetchFn` | `DiscoverFetchFn` | native fetch | Custom fetch function |
 | `extractFn` | `DiscoverExtractFn` | status check | Custom extraction function |
-| `normalizeUrlFn` | `DiscoverNormalizeUrlFn` | | Custom URL normalization function |
+| `resolveUrlFn` | `DiscoverResolveUrlFn` | | Custom URL resolution function |
 | `stopOnFirstMethod` | `boolean` | `false` | Stop URI collection after first method with results |
 | `stopOnFirstResult` | `boolean` | `false` | Stop after first valid favicon |
 | `concurrency` | `number` | `3` | Max parallel validations |

--- a/docs/reference/discover-feeds.md
+++ b/docs/reference/discover-feeds.md
@@ -42,7 +42,7 @@ All options are optional. When not provided, sensible defaults are used.
 | `methods` | `DiscoverMethodsConfig` | `['platform', 'html', 'headers', 'guess']` | Which methods to use |
 | `fetchFn` | `DiscoverFetchFn` | native fetch | Custom fetch function |
 | `extractFn` | `DiscoverExtractFn` | feedsmith | Custom feed extraction function |
-| `normalizeUrlFn` | `DiscoverNormalizeUrlFn` | | Custom URL normalization function |
+| `resolveUrlFn` | `DiscoverResolveUrlFn` | | Custom URL resolution function |
 | `stopOnFirstMethod` | `boolean` | `false` | Stop URI collection after first method with results |
 | `stopOnFirstResult` | `boolean` | `false` | Stop after first valid feed |
 | `concurrency` | `number` | `3` | Max parallel validations |

--- a/docs/reference/discover-hubs.md
+++ b/docs/reference/discover-hubs.md
@@ -39,7 +39,7 @@ discoverHubs({
 |----------|------|---------|-------------|
 | `methods` | `DiscoverHubsMethodsConfig` | all | Methods to use |
 | `fetchFn` | `DiscoverFetchFn` | native fetch | Custom fetch function |
-| `normalizeUrlFn` | `DiscoverNormalizeUrlFn` | resolve relative | Custom URL normalization |
+| `resolveUrlFn` | `DiscoverResolveUrlFn` | resolve relative | Custom URL resolution |
 
 #### methods
 
@@ -126,21 +126,21 @@ const hubs = await discoverHubs('https://example.com/feed.xml', {
 
 See [Customize Data Fetching](/customization/data-fetching) for examples with Axios, Got, Ky, and more.
 
-### With Custom URL Normalization
+### With Custom URL Resolution
 
 ```typescript
-import type { DiscoverNormalizeUrlFn } from 'feedscout'
+import type { DiscoverResolveUrlFn } from 'feedscout'
 
-const normalizeUrl: DiscoverNormalizeUrlFn = (url, baseUrl) => {
+const resolveUrl: DiscoverResolveUrlFn = (url, baseUrl) => {
   const resolved = new URL(url, baseUrl)
   resolved.protocol = 'https:'
   return resolved.href
 }
 
 const hubs = await discoverHubs('https://example.com/feed.xml', {
-  normalizeUrlFn: normalizeUrl,
+  resolveUrlFn: resolveUrl,
 })
 ```
 
-See [Customize URL Normalization](/customization/url-normalization) for more examples.
+See [Customize URL Resolution](/customization/url-resolution) for more examples.
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -14,7 +14,7 @@ import type {
   DiscoverResult,
   DiscoverProgress,
   DiscoverFetchFn,
-  DiscoverNormalizeUrlFn,
+  DiscoverResolveUrlFn,
   DiscoverUriEntry,
   DiscoverUriHint,
   UriEntry,
@@ -50,7 +50,7 @@ type DiscoverOptions<TValid, TMethods extends DiscoverMethod = DiscoverMethod> =
   methods?: DiscoverMethodsConfig<TMethods>
   fetchFn?: DiscoverFetchFn
   extractFn?: DiscoverExtractFn<TValid>
-  normalizeUrlFn?: DiscoverNormalizeUrlFn
+  resolveUrlFn?: DiscoverResolveUrlFn
   stopOnFirstMethod?: boolean
   stopOnFirstResult?: boolean
   concurrency?: number

--- a/src/blogrolls/index.ts
+++ b/src/blogrolls/index.ts
@@ -1,7 +1,7 @@
 import { discover } from '../common/discover/index.js'
 import { defaultFetchFn, defaultResolveSiteUrlFn } from '../common/discover/utils.js'
 import type { DiscoverInput, DiscoverOptions, DiscoverResult } from '../common/types.js'
-import { normalizeUrl } from '../common/utils.js'
+import { resolveUrl } from '../common/utils.js'
 import { defaultGuessOptions, defaultHeadersOptions, defaultHtmlOptions } from './defaults.js'
 import { defaultExtractor } from './extractors.js'
 import type { BlogrollResult } from './types.js'
@@ -17,7 +17,7 @@ export const discoverBlogrolls = <TValid extends BlogrollResult = BlogrollResult
       methods: options.methods ?? ['html', 'headers', 'guess'],
       fetchFn: options.fetchFn ?? defaultFetchFn,
       extractFn: options.extractFn ?? defaultExtractor,
-      normalizeUrlFn: options.normalizeUrlFn ?? normalizeUrl,
+      resolveUrlFn: options.resolveUrlFn ?? resolveUrl,
       resolveSiteUrlFn: options.resolveSiteUrlFn ?? defaultResolveSiteUrlFn,
     },
     {

--- a/src/common/discover/index.test.ts
+++ b/src/common/discover/index.test.ts
@@ -5,7 +5,7 @@ import locales from '../locales.json' with { type: 'json' }
 import type {
   DiscoverExtractFn,
   DiscoverFetchFn,
-  DiscoverNormalizeUrlFn,
+  DiscoverResolveUrlFn,
   DiscoverProgress,
   DiscoverResult,
 } from '../types.js'
@@ -891,12 +891,12 @@ describe('discover', () => {
     })
   })
 
-  describe('normalizeUrlFn', () => {
-    it('should use custom normalizeUrlFn to transform discovered URIs', async () => {
+  describe('resolveUrlFn', () => {
+    it('should use custom resolveUrlFn to transform discovered URIs', async () => {
       const mockFetch = createMockFetch({
         'https://custom.example.com/feed': rss,
       })
-      const customNormalizer: DiscoverNormalizeUrlFn = (url, baseUrl) => {
+      const customNormalizer: DiscoverResolveUrlFn = (url, baseUrl) => {
         const fullUrl = baseUrl ? new URL(url, baseUrl).href : url
         return fullUrl.replace('example.com', 'custom.example.com')
       }
@@ -905,7 +905,7 @@ describe('discover', () => {
         {
           methods: { guess: { uris: ['/feed'] } },
           fetchFn: mockFetch,
-          normalizeUrlFn: customNormalizer,
+          resolveUrlFn: customNormalizer,
         },
       )
       const expected: Array<DiscoverResult<FeedResult>> = [
@@ -923,12 +923,12 @@ describe('discover', () => {
       expect(value).toEqual(expected)
     })
 
-    it('should use custom normalizeUrlFn for HTML discovered links', async () => {
+    it('should use custom resolveUrlFn for HTML discovered links', async () => {
       const html = '<link rel="alternate" type="application/rss+xml" href="/feed.xml">'
       const mockFetch = createMockFetch({
         'https://cdn.example.com/feed.xml': rss,
       })
-      const customNormalizer: DiscoverNormalizeUrlFn = (url) => {
+      const customNormalizer: DiscoverResolveUrlFn = (url) => {
         return url.startsWith('/') ? `https://cdn.example.com${url}` : url
       }
       const value = await discoverFeeds(
@@ -936,7 +936,7 @@ describe('discover', () => {
         {
           methods: ['html'],
           fetchFn: mockFetch,
-          normalizeUrlFn: customNormalizer,
+          resolveUrlFn: customNormalizer,
         },
       )
       const expected: Array<DiscoverResult<FeedResult>> = [

--- a/src/common/discover/index.test.ts
+++ b/src/common/discover/index.test.ts
@@ -896,7 +896,7 @@ describe('discover', () => {
       const mockFetch = createMockFetch({
         'https://custom.example.com/feed': rss,
       })
-      const customNormalizer: DiscoverResolveUrlFn = (url, baseUrl) => {
+      const customResolveUrlFn: DiscoverResolveUrlFn = (url, baseUrl) => {
         const fullUrl = baseUrl ? new URL(url, baseUrl).href : url
         return fullUrl.replace('example.com', 'custom.example.com')
       }
@@ -905,7 +905,7 @@ describe('discover', () => {
         {
           methods: { guess: { uris: ['/feed'] } },
           fetchFn: mockFetch,
-          resolveUrlFn: customNormalizer,
+          resolveUrlFn: customResolveUrlFn,
         },
       )
       const expected: Array<DiscoverResult<FeedResult>> = [
@@ -928,7 +928,7 @@ describe('discover', () => {
       const mockFetch = createMockFetch({
         'https://cdn.example.com/feed.xml': rss,
       })
-      const customNormalizer: DiscoverResolveUrlFn = (url) => {
+      const customResolveUrlFn: DiscoverResolveUrlFn = (url) => {
         return url.startsWith('/') ? `https://cdn.example.com${url}` : url
       }
       const value = await discoverFeeds(
@@ -936,7 +936,7 @@ describe('discover', () => {
         {
           methods: ['html'],
           fetchFn: mockFetch,
-          resolveUrlFn: customNormalizer,
+          resolveUrlFn: customResolveUrlFn,
         },
       )
       const expected: Array<DiscoverResult<FeedResult>> = [

--- a/src/common/discover/index.ts
+++ b/src/common/discover/index.ts
@@ -21,7 +21,7 @@ export const discover = async <TValid>(
     methods,
     fetchFn,
     extractFn,
-    normalizeUrlFn,
+    resolveUrlFn,
     resolveSiteUrlFn,
     stopOnFirstMethod = false,
     stopOnFirstResult = false,
@@ -83,7 +83,7 @@ export const discover = async <TValid>(
     }
 
     const normalized = rawUris.map((entry) => {
-      return normalizeUriEntry(entry, normalizeUrlFn, sourceInput.url)
+      return normalizeUriEntry(entry, resolveUrlFn, sourceInput.url)
     })
 
     const unique = normalized.filter((entry) => {

--- a/src/common/discover/utils.test.ts
+++ b/src/common/discover/utils.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, spyOn } from 'bun:test'
 import { parseFeed } from 'feedsmith'
 import locales from '../locales.json' with { type: 'json' }
-import type { DiscoverFetchFn, DiscoverNormalizeUrlFn } from '../types.js'
+import type { DiscoverFetchFn, DiscoverResolveUrlFn } from '../types.js'
 import {
   defaultFetchFn,
   defaultResolveSiteUrlFn,
@@ -1614,7 +1614,7 @@ describe('normalizeMethodsConfig with siteInput', () => {
 })
 
 describe('normalizeUriEntry', () => {
-  const normalizeUrlFn: DiscoverNormalizeUrlFn = (url, baseUrl) => {
+  const resolveUrlFn: DiscoverResolveUrlFn = (url, baseUrl) => {
     return new URL(url, baseUrl).toString()
   }
 
@@ -1622,17 +1622,17 @@ describe('normalizeUriEntry', () => {
     const value = { uri: '/feed.xml' }
     const expected = { uri: 'https://example.com/feed.xml' }
 
-    expect(normalizeUriEntry(value, normalizeUrlFn, 'https://example.com')).toEqual(expected)
+    expect(normalizeUriEntry(value, resolveUrlFn, 'https://example.com')).toEqual(expected)
   })
 
   it('should normalize array entry', () => {
     const value = { uri: ['/feed/', '?feed=rss'] }
     const expected = { uri: ['https://example.com/feed/', 'https://example.com/?feed=rss'] }
 
-    expect(normalizeUriEntry(value, normalizeUrlFn, 'https://example.com')).toEqual(expected)
+    expect(normalizeUriEntry(value, resolveUrlFn, 'https://example.com')).toEqual(expected)
   })
 
-  it('should apply normalizeUrlFn to each alternative in array', () => {
+  it('should apply resolveUrlFn to each alternative in array', () => {
     const value = { uri: ['/feed/atom/', '?feed=atom', '/rss.xml'] }
     const expected = {
       uri: [
@@ -1642,28 +1642,28 @@ describe('normalizeUriEntry', () => {
       ],
     }
 
-    expect(normalizeUriEntry(value, normalizeUrlFn, 'https://example.com')).toEqual(expected)
+    expect(normalizeUriEntry(value, resolveUrlFn, 'https://example.com')).toEqual(expected)
   })
 
   it('should handle undefined baseUrl for string entry', () => {
     const value = { uri: 'https://example.com/feed.xml' }
     const expected = { uri: 'https://example.com/feed.xml' }
 
-    expect(normalizeUriEntry(value, normalizeUrlFn, undefined)).toEqual(expected)
+    expect(normalizeUriEntry(value, resolveUrlFn, undefined)).toEqual(expected)
   })
 
   it('should handle undefined baseUrl for array entry', () => {
     const value = { uri: ['https://example.com/feed/', 'https://example.com/?feed=rss'] }
     const expected = { uri: ['https://example.com/feed/', 'https://example.com/?feed=rss'] }
 
-    expect(normalizeUriEntry(value, normalizeUrlFn, undefined)).toEqual(expected)
+    expect(normalizeUriEntry(value, resolveUrlFn, undefined)).toEqual(expected)
   })
 
   it('should handle single-element array', () => {
     const value = { uri: ['/feed.xml'] }
     const expected = { uri: ['https://example.com/feed.xml'] }
 
-    expect(normalizeUriEntry(value, normalizeUrlFn, 'https://example.com')).toEqual(expected)
+    expect(normalizeUriEntry(value, resolveUrlFn, 'https://example.com')).toEqual(expected)
   })
 
   it('should preserve hint on string entry', () => {
@@ -1673,7 +1673,7 @@ describe('normalizeUriEntry', () => {
       hint: { key: 'test:feed', label: 'Feed' },
     }
 
-    expect(normalizeUriEntry(value, normalizeUrlFn, 'https://example.com')).toEqual(expected)
+    expect(normalizeUriEntry(value, resolveUrlFn, 'https://example.com')).toEqual(expected)
   })
 
   it('should preserve hint on array entry', () => {
@@ -1683,6 +1683,6 @@ describe('normalizeUriEntry', () => {
       hint: { key: 'test:feed', label: 'Feed' },
     }
 
-    expect(normalizeUriEntry(value, normalizeUrlFn, 'https://example.com')).toEqual(expected)
+    expect(normalizeUriEntry(value, resolveUrlFn, 'https://example.com')).toEqual(expected)
   })
 })

--- a/src/common/discover/utils.ts
+++ b/src/common/discover/utils.ts
@@ -8,11 +8,11 @@ import type {
   DiscoverMethodsConfig,
   DiscoverMethodsConfigDefaults,
   DiscoverMethodsConfigInternal,
-  DiscoverNormalizeUrlFn,
+  DiscoverResolveUrlFn,
   DiscoverResolveSiteUrlFn,
   DiscoverUriEntry,
 } from '../types.js'
-import { normalizeUrl } from '../utils.js'
+import { resolveUrl } from '../utils.js'
 
 export const defaultFetchFn: DiscoverFetchFn = async (url, options) => {
   const response = await fetch(url, {
@@ -84,7 +84,7 @@ export const defaultResolveSiteUrlFn: DiscoverResolveSiteUrlFn = (input) => {
       } catch {}
     } else {
       // Resolve relative site URLs against the feed URL.
-      siteUrl = normalizeUrl(siteUrl, input.url)
+      siteUrl = resolveUrl(siteUrl, input.url)
     }
 
     // Avoid re-fetching the same URL.
@@ -98,16 +98,16 @@ export const defaultResolveSiteUrlFn: DiscoverResolveSiteUrlFn = (input) => {
 
 export const normalizeUriEntry = (
   entry: DiscoverUriEntry,
-  normalizeUrlFn: DiscoverNormalizeUrlFn,
+  resolveUrlFn: DiscoverResolveUrlFn,
   baseUrl: string | undefined,
 ): DiscoverUriEntry => {
   if (typeof entry.uri === 'string') {
-    return { ...entry, uri: normalizeUrlFn(entry.uri, baseUrl) }
+    return { ...entry, uri: resolveUrlFn(entry.uri, baseUrl) }
   }
 
   return {
     ...entry,
-    uri: entry.uri.map((uri) => normalizeUrlFn(uri, baseUrl)),
+    uri: entry.uri.map((uri) => resolveUrlFn(uri, baseUrl)),
   }
 }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -29,7 +29,7 @@ export type LinkSelector = {
   types?: Array<string>
 }
 
-export type DiscoverNormalizeUrlFn = (url: string, baseUrl: string | undefined) => string
+export type DiscoverResolveUrlFn = (url: string, baseUrl: string | undefined) => string
 
 export type DiscoverResolveSiteUrlFn = (input: DiscoverInputObject) => string | undefined
 
@@ -144,7 +144,7 @@ export type DiscoverOptions<TValid, TMethods extends DiscoverMethod = DiscoverMe
   methods?: DiscoverMethodsConfig<TMethods>
   fetchFn?: DiscoverFetchFn
   extractFn?: DiscoverExtractFn<TValid>
-  normalizeUrlFn?: DiscoverNormalizeUrlFn
+  resolveUrlFn?: DiscoverResolveUrlFn
   resolveSiteUrlFn?: DiscoverResolveSiteUrlFn
   stopOnFirstMethod?: boolean
   stopOnFirstResult?: boolean
@@ -153,12 +153,12 @@ export type DiscoverOptions<TValid, TMethods extends DiscoverMethod = DiscoverMe
   includeInvalid?: boolean
 }
 
-// Internal options - required fetchFn, extractFn, normalizeUrlFn.
+// Internal options - required fetchFn, extractFn, resolveUrlFn.
 export type DiscoverOptionsInternal<TValid> = {
   methods: DiscoverMethodsConfig
   fetchFn: DiscoverFetchFn
   extractFn: DiscoverExtractFn<TValid>
-  normalizeUrlFn: DiscoverNormalizeUrlFn
+  resolveUrlFn: DiscoverResolveUrlFn
   resolveSiteUrlFn?: DiscoverResolveSiteUrlFn
   stopOnFirstMethod?: boolean
   stopOnFirstResult?: boolean

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -11,7 +11,7 @@ import {
   isSubdomainOf,
   matchesAnyOfLinkSelectors,
   normalizeMimeType,
-  normalizeUrl,
+  resolveUrl,
   omitEmpty,
   processConcurrently,
 } from './utils.js'
@@ -533,13 +533,13 @@ describe('omitEmpty', () => {
   })
 })
 
-describe('normalizeUrl', () => {
+describe('resolveUrl', () => {
   it('should resolve relative URL with base URL', () => {
     const value = '/feed.xml'
     const baseUrl = 'https://example.com'
     const expected = 'https://example.com/feed.xml'
 
-    expect(normalizeUrl(value, baseUrl)).toBe(expected)
+    expect(resolveUrl(value, baseUrl)).toBe(expected)
   })
 
   it('should resolve relative URL with base URL containing path', () => {
@@ -547,7 +547,7 @@ describe('normalizeUrl', () => {
     const baseUrl = 'https://example.com/blog/'
     const expected = 'https://example.com/blog/feed.xml'
 
-    expect(normalizeUrl(value, baseUrl)).toBe(expected)
+    expect(resolveUrl(value, baseUrl)).toBe(expected)
   })
 
   it('should preserve absolute URL when base URL provided', () => {
@@ -555,7 +555,7 @@ describe('normalizeUrl', () => {
     const baseUrl = 'https://example.com'
     const expected = 'https://other.com/feed.xml'
 
-    expect(normalizeUrl(value, baseUrl)).toBe(expected)
+    expect(resolveUrl(value, baseUrl)).toBe(expected)
   })
 
   it('should return URL unchanged when base URL is undefined', () => {
@@ -563,7 +563,7 @@ describe('normalizeUrl', () => {
     const baseUrl = undefined
     const expected = '/feed.xml'
 
-    expect(normalizeUrl(value, baseUrl)).toBe(expected)
+    expect(resolveUrl(value, baseUrl)).toBe(expected)
   })
 
   it('should handle protocol-relative URLs', () => {
@@ -571,7 +571,7 @@ describe('normalizeUrl', () => {
     const baseUrl = 'https://example.com'
     const expected = 'https://cdn.example.com/feed.xml'
 
-    expect(normalizeUrl(value, baseUrl)).toBe(expected)
+    expect(resolveUrl(value, baseUrl)).toBe(expected)
   })
 
   it('should handle parent directory references', () => {
@@ -579,7 +579,7 @@ describe('normalizeUrl', () => {
     const baseUrl = 'https://example.com/blog/posts/'
     const expected = 'https://example.com/blog/feed.xml'
 
-    expect(normalizeUrl(value, baseUrl)).toBe(expected)
+    expect(resolveUrl(value, baseUrl)).toBe(expected)
   })
 })
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -99,7 +99,7 @@ export const omitEmpty = <T>(array: Array<T | null | undefined>): Array<T> => {
   return result
 }
 
-export const normalizeUrl = (url: string, baseUrl: string | undefined): string => {
+export const resolveUrl = (url: string, baseUrl: string | undefined): string => {
   return baseUrl ? new URL(url, baseUrl).href : url
 }
 

--- a/src/exports/index.ts
+++ b/src/exports/index.ts
@@ -9,7 +9,7 @@ export type {
   DiscoverInputObject,
   DiscoverMethod,
   DiscoverMethodsConfig,
-  DiscoverNormalizeUrlFn,
+  DiscoverResolveUrlFn,
   DiscoverOnProgressFn,
   DiscoverOptions,
   DiscoverProgress,

--- a/src/favicons/index.ts
+++ b/src/favicons/index.ts
@@ -1,7 +1,7 @@
 import { discover } from '../common/discover/index.js'
 import { defaultFetchFn, defaultResolveSiteUrlFn } from '../common/discover/utils.js'
 import type { DiscoverInput, DiscoverOptions, DiscoverResult } from '../common/types.js'
-import { normalizeUrl } from '../common/utils.js'
+import { resolveUrl } from '../common/utils.js'
 import {
   defaultFeedOptions,
   defaultGuessOptions,
@@ -23,7 +23,7 @@ export const discoverFavicons = <TValid extends FaviconResult = FaviconResult>(
       methods: options.methods ?? ['platform', 'feed', 'html', 'headers', 'guess'],
       fetchFn: options.fetchFn ?? defaultFetchFn,
       extractFn: options.extractFn ?? defaultExtractor,
-      normalizeUrlFn: options.normalizeUrlFn ?? normalizeUrl,
+      resolveUrlFn: options.resolveUrlFn ?? resolveUrl,
       resolveSiteUrlFn: options.resolveSiteUrlFn ?? defaultResolveSiteUrlFn,
     },
     {

--- a/src/feeds/extractors.ts
+++ b/src/feeds/extractors.ts
@@ -1,7 +1,7 @@
 import { parseFeed } from 'feedsmith'
 import { getFeedSiteUrl } from '../common/discover/utils.js'
 import type { DiscoverExtractFn } from '../common/types.js'
-import { normalizeUrl } from '../common/utils.js'
+import { resolveUrl } from '../common/utils.js'
 import type { FeedResult } from './types.js'
 
 export const defaultExtractor: DiscoverExtractFn<FeedResult> = ({ content, url }) => {
@@ -13,7 +13,7 @@ export const defaultExtractor: DiscoverExtractFn<FeedResult> = ({ content, url }
     const parsed = parseFeed(content)
     const { format, feed } = parsed
     const rawSiteUrl = getFeedSiteUrl(parsed)
-    const siteUrl = rawSiteUrl ? normalizeUrl(rawSiteUrl, url) : undefined
+    const siteUrl = rawSiteUrl ? resolveUrl(rawSiteUrl, url) : undefined
 
     if (format === 'rss' || format === 'rdf') {
       return {

--- a/src/feeds/index.ts
+++ b/src/feeds/index.ts
@@ -1,7 +1,7 @@
 import { discover } from '../common/discover/index.js'
 import { defaultFetchFn } from '../common/discover/utils.js'
 import type { DiscoverInput, DiscoverOptions, DiscoverResult } from '../common/types.js'
-import { normalizeUrl } from '../common/utils.js'
+import { resolveUrl } from '../common/utils.js'
 import {
   defaultGuessOptions,
   defaultHeadersOptions,
@@ -22,7 +22,7 @@ export const discoverFeeds = <TValid extends FeedResult = FeedResult>(
       methods: options.methods ?? ['platform', 'html', 'headers', 'guess'],
       fetchFn: options.fetchFn ?? defaultFetchFn,
       extractFn: options.extractFn ?? defaultExtractor,
-      normalizeUrlFn: options.normalizeUrlFn ?? normalizeUrl,
+      resolveUrlFn: options.resolveUrlFn ?? resolveUrl,
       // No resolveSiteUrlFn — feeds discoverer early-returns in extractFn before site resolution.
     },
     {

--- a/src/hubs/discover/index.test.ts
+++ b/src/hubs/discover/index.test.ts
@@ -157,14 +157,14 @@ describe('discoverHubs', () => {
   describe('resolveUrlFn option', () => {
     it('should use custom resolveUrlFn for HTML hubs', async () => {
       const html = '<link rel="hub" href="/hub">'
-      const customNormalizer: DiscoverResolveUrlFn = (url) => {
+      const customResolveUrlFn: DiscoverResolveUrlFn = (url) => {
         return `https://custom.example.com${url}`
       }
       const value = await discoverHubs(
         { url: 'https://example.com/', content: html },
         {
           methods: ['html'],
-          resolveUrlFn: customNormalizer,
+          resolveUrlFn: customResolveUrlFn,
         },
       )
       const expected: Array<HubResult> = [
@@ -181,14 +181,14 @@ describe('discoverHubs', () => {
       const headers = new Headers({
         link: '</hub>; rel="hub"',
       })
-      const customNormalizer: DiscoverResolveUrlFn = (url) => {
+      const customResolveUrlFn: DiscoverResolveUrlFn = (url) => {
         return `https://custom.example.com${url}`
       }
       const value = await discoverHubs(
         { url: 'https://example.com/', headers },
         {
           methods: ['headers'],
-          resolveUrlFn: customNormalizer,
+          resolveUrlFn: customResolveUrlFn,
         },
       )
       const expected: Array<HubResult> = [
@@ -204,7 +204,7 @@ describe('discoverHubs', () => {
     it('should use custom resolveUrlFn for self URLs', async () => {
       const html =
         '<link rel="hub" href="https://hub.example.com/"><link rel="self" href="/feed.xml">'
-      const customNormalizer: DiscoverResolveUrlFn = (url) => {
+      const customResolveUrlFn: DiscoverResolveUrlFn = (url) => {
         if (url.startsWith('/')) {
           return `https://normalized.example.com${url}`
         }
@@ -214,7 +214,7 @@ describe('discoverHubs', () => {
         { url: 'https://example.com/', content: html },
         {
           methods: ['html'],
-          resolveUrlFn: customNormalizer,
+          resolveUrlFn: customResolveUrlFn,
         },
       )
       const expected: Array<HubResult> = [

--- a/src/hubs/discover/index.test.ts
+++ b/src/hubs/discover/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import type { DiscoverFetchFn, DiscoverNormalizeUrlFn } from '../../common/types.js'
+import type { DiscoverFetchFn, DiscoverResolveUrlFn } from '../../common/types.js'
 import { discoverHubs } from './index.js'
 import type { HubResult } from './types.js'
 
@@ -154,17 +154,17 @@ describe('discoverHubs', () => {
     })
   })
 
-  describe('normalizeUrlFn option', () => {
-    it('should use custom normalizeUrlFn for HTML hubs', async () => {
+  describe('resolveUrlFn option', () => {
+    it('should use custom resolveUrlFn for HTML hubs', async () => {
       const html = '<link rel="hub" href="/hub">'
-      const customNormalizer: DiscoverNormalizeUrlFn = (url) => {
+      const customNormalizer: DiscoverResolveUrlFn = (url) => {
         return `https://custom.example.com${url}`
       }
       const value = await discoverHubs(
         { url: 'https://example.com/', content: html },
         {
           methods: ['html'],
-          normalizeUrlFn: customNormalizer,
+          resolveUrlFn: customNormalizer,
         },
       )
       const expected: Array<HubResult> = [
@@ -177,18 +177,18 @@ describe('discoverHubs', () => {
       expect(value).toEqual(expected)
     })
 
-    it('should use custom normalizeUrlFn for header hubs', async () => {
+    it('should use custom resolveUrlFn for header hubs', async () => {
       const headers = new Headers({
         link: '</hub>; rel="hub"',
       })
-      const customNormalizer: DiscoverNormalizeUrlFn = (url) => {
+      const customNormalizer: DiscoverResolveUrlFn = (url) => {
         return `https://custom.example.com${url}`
       }
       const value = await discoverHubs(
         { url: 'https://example.com/', headers },
         {
           methods: ['headers'],
-          normalizeUrlFn: customNormalizer,
+          resolveUrlFn: customNormalizer,
         },
       )
       const expected: Array<HubResult> = [
@@ -201,10 +201,10 @@ describe('discoverHubs', () => {
       expect(value).toEqual(expected)
     })
 
-    it('should use custom normalizeUrlFn for self URLs', async () => {
+    it('should use custom resolveUrlFn for self URLs', async () => {
       const html =
         '<link rel="hub" href="https://hub.example.com/"><link rel="self" href="/feed.xml">'
-      const customNormalizer: DiscoverNormalizeUrlFn = (url) => {
+      const customNormalizer: DiscoverResolveUrlFn = (url) => {
         if (url.startsWith('/')) {
           return `https://normalized.example.com${url}`
         }
@@ -214,7 +214,7 @@ describe('discoverHubs', () => {
         { url: 'https://example.com/', content: html },
         {
           methods: ['html'],
-          normalizeUrlFn: customNormalizer,
+          resolveUrlFn: customNormalizer,
         },
       )
       const expected: Array<HubResult> = [

--- a/src/hubs/discover/index.ts
+++ b/src/hubs/discover/index.ts
@@ -1,6 +1,6 @@
 import { defaultFetchFn } from '../../common/discover/utils.js'
 import type { DiscoverInput } from '../../common/types.js'
-import { normalizeUrl } from '../../common/utils.js'
+import { resolveUrl } from '../../common/utils.js'
 import { discoverHubsFromFeed } from '../feed/index.js'
 import { discoverHubsFromHeaders } from '../headers/index.js'
 import { discoverHubsFromHtml } from '../html/index.js'
@@ -14,7 +14,7 @@ export const discoverHubs = async (
   const {
     methods = ['headers', 'feed', 'html'],
     fetchFn = defaultFetchFn,
-    normalizeUrlFn = normalizeUrl,
+    resolveUrlFn = resolveUrl,
   } = options
 
   const normalizedInput = await normalizeInput(input, fetchFn)
@@ -24,7 +24,7 @@ export const discoverHubs = async (
     const headerHubs = discoverHubsFromHeaders(
       normalizedInput.headers,
       normalizedInput.url,
-      normalizeUrlFn,
+      resolveUrlFn,
     )
     results.push(...headerHubs)
   }
@@ -33,7 +33,7 @@ export const discoverHubs = async (
     const feedHubs = discoverHubsFromFeed(
       normalizedInput.content,
       normalizedInput.url,
-      normalizeUrlFn,
+      resolveUrlFn,
     )
     results.push(...feedHubs)
   }
@@ -42,7 +42,7 @@ export const discoverHubs = async (
     const htmlHubs = discoverHubsFromHtml(
       normalizedInput.content,
       normalizedInput.url,
-      normalizeUrlFn,
+      resolveUrlFn,
     )
     results.push(...htmlHubs)
   }

--- a/src/hubs/discover/types.ts
+++ b/src/hubs/discover/types.ts
@@ -1,4 +1,4 @@
-import type { DiscoverFetchFn, DiscoverNormalizeUrlFn } from '../../common/types.js'
+import type { DiscoverFetchFn, DiscoverResolveUrlFn } from '../../common/types.js'
 
 export type HubResult = {
   hub: string
@@ -10,5 +10,5 @@ export type DiscoverHubsMethodsConfig = Array<'headers' | 'html' | 'feed'>
 export type DiscoverHubsOptions = {
   methods?: DiscoverHubsMethodsConfig
   fetchFn?: DiscoverFetchFn
-  normalizeUrlFn?: DiscoverNormalizeUrlFn
+  resolveUrlFn?: DiscoverResolveUrlFn
 }

--- a/src/hubs/feed/index.test.ts
+++ b/src/hubs/feed/index.test.ts
@@ -283,10 +283,10 @@ describe('discoverHubsFromFeed', () => {
         <link href="/feed.xml" rel="self"/>
       </feed>
     `
-    const customNormalizer: DiscoverResolveUrlFn = (url) => {
+    const customResolveUrlFn: DiscoverResolveUrlFn = (url) => {
       return `https://custom.example.com${url}`
     }
-    const value = discoverHubsFromFeed(content, 'https://example.com/feed.xml', customNormalizer)
+    const value = discoverHubsFromFeed(content, 'https://example.com/feed.xml', customResolveUrlFn)
     const expected: Array<HubResult> = [
       {
         hub: 'https://custom.example.com/hub',

--- a/src/hubs/feed/index.test.ts
+++ b/src/hubs/feed/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import type { DiscoverNormalizeUrlFn } from '../../common/types.js'
+import type { DiscoverResolveUrlFn } from '../../common/types.js'
 import type { HubResult } from '../discover/types.js'
 import { discoverHubsFromFeed } from './index.js'
 
@@ -274,7 +274,7 @@ describe('discoverHubsFromFeed', () => {
     expect(value).toEqual(expected)
   })
 
-  it('should apply custom normalizeUrlFn to hub and topic URLs', () => {
+  it('should apply custom resolveUrlFn to hub and topic URLs', () => {
     const content = `
       <?xml version="1.0" encoding="utf-8"?>
       <feed xmlns="http://www.w3.org/2005/Atom">
@@ -283,7 +283,7 @@ describe('discoverHubsFromFeed', () => {
         <link href="/feed.xml" rel="self"/>
       </feed>
     `
-    const customNormalizer: DiscoverNormalizeUrlFn = (url) => {
+    const customNormalizer: DiscoverResolveUrlFn = (url) => {
       return `https://custom.example.com${url}`
     }
     const value = discoverHubsFromFeed(content, 'https://example.com/feed.xml', customNormalizer)

--- a/src/hubs/feed/index.ts
+++ b/src/hubs/feed/index.ts
@@ -1,7 +1,7 @@
 import { parseFeed } from 'feedsmith'
 import type { Atom, DeepPartial } from 'feedsmith/types'
-import type { DiscoverNormalizeUrlFn } from '../../common/types.js'
-import { normalizeUrl } from '../../common/utils.js'
+import type { DiscoverResolveUrlFn } from '../../common/types.js'
+import { resolveUrl } from '../../common/utils.js'
 import type { HubResult } from '../discover/types.js'
 
 const getLinksWithRel = (
@@ -16,7 +16,7 @@ const getLinksWithRel = (
 export const discoverHubsFromFeed = (
   content: string,
   baseUrl: string,
-  normalizeUrlFn: DiscoverNormalizeUrlFn = normalizeUrl,
+  resolveUrlFn: DiscoverResolveUrlFn = resolveUrl,
 ): Array<HubResult> => {
   try {
     const { format, feed } = parseFeed(content)
@@ -24,12 +24,12 @@ export const discoverHubsFromFeed = (
     // JSON Feed has native hubs support.
     if (format === 'json') {
       const hubs = feed.hubs ?? []
-      const topic = feed.feed_url ? normalizeUrlFn(feed.feed_url, baseUrl) : baseUrl
+      const topic = feed.feed_url ? resolveUrlFn(feed.feed_url, baseUrl) : baseUrl
 
       return hubs
         .filter((hub) => hub.url)
         .map((hub) => ({
-          hub: normalizeUrlFn(hub.url as string, baseUrl),
+          hub: resolveUrlFn(hub.url as string, baseUrl),
           topic,
         }))
     }
@@ -40,10 +40,10 @@ export const discoverHubsFromFeed = (
 
     if (hubUris.length > 0) {
       const selfUris = getLinksWithRel(links, 'self')
-      const topic = selfUris[0] ? normalizeUrlFn(selfUris[0], baseUrl) : baseUrl
+      const topic = selfUris[0] ? resolveUrlFn(selfUris[0], baseUrl) : baseUrl
 
       return hubUris.map((hub) => ({
-        hub: normalizeUrlFn(hub, baseUrl),
+        hub: resolveUrlFn(hub, baseUrl),
         topic,
       }))
     }

--- a/src/hubs/headers/index.test.ts
+++ b/src/hubs/headers/index.test.ts
@@ -137,7 +137,7 @@ describe('discoverHubsFromHeaders', () => {
     expect(value).toEqual(expected)
   })
 
-  it('should apply custom normalizeUrlFn to hub and topic URLs', () => {
+  it('should apply custom resolveUrlFn to hub and topic URLs', () => {
     const headers = new Headers({
       link: '</hub>; rel="hub", </feed.xml>; rel="self"',
     })

--- a/src/hubs/headers/index.test.ts
+++ b/src/hubs/headers/index.test.ts
@@ -141,10 +141,10 @@ describe('discoverHubsFromHeaders', () => {
     const headers = new Headers({
       link: '</hub>; rel="hub", </feed.xml>; rel="self"',
     })
-    const customNormalizer = (url: string) => {
+    const customResolveUrlFn = (url: string) => {
       return `https://custom.example.com${url}`
     }
-    const value = discoverHubsFromHeaders(headers, 'https://example.com/feed.xml', customNormalizer)
+    const value = discoverHubsFromHeaders(headers, 'https://example.com/feed.xml', customResolveUrlFn)
     const expected: Array<HubResult> = [
       {
         hub: 'https://custom.example.com/hub',

--- a/src/hubs/headers/index.ts
+++ b/src/hubs/headers/index.ts
@@ -1,6 +1,6 @@
-import type { DiscoverNormalizeUrlFn } from '../../common/types.js'
+import type { DiscoverResolveUrlFn } from '../../common/types.js'
 import { discoverUrisFromHeaders } from '../../common/uris/headers/index.js'
-import { normalizeUrl } from '../../common/utils.js'
+import { resolveUrl } from '../../common/utils.js'
 import type { HubResult } from '../discover/types.js'
 
 const hubSelector = [{ rel: 'hub' }]
@@ -9,7 +9,7 @@ const selfSelector = [{ rel: 'self' }]
 export const discoverHubsFromHeaders = (
   headers: Headers,
   baseUrl: string,
-  normalizeUrlFn: DiscoverNormalizeUrlFn = normalizeUrl,
+  resolveUrlFn: DiscoverResolveUrlFn = resolveUrl,
 ): Array<HubResult> => {
   const hubUris = discoverUrisFromHeaders(headers, { linkSelectors: hubSelector })
 
@@ -18,10 +18,10 @@ export const discoverHubsFromHeaders = (
   }
 
   const selfUris = discoverUrisFromHeaders(headers, { linkSelectors: selfSelector })
-  const topic = selfUris[0] ? normalizeUrlFn(selfUris[0], baseUrl) : baseUrl
+  const topic = selfUris[0] ? resolveUrlFn(selfUris[0], baseUrl) : baseUrl
 
   return hubUris.map((hub) => ({
-    hub: normalizeUrlFn(hub, baseUrl),
+    hub: resolveUrlFn(hub, baseUrl),
     topic,
   }))
 }

--- a/src/hubs/html/index.test.ts
+++ b/src/hubs/html/index.test.ts
@@ -97,8 +97,8 @@ describe('discoverHubsFromHtml', () => {
 
   it('should apply custom resolveUrlFn', () => {
     const html = '<link rel="hub" href="/hub">'
-    const customNormalizer = (url: string) => `https://custom.example.com${url}`
-    const value = discoverHubsFromHtml(html, 'https://example.com/', customNormalizer)
+    const customResolveUrlFn = (url: string) => `https://custom.example.com${url}`
+    const value = discoverHubsFromHtml(html, 'https://example.com/', customResolveUrlFn)
     const expected: Array<HubResult> = [
       {
         hub: 'https://custom.example.com/hub',

--- a/src/hubs/html/index.test.ts
+++ b/src/hubs/html/index.test.ts
@@ -95,7 +95,7 @@ describe('discoverHubsFromHtml', () => {
     expect(value).toEqual(expected)
   })
 
-  it('should apply custom normalizeUrlFn', () => {
+  it('should apply custom resolveUrlFn', () => {
     const html = '<link rel="hub" href="/hub">'
     const customNormalizer = (url: string) => `https://custom.example.com${url}`
     const value = discoverHubsFromHtml(html, 'https://example.com/', customNormalizer)

--- a/src/hubs/html/index.ts
+++ b/src/hubs/html/index.ts
@@ -1,6 +1,6 @@
-import type { DiscoverNormalizeUrlFn } from '../../common/types.js'
+import type { DiscoverResolveUrlFn } from '../../common/types.js'
 import { discoverUrisFromHtml } from '../../common/uris/html/index.js'
-import { normalizeUrl } from '../../common/utils.js'
+import { resolveUrl } from '../../common/utils.js'
 import type { HubResult } from '../discover/types.js'
 
 const hubSelector = [{ rel: 'hub' }]
@@ -15,7 +15,7 @@ const htmlOptions = {
 export const discoverHubsFromHtml = (
   content: string,
   baseUrl: string,
-  normalizeUrlFn: DiscoverNormalizeUrlFn = normalizeUrl,
+  resolveUrlFn: DiscoverResolveUrlFn = resolveUrl,
 ): Array<HubResult> => {
   const hubUris = discoverUrisFromHtml(content, { ...htmlOptions, linkSelectors: hubSelector })
 
@@ -24,10 +24,10 @@ export const discoverHubsFromHtml = (
   }
 
   const selfUris = discoverUrisFromHtml(content, { ...htmlOptions, linkSelectors: selfSelector })
-  const topic = selfUris[0] ? normalizeUrlFn(selfUris[0], baseUrl) : baseUrl
+  const topic = selfUris[0] ? resolveUrlFn(selfUris[0], baseUrl) : baseUrl
 
   return hubUris.map((hub) => ({
-    hub: normalizeUrlFn(hub, baseUrl),
+    hub: resolveUrlFn(hub, baseUrl),
     topic,
   }))
 }


### PR DESCRIPTION
Rename `normalizeUrl` to `resolveUrl` across the codebase: the function resolves relative URLs against a base, it doesn't normalize anything.

- `normalizeUrl` → `resolveUrl`
- `normalizeUrlFn` → `resolveUrlFn`
- `DiscoverNormalizeUrlFn` → `DiscoverResolveUrlFn`
- `customNormalizer` → `customResolveUrlFn` in tests
- Docs and nav updated accordingly