### PR TITLE
feat: Support RegExp patterns in HTML anchor URI matching

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -6,6 +6,8 @@ import type { PlatformMethodOptions } from './uris/platform/types.js'
 
 export type MaybePromise<T> = T | Promise<T>
 
+export type Pattern = string | RegExp
+
 export type UriEntry = string | Array<string>
 
 export type DiscoverUriHint = {

--- a/src/common/uris/html/handlers.test.ts
+++ b/src/common/uris/html/handlers.test.ts
@@ -14,7 +14,8 @@ const createMockContext = (): HtmlMethodContext => {
         { rel: 'alternate', types: ['application/rss+xml', 'application/atom+xml'] },
         { rel: 'feed' },
       ],
-      anchorUris: ['/feed', '/rss', '/atom.xml'],
+      // biome-ignore lint/performance/useTopLevelRegex: Test-specific patterns.
+      anchorUris: ['/feed', '/rss', '/atom.xml', /\/rss\//, /\/atom\//, /\/feed\//],
       anchorIgnoredUris: ['#', 'javascript:', 'mailto:'],
       anchorLabels: ['rss', 'feed', 'atom'],
     },
@@ -253,6 +254,22 @@ describe('handleOpenTag', () => {
     handleOpenTag(value, 'a', { href: '/blog/feed' })
 
     expect(value.discoveredUris.has('/blog/feed')).toBe(true)
+  })
+
+  it('should add anchor tag with href matching a RegExp pattern', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: '/rss/now.xml' })
+
+    expect(value.discoveredUris.has('/rss/now.xml')).toBe(true)
+  })
+
+  it('should not add anchor tag when href does not match any RegExp pattern', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: '/blog/post.html' })
+
+    expect(value.discoveredUris.has('/blog/post.html')).toBe(false)
   })
 })
 

--- a/src/common/uris/html/index.test.ts
+++ b/src/common/uris/html/index.test.ts
@@ -50,9 +50,11 @@ const anchorIgnoredUris = ['wp-json/oembed/', 'wp-json/wp/']
 
 const anchorLabels = ['rss', 'feed', 'atom', 'subscribe', 'syndicate', 'json feed']
 
+const anchorPathSegments = [/\/rss\//, /\/atom\//, /\/feed\//]
+
 const defaultOptions: HtmlMethodOptions = {
   linkSelectors: [{ rel: 'alternate', types: linkMimeTypes }, { rel: 'feed' }],
-  anchorUris,
+  anchorUris: [...anchorUris, ...anchorPathSegments],
   anchorIgnoredUris,
   anchorLabels,
 }
@@ -283,11 +285,12 @@ describe('discoverUrisFromHtml', () => {
       expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
     })
 
-    it('should not match anchor if URI not at end', () => {
+    it('should not match anchor by suffix if URI not at end', () => {
       const value = '<a href="/feed/comments">Comments</a>'
       const expected: Array<string> = []
 
-      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+      // Uses string-only anchorUris to test pure suffix matching behavior.
+      expect(discoverUrisFromHtml(value, { ...defaultOptions, anchorUris })).toEqual(expected)
     })
 
     it('should ignore wp-json/oembed/ URI', () => {
@@ -300,6 +303,50 @@ describe('discoverUrisFromHtml', () => {
     it('should ignore wp-json/wp/ URI', () => {
       const value = '<a href="/wp-json/wp/v2/posts">Posts</a>'
       const expected: Array<string> = []
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+  })
+
+  describe('anchor elements by href path segment', () => {
+    it('should find anchor with /rss/ in path', () => {
+      const value = '<a href="/rss/now.xml"><svg></svg></a>'
+      const expected = ['/rss/now.xml']
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should find anchor with /atom/ in path', () => {
+      const value = '<a href="/atom/entries.xml">Link</a>'
+      const expected = ['/atom/entries.xml']
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should find anchor with /feed/ in path', () => {
+      const value = '<a href="/feed/podcast.xml">Link</a>'
+      const expected = ['/feed/podcast.xml']
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should not match without full path segment', () => {
+      const value = '<a href="/my-rss-page">Link</a>'
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should handle case-insensitive path segments', () => {
+      const value = '<a href="/RSS/now.xml"><svg></svg></a>'
+      const expected = ['/RSS/now.xml']
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should deduplicate with suffix matching', () => {
+      const value = '<a href="/blog/feed/">Feed</a>'
+      const expected = ['/blog/feed/']
 
       expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
     })
@@ -443,6 +490,19 @@ describe('discoverUrisFromHtml', () => {
         discoverUrisFromHtml(value, {
           ...defaultOptions,
           anchorUris: ['/custom-feed'],
+        }),
+      ).toEqual(expected)
+    })
+
+    it('should use custom RegExp anchorUris', () => {
+      const value = '<a href="/podcast/episodes.xml">Link</a>'
+      const expected = ['/podcast/episodes.xml']
+
+      expect(
+        discoverUrisFromHtml(value, {
+          ...defaultOptions,
+          // biome-ignore lint/performance/useTopLevelRegex: Test-specific pattern.
+          anchorUris: [/\/podcast\//],
         }),
       ).toEqual(expected)
     })

--- a/src/common/uris/html/types.ts
+++ b/src/common/uris/html/types.ts
@@ -1,11 +1,11 @@
-import type { LinkSelector } from '../../types.js'
+import type { LinkSelector, Pattern } from '../../types.js'
 
 export type HtmlMethodOptions = {
   baseUrl?: string
   linkSelectors: Array<LinkSelector>
-  anchorUris: Array<string>
-  anchorIgnoredUris: Array<string>
-  anchorLabels: Array<string>
+  anchorUris: Array<Pattern>
+  anchorIgnoredUris: Array<Pattern>
+  anchorLabels: Array<Pattern>
 }
 
 export type HtmlMethodContext = {

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -349,6 +349,30 @@ describe('includesAnyOf', () => {
   it('should return false when pattern is empty string', () => {
     expect(includesAnyOf('anything', [''])).toBe(false)
   })
+
+  it('should return true when value matches a RegExp pattern', () => {
+    const value = '/rss/now.xml'
+    // biome-ignore lint/performance/useTopLevelRegex: Test-specific pattern.
+    const patterns = [/\/rss\//]
+
+    expect(includesAnyOf(value, patterns)).toBe(true)
+  })
+
+  it('should return false when value does not match a RegExp pattern', () => {
+    const value = '/blog/post.html'
+    // biome-ignore lint/performance/useTopLevelRegex: Test-specific pattern.
+    const patterns = [/\/rss\//]
+
+    expect(includesAnyOf(value, patterns)).toBe(false)
+  })
+
+  it('should handle mixed string and RegExp patterns', () => {
+    const value = '/rss/now.xml'
+    // biome-ignore lint/performance/useTopLevelRegex: Test-specific pattern.
+    const patterns = ['atom', /\/rss\//]
+
+    expect(includesAnyOf(value, patterns)).toBe(true)
+  })
 })
 
 describe('isAnyOf', () => {
@@ -464,6 +488,22 @@ describe('isAnyOf', () => {
     const patterns = ['', 'application/rss+xml']
 
     expect(isAnyOf(value, patterns)).toBe(true)
+  })
+
+  it('should return true when value matches a RegExp pattern', () => {
+    const value = 'application/rss+xml'
+    // biome-ignore lint/performance/useTopLevelRegex: Test-specific pattern.
+    const patterns = [/^application\/rss/]
+
+    expect(isAnyOf(value, patterns)).toBe(true)
+  })
+
+  it('should return false when value does not match a RegExp pattern', () => {
+    const value = 'text/html'
+    // biome-ignore lint/performance/useTopLevelRegex: Test-specific pattern.
+    const patterns = [/^application\/rss/]
+
+    expect(isAnyOf(value, patterns)).toBe(false)
   })
 })
 
@@ -709,6 +749,22 @@ describe('anyWordMatchesAnyOf', () => {
 
     expect(anyWordMatchesAnyOf(value, patterns)).toBe(false)
   })
+
+  it('should return true when a word matches a RegExp pattern', () => {
+    const value = 'alternate feed'
+    // biome-ignore lint/performance/useTopLevelRegex: Test-specific pattern.
+    const patterns = [/^feed$/]
+
+    expect(anyWordMatchesAnyOf(value, patterns)).toBe(true)
+  })
+
+  it('should return false when no word matches a RegExp pattern', () => {
+    const value = 'alternate stylesheet'
+    // biome-ignore lint/performance/useTopLevelRegex: Test-specific pattern.
+    const patterns = [/^feed$/]
+
+    expect(anyWordMatchesAnyOf(value, patterns)).toBe(false)
+  })
 })
 
 describe('endsWithAnyOf', () => {
@@ -763,6 +819,30 @@ describe('endsWithAnyOf', () => {
 
   it('should return false when pattern is empty string', () => {
     expect(endsWithAnyOf('anything', [''])).toBe(false)
+  })
+
+  it('should return true when value matches a RegExp pattern', () => {
+    const value = '/rss/now.xml'
+    // biome-ignore lint/performance/useTopLevelRegex: Test-specific pattern.
+    const patterns = [/\/rss\//]
+
+    expect(endsWithAnyOf(value, patterns)).toBe(true)
+  })
+
+  it('should return false when value does not match a RegExp pattern', () => {
+    const value = '/blog/post.html'
+    // biome-ignore lint/performance/useTopLevelRegex: Test-specific pattern.
+    const patterns = [/\/rss\//]
+
+    expect(endsWithAnyOf(value, patterns)).toBe(false)
+  })
+
+  it('should handle mixed string and RegExp patterns', () => {
+    const value = '/rss/now.xml'
+    // biome-ignore lint/performance/useTopLevelRegex: Test-specific pattern.
+    const patterns = ['.html', /\/rss\//]
+
+    expect(endsWithAnyOf(value, patterns)).toBe(true)
   })
 })
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,5 +1,5 @@
 import locales from './locales.json' with { type: 'json' }
-import type { DiscoverUriHint } from './types.js'
+import type { DiscoverUriHint, Pattern } from './types.js'
 
 const whitespaceRegex = /\s+/
 
@@ -33,30 +33,52 @@ export const isHostOf = (url: string, hosts: string | Array<string>): boolean =>
 
 export const includesAnyOf = (
   value: string,
-  patterns: Array<string>,
+  patterns: Array<Pattern>,
   parser?: (value: string) => string,
 ): boolean => {
   const parsedValue = parser ? parser(value) : value?.toLowerCase()
-  return patterns.some((pattern) => pattern && parsedValue?.includes(pattern.toLowerCase()))
+
+  return patterns.some((pattern) => {
+    if (pattern instanceof RegExp) {
+      return pattern.test(parsedValue)
+    }
+
+    return pattern && parsedValue?.includes(pattern.toLowerCase())
+  })
 }
 
 export const isAnyOf = (
   value: string,
-  patterns: Array<string>,
+  patterns: Array<Pattern>,
   parser?: (value: string) => string,
 ): boolean => {
   const parsedValue = parser ? parser(value) : value?.toLowerCase()?.trim()
-  return patterns.some((pattern) => parsedValue === pattern.toLowerCase().trim())
+
+  return patterns.some((pattern) => {
+    if (pattern instanceof RegExp) {
+      return pattern.test(parsedValue)
+    }
+
+    return parsedValue === pattern.toLowerCase().trim()
+  })
 }
 
-export const anyWordMatchesAnyOf = (value: string, patterns: Array<string>): boolean => {
+export const anyWordMatchesAnyOf = (value: string, patterns: Array<Pattern>): boolean => {
   const words = value.toLowerCase().split(whitespaceRegex)
+
   return words.some((word) => isAnyOf(word, patterns))
 }
 
-export const endsWithAnyOf = (value: string, patterns: Array<string>): boolean => {
+export const endsWithAnyOf = (value: string, patterns: Array<Pattern>): boolean => {
   const lowerValue = value.toLowerCase()
-  return patterns.some((pattern) => pattern && lowerValue.endsWith(pattern.toLowerCase()))
+
+  return patterns.some((pattern) => {
+    if (pattern instanceof RegExp) {
+      return pattern.test(lowerValue)
+    }
+
+    return pattern && lowerValue.endsWith(pattern.toLowerCase())
+  })
 }
 
 export const isOfAllowedMimeType = (

--- a/src/exports/utils.ts
+++ b/src/exports/utils.ts
@@ -1,3 +1,4 @@
+export type { Pattern } from '../common/types.js'
 export {
   anyWordMatchesAnyOf,
   endsWithAnyOf,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -124,10 +124,13 @@ export const linkSelectors: Array<LinkSelector> = [
   { rel: 'feed' },
 ]
 
+// Path segments that indicate feed URLs when found within anchor hrefs.
+export const anchorPathSegments = [/\/rss\//, /\/atom\//, /\/feed\//]
+
 // Default options for HTML method.
 export const defaultHtmlOptions: Omit<HtmlMethodOptions, 'baseUrl'> = {
   linkSelectors,
-  anchorUris: urisComprehensive.flat(),
+  anchorUris: [...urisComprehensive.flat(), ...anchorPathSegments],
   anchorIgnoredUris: ignoredUris,
   anchorLabels,
 }


### PR DESCRIPTION
Widen `anchorUris`, `anchorIgnoredUris`, and `anchorLabels` in `HtmlMethodOptions` from `Array<string>` to `Array<Pattern>` (`string | RegExp`). Strings keep their existing matching behavior (endsWith/includes), RegExps use `.test()`.

This enables discovering feeds from `<a>` tags like `<a href="/rss/now.xml"><svg>...</svg></a>` that were previously missed because:
- The href doesn't end with any known suffix pattern
- The anchor contains no text (only an SVG icon)

By adding `/\/rss\//`, `/\/atom\//`, `/\/feed\//` regex patterns to the default `anchorUris`, feeds with these path segments are now discoverable regardless of what follows in the URL.

Changes:
- Add `Pattern` type alias (`string | RegExp`) to `common/types.ts`
- Update `includesAnyOf`, `endsWithAnyOf`, `isAnyOf`, `anyWordMatchesAnyOf` utilities to accept `Array<Pattern>`
- Widen all anchor option types in `HtmlMethodOptions` to `Array<Pattern>`
- Add path segment regex patterns to feeds HTML defaults
- Export `Pattern` type from `exports/utils.ts`