### PR TITLE
feat: Add microformat (h-feed/h-entry) detection in HTML discovery

### DIFF
--- a/src/common/uris/html/handlers.test.ts
+++ b/src/common/uris/html/handlers.test.ts
@@ -9,6 +9,7 @@ const createMockContext = (): HtmlMethodContext => {
       href: '',
       text: '',
     },
+    foundMicroformat: false,
     options: {
       linkSelectors: [
         { rel: 'alternate', types: ['application/rss+xml', 'application/atom+xml'] },
@@ -253,6 +254,69 @@ describe('handleOpenTag', () => {
     handleOpenTag(value, 'a', { href: '/blog/feed' })
 
     expect(value.discoveredUris.has('/blog/feed')).toBe(true)
+  })
+
+  it('should set foundMicroformat when element has class h-feed', () => {
+    const value = createMockContext()
+    value.options.microformatClasses = ['h-feed', 'h-entry']
+
+    handleOpenTag(value, 'div', { class: 'h-feed' })
+
+    expect(value.foundMicroformat).toBe(true)
+  })
+
+  it('should set foundMicroformat when element has class h-entry', () => {
+    const value = createMockContext()
+    value.options.microformatClasses = ['h-feed', 'h-entry']
+
+    handleOpenTag(value, 'article', { class: 'h-entry' })
+
+    expect(value.foundMicroformat).toBe(true)
+  })
+
+  it('should set foundMicroformat when h-entry is in compound class', () => {
+    const value = createMockContext()
+    value.options.microformatClasses = ['h-feed', 'h-entry']
+
+    handleOpenTag(value, 'article', { class: 'post h-entry h-card' })
+
+    expect(value.foundMicroformat).toBe(true)
+  })
+
+  it('should not set foundMicroformat when microformatClasses is not set', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'div', { class: 'h-feed' })
+
+    expect(value.foundMicroformat).toBe(false)
+  })
+
+  it('should not set foundMicroformat for unrelated classes', () => {
+    const value = createMockContext()
+    value.options.microformatClasses = ['h-feed', 'h-entry']
+
+    handleOpenTag(value, 'div', { class: 'blog-post article' })
+
+    expect(value.foundMicroformat).toBe(false)
+  })
+
+  it('should handle case-insensitive microformat class matching', () => {
+    const value = createMockContext()
+    value.options.microformatClasses = ['h-feed', 'h-entry']
+
+    handleOpenTag(value, 'div', { class: 'H-Feed' })
+
+    expect(value.foundMicroformat).toBe(true)
+  })
+
+  it('should not re-check once foundMicroformat is true', () => {
+    const value = createMockContext()
+    value.options.microformatClasses = ['h-feed', 'h-entry']
+    value.foundMicroformat = true
+
+    handleOpenTag(value, 'div', { class: 'some-other-class' })
+
+    expect(value.foundMicroformat).toBe(true)
   })
 })
 

--- a/src/common/uris/html/handlers.ts
+++ b/src/common/uris/html/handlers.ts
@@ -2,6 +2,8 @@ import type { Handler } from 'htmlparser2'
 import { endsWithAnyOf, includesAnyOf, matchesAnyOfLinkSelectors } from '../../../common/utils.js'
 import type { HtmlMethodContext } from './types.js'
 
+const whitespacePattern = /\s+/
+
 export const handleOpenTag = (
   context: HtmlMethodContext,
   name: string,
@@ -38,6 +40,15 @@ export const handleOpenTag = (
     // Check if href ends with any anchor URI pattern.
     if (endsWithAnyOf(lowerHref, context.options.anchorUris)) {
       context.discoveredUris.add(attribs.href)
+    }
+  }
+
+  // Detect microformat classes indicating the page itself is a feed.
+  if (!context.foundMicroformat && context.options.microformatClasses?.length && attribs.class) {
+    const classes = attribs.class.toLowerCase().split(whitespacePattern)
+
+    if (context.options.microformatClasses.some((mf) => classes.includes(mf.toLowerCase()))) {
+      context.foundMicroformat = true
     }
   }
 }

--- a/src/common/uris/html/index.test.ts
+++ b/src/common/uris/html/index.test.ts
@@ -720,6 +720,111 @@ describe('discoverUrisFromHtml', () => {
     })
   })
 
+  describe('microformat detection', () => {
+    it('should return baseUrl when h-feed class is detected', () => {
+      const value = '<div class="h-feed"><article class="h-entry"><p>Post</p></article></div>'
+      const expected = ['https://example.com']
+
+      expect(
+        discoverUrisFromHtml(value, {
+          ...defaultOptions,
+          baseUrl: 'https://example.com',
+          microformatClasses: ['h-feed', 'h-entry'],
+        }),
+      ).toEqual(expected)
+    })
+
+    it('should return baseUrl when h-entry class is detected', () => {
+      const value = '<article class="h-entry"><p>Post</p></article>'
+      const expected = ['https://example.com']
+
+      expect(
+        discoverUrisFromHtml(value, {
+          ...defaultOptions,
+          baseUrl: 'https://example.com',
+          microformatClasses: ['h-feed', 'h-entry'],
+        }),
+      ).toEqual(expected)
+    })
+
+    it('should return baseUrl with compound class', () => {
+      const value = '<article class="post h-entry h-card"><p>Post</p></article>'
+      const expected = ['https://example.com']
+
+      expect(
+        discoverUrisFromHtml(value, {
+          ...defaultOptions,
+          baseUrl: 'https://example.com',
+          microformatClasses: ['h-feed', 'h-entry'],
+        }),
+      ).toEqual(expected)
+    })
+
+    it('should not return baseUrl when microformatClasses is not configured', () => {
+      const value = '<div class="h-feed"><article class="h-entry"><p>Post</p></article></div>'
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should not return baseUrl when no microformat classes found', () => {
+      const value = '<div class="blog"><article class="post"><p>Post</p></article></div>'
+      const expected: Array<string> = []
+
+      expect(
+        discoverUrisFromHtml(value, {
+          ...defaultOptions,
+          baseUrl: 'https://example.com',
+          microformatClasses: ['h-feed', 'h-entry'],
+        }),
+      ).toEqual(expected)
+    })
+
+    it('should not return baseUrl when baseUrl is not set', () => {
+      const value = '<div class="h-feed"><article class="h-entry"><p>Post</p></article></div>'
+      const expected: Array<string> = []
+
+      expect(
+        discoverUrisFromHtml(value, {
+          ...defaultOptions,
+          microformatClasses: ['h-feed', 'h-entry'],
+        }),
+      ).toEqual(expected)
+    })
+
+    it('should combine microformat detection with link discovery', () => {
+      const value = `
+        <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+        <div class="h-feed"><article class="h-entry"><p>Post</p></article></div>
+      `
+      const expected = ['/feed.xml', 'https://example.com']
+
+      expect(
+        discoverUrisFromHtml(value, {
+          ...defaultOptions,
+          baseUrl: 'https://example.com',
+          microformatClasses: ['h-feed', 'h-entry'],
+        }),
+      ).toEqual(expected)
+    })
+
+    it('should deduplicate when baseUrl already discovered via other means', () => {
+      const value = `
+        <link rel="alternate" type="application/rss+xml" href="https://example.com">
+        <div class="h-feed"><article class="h-entry"><p>Post</p></article></div>
+      `
+      const expected = ['https://example.com']
+
+      expect(
+        discoverUrisFromHtml(value, {
+          ...defaultOptions,
+          baseUrl: 'https://example.com',
+          microformatClasses: ['h-feed', 'h-entry'],
+        }),
+      ).toEqual(expected)
+    })
+  })
+
   describe('exotic edge cases', () => {
     it('should handle very long feed URLs', () => {
       const longUrl = `/feed/${'a'.repeat(1000)}.xml`

--- a/src/common/uris/html/index.ts
+++ b/src/common/uris/html/index.ts
@@ -6,6 +6,7 @@ export const discoverUrisFromHtml = (html: string, options: HtmlMethodOptions): 
   const context: HtmlMethodContext = {
     discoveredUris: new Set<string>(),
     currentAnchor: { href: '', text: '' },
+    foundMicroformat: false,
     options,
   }
 
@@ -14,6 +15,11 @@ export const discoverUrisFromHtml = (html: string, options: HtmlMethodOptions): 
 
   parser.write(html)
   parser.end()
+
+  // If microformat classes detected, the page itself is a feed candidate.
+  if (context.foundMicroformat && options.baseUrl) {
+    context.discoveredUris.add(options.baseUrl)
+  }
 
   return [...context.discoveredUris]
 }

--- a/src/common/uris/html/types.ts
+++ b/src/common/uris/html/types.ts
@@ -6,6 +6,7 @@ export type HtmlMethodOptions = {
   anchorUris: Array<string>
   anchorIgnoredUris: Array<string>
   anchorLabels: Array<string>
+  microformatClasses?: Array<string>
 }
 
 export type HtmlMethodContext = {
@@ -14,5 +15,6 @@ export type HtmlMethodContext = {
     href: string
     text: string
   }
+  foundMicroformat: boolean
   options: HtmlMethodOptions
 }

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -130,6 +130,7 @@ export const defaultHtmlOptions: Omit<HtmlMethodOptions, 'baseUrl'> = {
   anchorUris: urisComprehensive.flat(),
   anchorIgnoredUris: ignoredUris,
   anchorLabels,
+  microformatClasses: ['h-feed', 'h-entry'],
 }
 
 // Default options for Headers method.


### PR DESCRIPTION
This PR detects h-feed and h-entry microformats during HTML discovery, treating a page that carries them as a feed in its own right.

- Extend HTML discovery method to detect h-feed/h-entry microformat classes on HTML elements
- When microformat markup is found, return the page URL itself as a feed candidate (the page IS the feed)
- Add `microformatClasses` option to `HtmlMethodOptions` for configurable class detection
- Enable by default for feed discovery with classes `h-feed` and `h-entry`
- Not enabled for blogrolls, favicons, or hubs (not applicable)
