### PR TITLE
feat: Add Velog platform handler

### DIFF
--- a/check/feeds.json
+++ b/check/feeds.json
@@ -353,6 +353,7 @@
     "https://www.v2ex.com/feed/member/livid.xml",
     "https://www.v2ex.com/feed/tab/tech.xml"
   ],
+  "velog": ["https://v2.velog.io/rss/velopert"],
   "ximalaya": ["https://www.ximalaya.com/album/203355.xml"],
   "youtube": [
     "https://www.youtube.com/feeds/videos.xml?channel_id=UCXuqSBlHAE6Xw-yeJA0Tunw",

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -428,6 +428,14 @@ Discovers RSS feeds for Ximalaya podcast albums.
 |-------------|-----------------|
 | `www.ximalaya.com/album/{id}` | Album feed |
 
+### Velog
+
+Discovers RSS feeds for Velog users.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `velog.io/@{user}` | Posts feed |
+
 ## Basic Usage
 
 ```typescript
@@ -506,6 +514,7 @@ import {
   substackHandler,
   tumblrHandler,
   v2exHandler,
+  velogHandler,
   vimeoHandler,
   wordpressHandler,
   wpengineHandler,

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -127,6 +127,7 @@
     "goodreads:shelf": "Shelf",
     "sourceforge:activity": "Recent activity",
     "sourceforge:files": "File releases",
+    "velog:posts": "Posts",
     "vimeo:videos": "Videos",
     "vimeo:likes": "Likes",
     "vimeo:channel": "Channel",

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -37,6 +37,7 @@ import { steamHandler } from './platform/handlers/steam.js'
 import { substackHandler } from './platform/handlers/substack.js'
 import { tumblrHandler } from './platform/handlers/tumblr.js'
 import { v2exHandler } from './platform/handlers/v2ex.js'
+import { velogHandler } from './platform/handlers/velog.js'
 import { vimeoHandler } from './platform/handlers/vimeo.js'
 import { wordpressHandler } from './platform/handlers/wordpress.js'
 import { wpengineHandler } from './platform/handlers/wpengine.js'
@@ -182,6 +183,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     substackHandler,
     tumblrHandler,
     v2exHandler,
+    velogHandler,
     vimeoHandler,
     wordpressHandler,
     wpengineHandler,

--- a/src/feeds/platform/handlers/velog.test.ts
+++ b/src/feeds/platform/handlers/velog.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { velogHandler } from './velog.js'
+
+describe('velogHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://velog.io/@velopert', true],
+      ['https://www.velog.io/@user', true],
+      ['https://velog.io', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(velogHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(velogHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for user', () => {
+      const value = 'https://velog.io/@velopert'
+      const expected = [
+        {
+          uri: 'https://v2.velog.io/rss/velopert',
+          hint: { key: 'velog:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(velogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://velog.io/@velopert/some-post-slug'
+      const expected = [
+        {
+          uri: 'https://v2.velog.io/rss/velopert',
+          hint: { key: 'velog:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(velogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://velog.io/'
+
+      expect(velogHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for paths without @ prefix', () => {
+      const value = 'https://velog.io/trending'
+
+      expect(velogHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/velog.ts
+++ b/src/feeds/platform/handlers/velog.ts
@@ -1,0 +1,27 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isHostOf } from '../../../common/utils.js'
+
+const hosts = ['velog.io', 'www.velog.io']
+const userRegex = /^\/@([^/]+)/
+
+export const velogHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const userMatch = pathname.match(userRegex)
+
+    if (!userMatch?.[1]) {
+      return []
+    }
+
+    return [
+      {
+        uri: `https://v2.velog.io/rss/${userMatch[1]}`,
+        hint: composeHint('velog:posts'),
+      },
+    ]
+  },
+}


### PR DESCRIPTION
Adds a platform handler for Velog (velog.io), a Korean dev blogging platform. Velog profile pages don't expose RSS via HTML autodiscovery, so the handler is the only way to find these feeds.

## Patterns supported

| URL Pattern | Feeds Generated |
|-------------|-----------------|
| `velog.io/@{user}` | Posts feed |