### PR TITLE
feat: Add Tistory platform handler

### DIFF
--- a/check/feeds.json
+++ b/check/feeds.json
@@ -27,6 +27,7 @@
     "https://codeberg.org/forgejo/forgejo/rss/branch/forgejo",
     "https://codeberg.org/forgejo/forgejo/rss/branch/forgejo/README.md"
   ],
+  "csdn": ["https://rss.csdn.net/csdnnews/rss/map", "https://blog.csdn.net/csdnnews/rss/list"],
   "dailymotion": [
     "https://www.dailymotion.com/rss/Euronews-en",
     "https://www.dailymotion.com/rss/playlist/x5e4h5",
@@ -40,6 +41,16 @@
     "https://backend.deviantart.com/rss.xml?q=journal:yuumei"
   ],
   "devto": ["https://dev.to/feed/ben", "https://dev.to/feed/tag/javascript"],
+  "douban": [
+    "https://www.douban.com/feed/people/ahbei/interests",
+    "https://www.douban.com/feed/people/ahbei/reviews",
+    "https://www.douban.com/feed/people/ahbei/notes",
+    "https://www.douban.com/feed/subject/1084336/reviews",
+    "https://www.douban.com/feed/review/book",
+    "https://www.douban.com/feed/review/movie",
+    "https://www.douban.com/feed/review/music",
+    "https://www.douban.com/feed/review/drama"
+  ],
   "gitea": [
     "https://gitea.com/gitea.rss",
     "https://gitea.com/gitea/go-sdk.rss",
@@ -77,6 +88,39 @@
     "https://www.goodreads.com/review/list_rss/1",
     "https://www.goodreads.com/review/list_rss/1?shelf=read"
   ],
+  "hashnode": ["https://townhall.hashnode.com/rss.xml"],
+  "hatenablog": [
+    "https://staff.hatenablog.com/rss",
+    "https://staff.hatenablog.com/feed",
+    "https://staff.hatenablog.com/rss/category/news",
+    "https://staff.hatenablog.com/feed/category/news",
+    "https://blog.hatenablog.com/rss/author/hatenablog-editors",
+    "https://blog.hatenablog.com/feed/author/hatenablog-editors"
+  ],
+  "itchio": [
+    "https://qeresi.itch.io/a-tale-of-crowns/devlog.rss",
+    "https://itch.io/games/by-leafo.xml",
+    "https://itch.io/games/tag-horror.xml",
+    "https://itch.io/games/platform-web.xml",
+    "https://itch.io/games/genre-puzzle.xml",
+    "https://itch.io/games/made-with-unity.xml",
+    "https://itch.io/games/newest.xml",
+    "https://itch.io/games/top-rated.xml",
+    "https://itch.io/games/top-sellers.xml",
+    "https://itch.io/games/on-sale.xml",
+    "https://itch.io/games.xml",
+    "https://itch.io/devlogs.xml",
+    "https://itch.io/tools.xml",
+    "https://itch.io/game-assets.xml",
+    "https://itch.io/soundtracks.xml",
+    "https://itch.io/physical-games.xml",
+    "https://itch.io/books.xml",
+    "https://itch.io/comics.xml",
+    "https://itch.io/misc.xml",
+    "https://itch.io/feed/featured.xml",
+    "https://itch.io/feed/new.xml",
+    "https://itch.io/feed/sales.xml"
+  ],
   "kickstarter": [
     "https://www.kickstarter.com/projects/elanlee/exploding-kittens/posts.atom",
     "https://www.kickstarter.com/projects/feed.atom"
@@ -98,17 +142,18 @@
     "https://lobste.rs/comments.rss",
     "https://lobste.rs/rss"
   ],
+  "mastodon": [
+    "https://mastodon.social/@Mastodon.rss",
+    "https://mastodon.social/tags/mastodon.rss",
+    "https://mastodon.social/@Gargron/tagged/mastodev.rss"
+  ],
   "medium": [
     "https://medium.com/feed/@ev",
     "https://medium.com/feed/tag/programming",
     "https://medium.com/feed/towards-data-science/tagged/python",
     "https://medium.com/feed/towards-data-science"
   ],
-  "mastodon": [
-    "https://mastodon.social/@Mastodon.rss",
-    "https://mastodon.social/tags/mastodon.rss",
-    "https://mastodon.social/@Gargron/tagged/mastodev.rss"
-  ],
+  "paragraph": ["https://paragraph.com/@blog/feed", "https://paragraph.com/@optimism/rss"],
   "pinterest": ["https://www.pinterest.com/pinterest/feed.rss"],
   "producthunt": [
     "https://www.producthunt.com/feed?topic=artificial-intelligence",
@@ -163,7 +208,14 @@
     "https://newsletter.pragmaticengineer.com/feed",
     "https://garymarcus.substack.com/feed"
   ],
+  "tistory": ["https://notice.tistory.com/rss"],
   "tumblr": ["https://staff.tumblr.com/rss", "https://staff.tumblr.com/tagged/updates/rss"],
+  "v2ex": [
+    "https://www.v2ex.com/index.xml",
+    "https://www.v2ex.com/feed/programmer.xml",
+    "https://www.v2ex.com/feed/member/livid.xml",
+    "https://www.v2ex.com/feed/tab/tech.xml"
+  ],
   "vimeo": [
     "https://vimeo.com/casey/videos/rss",
     "https://vimeo.com/casey/likes/rss",
@@ -301,57 +353,6 @@
     "https://developer.wpengine.com/2023/06/14/?feed=atom",
     "https://developer.wpengine.com/2023/06/14/feed/rdf/",
     "https://developer.wpengine.com/2023/06/14/?feed=rdf"
-  ],
-  "hashnode": ["https://townhall.hashnode.com/rss.xml"],
-  "paragraph": ["https://paragraph.com/@blog/feed", "https://paragraph.com/@optimism/rss"],
-  "hatenablog": [
-    "https://staff.hatenablog.com/rss",
-    "https://staff.hatenablog.com/feed",
-    "https://staff.hatenablog.com/rss/category/news",
-    "https://staff.hatenablog.com/feed/category/news",
-    "https://blog.hatenablog.com/rss/author/hatenablog-editors",
-    "https://blog.hatenablog.com/feed/author/hatenablog-editors"
-  ],
-  "itchio": [
-    "https://qeresi.itch.io/a-tale-of-crowns/devlog.rss",
-    "https://itch.io/games/by-leafo.xml",
-    "https://itch.io/games/tag-horror.xml",
-    "https://itch.io/games/platform-web.xml",
-    "https://itch.io/games/genre-puzzle.xml",
-    "https://itch.io/games/made-with-unity.xml",
-    "https://itch.io/games/newest.xml",
-    "https://itch.io/games/top-rated.xml",
-    "https://itch.io/games/top-sellers.xml",
-    "https://itch.io/games/on-sale.xml",
-    "https://itch.io/games.xml",
-    "https://itch.io/devlogs.xml",
-    "https://itch.io/tools.xml",
-    "https://itch.io/game-assets.xml",
-    "https://itch.io/soundtracks.xml",
-    "https://itch.io/physical-games.xml",
-    "https://itch.io/books.xml",
-    "https://itch.io/comics.xml",
-    "https://itch.io/misc.xml",
-    "https://itch.io/feed/featured.xml",
-    "https://itch.io/feed/new.xml",
-    "https://itch.io/feed/sales.xml"
-  ],
-  "csdn": ["https://rss.csdn.net/csdnnews/rss/map", "https://blog.csdn.net/csdnnews/rss/list"],
-  "douban": [
-    "https://www.douban.com/feed/people/ahbei/interests",
-    "https://www.douban.com/feed/people/ahbei/reviews",
-    "https://www.douban.com/feed/people/ahbei/notes",
-    "https://www.douban.com/feed/subject/1084336/reviews",
-    "https://www.douban.com/feed/review/book",
-    "https://www.douban.com/feed/review/movie",
-    "https://www.douban.com/feed/review/music",
-    "https://www.douban.com/feed/review/drama"
-  ],
-  "v2ex": [
-    "https://www.v2ex.com/index.xml",
-    "https://www.v2ex.com/feed/programmer.xml",
-    "https://www.v2ex.com/feed/member/livid.xml",
-    "https://www.v2ex.com/feed/tab/tech.xml"
   ],
   "ximalaya": ["https://www.ximalaya.com/album/203355.xml"],
   "youtube": [

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -428,6 +428,14 @@ Discovers RSS feeds for Ximalaya podcast albums.
 |-------------|-----------------|
 | `www.ximalaya.com/album/{id}` | Album feed |
 
+### Tistory
+
+Discovers RSS feeds for Tistory blogs.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.tistory.com` | Blog feed |
+
 ## Basic Usage
 
 ```typescript
@@ -510,6 +518,7 @@ import {
   wordpressHandler,
   wpengineHandler,
   ximalayaHandler,
+  tistoryHandler,
   youtubeHandler,
 } from 'feedscout/platform'
 ```

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -163,6 +163,7 @@
     "lemmy:user": "User",
     "lemmy:all": "All",
     "lemmy:local": "Local",
-    "apple-podcasts:podcast": "Podcast"
+    "apple-podcasts:podcast": "Podcast",
+    "tistory:blog": "Blog"
   }
 }

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -35,6 +35,7 @@ import { sourceforgeHandler } from './platform/handlers/sourceforge.js'
 import { stackExchangeHandler } from './platform/handlers/stackExchange.js'
 import { steamHandler } from './platform/handlers/steam.js'
 import { substackHandler } from './platform/handlers/substack.js'
+import { tistoryHandler } from './platform/handlers/tistory.js'
 import { tumblrHandler } from './platform/handlers/tumblr.js'
 import { v2exHandler } from './platform/handlers/v2ex.js'
 import { vimeoHandler } from './platform/handlers/vimeo.js'
@@ -152,18 +153,18 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     behanceHandler,
     blogspotHandler,
     blueskyHandler,
-    csdnHandler,
     codebergHandler,
-    doubanHandler,
-    deviantartHandler,
+    csdnHandler,
     dailymotionHandler,
+    deviantartHandler,
     devtoHandler,
-    goodreadsHandler,
+    doubanHandler,
     githubHandler,
-    hashnodeHandler,
-    hatenablogHandler,
     githubGistHandler,
     gitlabHandler,
+    goodreadsHandler,
+    hashnodeHandler,
+    hatenablogHandler,
     itchioHandler,
     kickstarterHandler,
     lemmyHandler,
@@ -180,6 +181,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     stackExchangeHandler,
     steamHandler,
     substackHandler,
+    tistoryHandler,
     tumblrHandler,
     v2exHandler,
     vimeoHandler,

--- a/src/feeds/platform/handlers/tistory.test.ts
+++ b/src/feeds/platform/handlers/tistory.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+import { tistoryHandler } from './tistory.js'
+
+describe('tistoryHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://headstartup.tistory.com', true],
+      ['https://blog.example.tistory.com', true],
+      ['https://tistory.com', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(tistoryHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(tistoryHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for blog', () => {
+      const value = 'https://headstartup.tistory.com'
+      const expected = [
+        {
+          uri: 'https://headstartup.tistory.com/rss',
+          hint: { key: 'tistory:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(tistoryHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of path', () => {
+      const value = 'https://headstartup.tistory.com/123'
+      const expected = [
+        {
+          uri: 'https://headstartup.tistory.com/rss',
+          hint: { key: 'tistory:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(tistoryHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/tistory.ts
+++ b/src/feeds/platform/handlers/tistory.ts
@@ -1,0 +1,16 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Not discoverable without handler.
+
+export const tistoryHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'tistory.com')
+  },
+
+  resolve: (url) => {
+    const { origin } = new URL(url)
+
+    return [{ uri: `${origin}/rss`, hint: composeHint('tistory:blog') }]
+  },
+}


### PR DESCRIPTION
Discovers RSS feeds for Tistory blogs.

## Patterns supported

| URL Pattern | Feeds Generated |
|-------------|-----------------|
| `*.tistory.com` | Blog feed |
