### PR TITLE
feat: Add Tistory platform handler

### DIFF
--- a/check/feeds.json
+++ b/check/feeds.json
@@ -163,6 +163,7 @@
     "https://newsletter.pragmaticengineer.com/feed",
     "https://garymarcus.substack.com/feed"
   ],
+  "tistory": ["https://notice.tistory.com/rss"],
   "tumblr": ["https://staff.tumblr.com/rss", "https://staff.tumblr.com/tagged/updates/rss"],
   "vimeo": [
     "https://vimeo.com/casey/videos/rss",

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -428,6 +428,14 @@ Discovers RSS feeds for Ximalaya podcast albums.
 |-------------|-----------------|
 | `www.ximalaya.com/album/{id}` | Album feed |
 
+### Tistory
+
+Discovers RSS feeds for Tistory blogs.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.tistory.com` | Blog feed |
+
 ## Basic Usage
 
 ```typescript
@@ -510,6 +518,7 @@ import {
   wordpressHandler,
   wpengineHandler,
   ximalayaHandler,
+  tistoryHandler,
   youtubeHandler,
 } from 'feedscout/platform'
 ```

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -163,6 +163,7 @@
     "lemmy:user": "User",
     "lemmy:all": "All",
     "lemmy:local": "Local",
-    "apple-podcasts:podcast": "Podcast"
+    "apple-podcasts:podcast": "Podcast",
+    "tistory:blog": "Blog"
   }
 }

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -35,6 +35,7 @@ import { sourceforgeHandler } from './platform/handlers/sourceforge.js'
 import { stackExchangeHandler } from './platform/handlers/stackExchange.js'
 import { steamHandler } from './platform/handlers/steam.js'
 import { substackHandler } from './platform/handlers/substack.js'
+import { tistoryHandler } from './platform/handlers/tistory.js'
 import { tumblrHandler } from './platform/handlers/tumblr.js'
 import { v2exHandler } from './platform/handlers/v2ex.js'
 import { vimeoHandler } from './platform/handlers/vimeo.js'
@@ -152,18 +153,18 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     behanceHandler,
     blogspotHandler,
     blueskyHandler,
-    csdnHandler,
     codebergHandler,
-    doubanHandler,
-    deviantartHandler,
+    csdnHandler,
     dailymotionHandler,
+    deviantartHandler,
     devtoHandler,
-    goodreadsHandler,
+    doubanHandler,
     githubHandler,
-    hashnodeHandler,
-    hatenablogHandler,
     githubGistHandler,
     gitlabHandler,
+    goodreadsHandler,
+    hashnodeHandler,
+    hatenablogHandler,
     itchioHandler,
     kickstarterHandler,
     lemmyHandler,
@@ -180,6 +181,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     stackExchangeHandler,
     steamHandler,
     substackHandler,
+    tistoryHandler,
     tumblrHandler,
     v2exHandler,
     vimeoHandler,

--- a/src/feeds/platform/handlers/tistory.test.ts
+++ b/src/feeds/platform/handlers/tistory.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+import { tistoryHandler } from './tistory.js'
+
+describe('tistoryHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://headstartup.tistory.com', true],
+      ['https://blog.example.tistory.com', true],
+      ['https://tistory.com', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(tistoryHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(tistoryHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for blog', () => {
+      const value = 'https://headstartup.tistory.com'
+      const expected = [
+        {
+          uri: 'https://headstartup.tistory.com/rss',
+          hint: { key: 'tistory:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(tistoryHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of path', () => {
+      const value = 'https://headstartup.tistory.com/123'
+      const expected = [
+        {
+          uri: 'https://headstartup.tistory.com/rss',
+          hint: { key: 'tistory:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(tistoryHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/tistory.ts
+++ b/src/feeds/platform/handlers/tistory.ts
@@ -1,0 +1,16 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Not discoverable without handler.
+
+export const tistoryHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'tistory.com')
+  },
+
+  resolve: (url) => {
+    const { origin } = new URL(url)
+
+    return [{ uri: `${origin}/rss`, hint: composeHint('tistory:blog') }]
+  },
+}


### PR DESCRIPTION
Discovers RSS feeds for Tistory blogs.

## Patterns supported

| URL Pattern | Feeds Generated |
|-------------|-----------------|
| `*.tistory.com` | Blog feed |
