### PR TITLE
feat: Add ArtStation platform handler

### DIFF
--- a/check/feeds.json
+++ b/check/feeds.json
@@ -1,4 +1,9 @@
 {
+  "artstation": [
+    "https://www.artstation.com/rossdraws.rss",
+    "https://www.artstation.com/artwork.rss",
+    "https://www.artstation.com/artwork.rss?sorting=trending"
+  ],
   "behance": [
     "https://www.behance.net/feeds/user?username=matejlatin",
     "https://www.behance.net/feeds/user?username=matejlatin&content=appreciated",

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -428,6 +428,16 @@ Discovers RSS feeds for Ximalaya podcast albums.
 |-------------|-----------------|
 | `www.ximalaya.com/album/{id}` | Album feed |
 
+### ArtStation
+
+Discovers RSS feeds for ArtStation portfolios and the global artwork feed.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `artstation.com/{user}` | Portfolio feed |
+| `{user}.artstation.com` | Portfolio feed |
+| `artstation.com/artwork` | Artwork + Artwork (Trending) |
+
 ## Basic Usage
 
 ```typescript
@@ -475,6 +485,7 @@ Or import individual handlers:
 ```typescript
 import {
   applePodcastsHandler,
+  artstationHandler,
   behanceHandler,
   blogspotHandler,
   blueskyHandler,
@@ -484,10 +495,10 @@ import {
   deviantartHandler,
   devtoHandler,
   doubanHandler,
-  goodreadsHandler,
-  githubGistHandler,
   githubHandler,
+  githubGistHandler,
   gitlabHandler,
+  goodreadsHandler,
   hashnodeHandler,
   hatenablogHandler,
   itchioHandler,

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -163,6 +163,9 @@
     "lemmy:user": "User",
     "lemmy:all": "All",
     "lemmy:local": "Local",
-    "apple-podcasts:podcast": "Podcast"
+    "apple-podcasts:podcast": "Podcast",
+    "artstation:portfolio": "Portfolio",
+    "artstation:artwork": "Artwork",
+    "artstation:artwork-trending": "Artwork (Trending)"
   }
 }

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -4,6 +4,7 @@ import type { HeadersMethodOptions } from '../common/uris/headers/types.js'
 import type { HtmlMethodOptions } from '../common/uris/html/types.js'
 import type { PlatformMethodOptions } from '../common/uris/platform/types.js'
 import { applePodcastsHandler } from './platform/handlers/applePodcasts.js'
+import { artstationHandler } from './platform/handlers/artstation.js'
 import { behanceHandler } from './platform/handlers/behance.js'
 import { blogspotHandler } from './platform/handlers/blogspot.js'
 import { blueskyHandler } from './platform/handlers/bluesky.js'
@@ -149,21 +150,22 @@ export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
 export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
   handlers: [
     applePodcastsHandler,
+    artstationHandler,
     behanceHandler,
     blogspotHandler,
     blueskyHandler,
-    csdnHandler,
     codebergHandler,
-    doubanHandler,
-    deviantartHandler,
+    csdnHandler,
     dailymotionHandler,
+    deviantartHandler,
     devtoHandler,
-    goodreadsHandler,
+    doubanHandler,
     githubHandler,
-    hashnodeHandler,
-    hatenablogHandler,
     githubGistHandler,
     gitlabHandler,
+    goodreadsHandler,
+    hashnodeHandler,
+    hatenablogHandler,
     itchioHandler,
     kickstarterHandler,
     lemmyHandler,

--- a/src/feeds/platform/handlers/artstation.test.ts
+++ b/src/feeds/platform/handlers/artstation.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'bun:test'
+import { artstationHandler } from './artstation.js'
+
+describe('artstationHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://www.artstation.com/rossdraws', true],
+      ['https://artstation.com/user', true],
+      ['https://artstation.com', true],
+      ['https://rossdraws.artstation.com', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(artstationHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(artstationHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for portfolio', () => {
+      const value = 'https://www.artstation.com/rossdraws'
+      const expected = [
+        {
+          uri: 'https://www.artstation.com/rossdraws.rss',
+          hint: { key: 'artstation:portfolio', label: 'Portfolio' },
+        },
+      ]
+
+      expect(artstationHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://www.artstation.com/rossdraws/albums/all'
+      const expected = [
+        {
+          uri: 'https://www.artstation.com/rossdraws.rss',
+          hint: { key: 'artstation:portfolio', label: 'Portfolio' },
+        },
+      ]
+
+      expect(artstationHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL for subdomain form', () => {
+      const value = 'https://rossdraws.artstation.com'
+      const expected = [
+        {
+          uri: 'https://www.artstation.com/rossdraws.rss',
+          hint: { key: 'artstation:portfolio', label: 'Portfolio' },
+        },
+      ]
+
+      expect(artstationHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return global artwork feeds for root path', () => {
+      const value = 'https://www.artstation.com/'
+      const expected = [
+        {
+          uri: 'https://www.artstation.com/artwork.rss',
+          hint: { key: 'artstation:artwork', label: 'Artwork' },
+        },
+        {
+          uri: 'https://www.artstation.com/artwork.rss?sorting=trending',
+          hint: { key: 'artstation:artwork-trending', label: 'Artwork (Trending)' },
+        },
+      ]
+
+      expect(artstationHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return global artwork feeds for /artwork page', () => {
+      const value = 'https://www.artstation.com/artwork'
+      const expected = [
+        {
+          uri: 'https://www.artstation.com/artwork.rss',
+          hint: { key: 'artstation:artwork', label: 'Artwork' },
+        },
+        {
+          uri: 'https://www.artstation.com/artwork.rss?sorting=trending',
+          hint: { key: 'artstation:artwork-trending', label: 'Artwork (Trending)' },
+        },
+      ]
+
+      expect(artstationHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for excluded paths', () => {
+      const value = 'https://www.artstation.com/jobs'
+
+      expect(artstationHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/artstation.ts
+++ b/src/feeds/platform/handlers/artstation.ts
@@ -1,0 +1,76 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isAnyOf, isHostOf, isSubdomainOf } from '../../../common/utils.js'
+
+// Not discoverable without handler.
+
+const hosts = ['artstation.com', 'www.artstation.com']
+const domainSuffix = /\.artstation\.com$/i
+const excludedPaths = [
+  'blogs',
+  'channels',
+  'contests',
+  'features',
+  'jobs',
+  'learning',
+  'login',
+  'marketplace',
+  'prints',
+  'search',
+  'signup',
+  'studios',
+  'terms',
+]
+
+export const artstationHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts) || isSubdomainOf(url, 'artstation.com')
+  },
+
+  resolve: (url) => {
+    const parsed = new URL(url)
+
+    // Subdomain form: {user}.artstation.com
+    if (!isHostOf(url, hosts) && isSubdomainOf(url, 'artstation.com')) {
+      const username = parsed.hostname.replace(domainSuffix, '')
+
+      return [
+        {
+          uri: `https://www.artstation.com/${username}.rss`,
+          hint: composeHint('artstation:portfolio'),
+        },
+      ]
+    }
+
+    const pathSegments = parsed.pathname.split('/').filter(Boolean)
+
+    // Global artwork page: /artwork
+    if (pathSegments[0] === 'artwork' || pathSegments.length === 0) {
+      const uris: Array<DiscoverUriEntry> = []
+
+      uris.push({
+        uri: 'https://www.artstation.com/artwork.rss',
+        hint: composeHint('artstation:artwork'),
+      })
+      uris.push({
+        uri: 'https://www.artstation.com/artwork.rss?sorting=trending',
+        hint: composeHint('artstation:artwork-trending'),
+      })
+
+      return uris
+    }
+
+    const username = pathSegments[0]
+
+    if (isAnyOf(username, excludedPaths)) {
+      return []
+    }
+
+    return [
+      {
+        uri: `https://www.artstation.com/${username}.rss`,
+        hint: composeHint('artstation:portfolio'),
+      },
+    ]
+  },
+}


### PR DESCRIPTION
Discovers RSS feeds for ArtStation portfolios and the global artwork feed.

## Patterns supported

| URL Pattern | Feeds Generated |
|-------------|-----------------|
| `artstation.com/{user}` | Portfolio feed |
| `{user}.artstation.com` | Portfolio feed |
| `artstation.com/artwork` | Artwork + Artwork (Trending) |
