### PR TITLE
feat: Add Hacker News platform handler

### DIFF
--- a/check/feeds.json
+++ b/check/feeds.json
@@ -77,6 +77,7 @@
     "https://www.goodreads.com/review/list_rss/1",
     "https://www.goodreads.com/review/list_rss/1?shelf=read"
   ],
+  "hackernews": ["https://news.ycombinator.com/rss", "https://news.ycombinator.com/showrss"],
   "kickstarter": [
     "https://www.kickstarter.com/projects/elanlee/exploding-kittens/posts.atom",
     "https://www.kickstarter.com/projects/feed.atom"

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -428,6 +428,15 @@ Discovers RSS feeds for Ximalaya podcast albums.
 |-------------|-----------------|
 | `www.ximalaya.com/album/{id}` | Album feed |
 
+### Hacker News
+
+Discovers RSS feeds for Hacker News.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `news.ycombinator.com` | Front page feed (RSS) |
+| `news.ycombinator.com/show` | Show HN feed (RSS) |
+
 ## Basic Usage
 
 ```typescript
@@ -484,10 +493,11 @@ import {
   deviantartHandler,
   devtoHandler,
   doubanHandler,
-  goodreadsHandler,
-  githubGistHandler,
   githubHandler,
+  githubGistHandler,
   gitlabHandler,
+  goodreadsHandler,
+  hackernewsHandler,
   hashnodeHandler,
   hatenablogHandler,
   itchioHandler,

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -163,6 +163,8 @@
     "lemmy:user": "User",
     "lemmy:all": "All",
     "lemmy:local": "Local",
-    "apple-podcasts:podcast": "Podcast"
+    "apple-podcasts:podcast": "Podcast",
+    "hackernews:front": "Front page",
+    "hackernews:show": "Show HN"
   }
 }

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -17,6 +17,7 @@ import { githubHandler } from './platform/handlers/github.js'
 import { githubGistHandler } from './platform/handlers/githubGist.js'
 import { gitlabHandler } from './platform/handlers/gitlab.js'
 import { goodreadsHandler } from './platform/handlers/goodreads.js'
+import { hackernewsHandler } from './platform/handlers/hackernews.js'
 import { hashnodeHandler } from './platform/handlers/hashnode.js'
 import { hatenablogHandler } from './platform/handlers/hatenablog.js'
 import { itchioHandler } from './platform/handlers/itchio.js'
@@ -152,18 +153,19 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     behanceHandler,
     blogspotHandler,
     blueskyHandler,
-    csdnHandler,
     codebergHandler,
-    doubanHandler,
-    deviantartHandler,
+    csdnHandler,
     dailymotionHandler,
+    deviantartHandler,
     devtoHandler,
-    goodreadsHandler,
+    doubanHandler,
     githubHandler,
-    hashnodeHandler,
-    hatenablogHandler,
     githubGistHandler,
     gitlabHandler,
+    goodreadsHandler,
+    hackernewsHandler,
+    hashnodeHandler,
+    hatenablogHandler,
     itchioHandler,
     kickstarterHandler,
     lemmyHandler,

--- a/src/feeds/platform/handlers/hackernews.test.ts
+++ b/src/feeds/platform/handlers/hackernews.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test'
+import { hackernewsHandler } from './hackernews.js'
+
+describe('hackernewsHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://news.ycombinator.com', true],
+      ['https://news.ycombinator.com/news', true],
+      ['https://news.ycombinator.com/item?id=12345', true],
+      ['https://ycombinator.com', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(hackernewsHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(hackernewsHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return front page feed for root', () => {
+      const value = 'https://news.ycombinator.com'
+      const expected = [
+        {
+          uri: 'https://news.ycombinator.com/rss',
+          hint: { key: 'hackernews:front', label: 'Front page' },
+        },
+      ]
+
+      expect(hackernewsHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return front page feed for any non-show path', () => {
+      const value = 'https://news.ycombinator.com/item?id=12345'
+      const expected = [
+        {
+          uri: 'https://news.ycombinator.com/rss',
+          hint: { key: 'hackernews:front', label: 'Front page' },
+        },
+      ]
+
+      expect(hackernewsHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return Show HN feed for /show', () => {
+      const value = 'https://news.ycombinator.com/show'
+      const expected = [
+        {
+          uri: 'https://news.ycombinator.com/showrss',
+          hint: { key: 'hackernews:show', label: 'Show HN' },
+        },
+      ]
+
+      expect(hackernewsHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return Show HN feed for /shownew', () => {
+      const value = 'https://news.ycombinator.com/shownew'
+      const expected = [
+        {
+          uri: 'https://news.ycombinator.com/showrss',
+          hint: { key: 'hackernews:show', label: 'Show HN' },
+        },
+      ]
+
+      expect(hackernewsHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/hackernews.ts
+++ b/src/feeds/platform/handlers/hackernews.ts
@@ -1,0 +1,34 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isHostOf } from '../../../common/utils.js'
+
+// Not discoverable without handler.
+
+const hosts = ['news.ycombinator.com']
+
+export const hackernewsHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+
+    // Show HN section.
+    if (pathname === '/show' || pathname === '/shownew') {
+      return [
+        {
+          uri: 'https://news.ycombinator.com/showrss',
+          hint: composeHint('hackernews:show'),
+        },
+      ]
+    }
+
+    // Default: front page feed.
+    return [
+      {
+        uri: 'https://news.ycombinator.com/rss',
+        hint: composeHint('hackernews:front'),
+      },
+    ]
+  },
+}


### PR DESCRIPTION
Discovers RSS feeds for Hacker News.

## Patterns supported

| URL Pattern | Feeds Generated |
|-------------|-----------------|
| `news.ycombinator.com` | Front page feed (RSS) |
| `news.ycombinator.com/show` | Show HN feed (RSS) |
