### PR TITLE
feat: Add MyAnimeList platform handler

### DIFF
--- a/check/feeds.json
+++ b/check/feeds.json
@@ -109,6 +109,11 @@
     "https://mastodon.social/tags/mastodon.rss",
     "https://mastodon.social/@Gargron/tagged/mastodev.rss"
   ],
+  "myanimelist": [
+    "https://myanimelist.net/rss.php?type=rw&u=Xinil",
+    "https://myanimelist.net/rss.php?type=rm&u=Xinil",
+    "https://myanimelist.net/rss.php?type=rrm&u=Xinil"
+  ],
   "pinterest": ["https://www.pinterest.com/pinterest/feed.rss"],
   "producthunt": [
     "https://www.producthunt.com/feed?topic=artificial-intelligence",

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -428,6 +428,17 @@ Discovers RSS feeds for Ximalaya podcast albums.
 |-------------|-----------------|
 | `www.ximalaya.com/album/{id}` | Album feed |
 
+### MyAnimeList
+
+Discovers RSS feeds for MyAnimeList user lists.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `myanimelist.net/profile/{user}` | Anime list, Manga list, Recently watched, Recently read (RSS) |
+| `myanimelist.net/animelist/{user}` | (same as above) |
+| `myanimelist.net/mangalist/{user}` | (same as above) |
+| `myanimelist.net/history/{user}` | (same as above) |
+
 ## Basic Usage
 
 ```typescript
@@ -484,10 +495,10 @@ import {
   deviantartHandler,
   devtoHandler,
   doubanHandler,
-  goodreadsHandler,
-  githubGistHandler,
   githubHandler,
+  githubGistHandler,
   gitlabHandler,
+  goodreadsHandler,
   hashnodeHandler,
   hatenablogHandler,
   itchioHandler,
@@ -496,6 +507,7 @@ import {
   lobstersHandler,
   mastodonHandler,
   mediumHandler,
+  myanimelistHandler,
   paragraphHandler,
   producthuntHandler,
   redditHandler,

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -163,6 +163,10 @@
     "lemmy:user": "User",
     "lemmy:all": "All",
     "lemmy:local": "Local",
-    "apple-podcasts:podcast": "Podcast"
+    "apple-podcasts:podcast": "Podcast",
+    "myanimelist:anime": "Anime list",
+    "myanimelist:manga": "Manga list",
+    "myanimelist:recently-watched": "Recently watched",
+    "myanimelist:recently-read": "Recently read"
   }
 }

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -26,6 +26,7 @@ import { letterboxdHandler } from './platform/handlers/letterboxd.js'
 import { lobstersHandler } from './platform/handlers/lobsters.js'
 import { mastodonHandler } from './platform/handlers/mastodon.js'
 import { mediumHandler } from './platform/handlers/medium.js'
+import { myanimelistHandler } from './platform/handlers/myanimelist.js'
 import { paragraphHandler } from './platform/handlers/paragraph.js'
 import { pinterestHandler } from './platform/handlers/pinterest.js'
 import { producthuntHandler } from './platform/handlers/producthunt.js'
@@ -152,18 +153,18 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     behanceHandler,
     blogspotHandler,
     blueskyHandler,
-    csdnHandler,
     codebergHandler,
-    doubanHandler,
-    deviantartHandler,
+    csdnHandler,
     dailymotionHandler,
+    deviantartHandler,
     devtoHandler,
-    goodreadsHandler,
+    doubanHandler,
     githubHandler,
-    hashnodeHandler,
-    hatenablogHandler,
     githubGistHandler,
     gitlabHandler,
+    goodreadsHandler,
+    hashnodeHandler,
+    hatenablogHandler,
     itchioHandler,
     kickstarterHandler,
     lemmyHandler,
@@ -171,6 +172,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     lobstersHandler,
     mastodonHandler,
     mediumHandler,
+    myanimelistHandler,
     paragraphHandler,
     pinterestHandler,
     producthuntHandler,

--- a/src/feeds/platform/handlers/myanimelist.test.ts
+++ b/src/feeds/platform/handlers/myanimelist.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test'
+import { myanimelistHandler } from './myanimelist.js'
+
+const expectedFeeds = (user: string) => [
+  {
+    uri: `https://myanimelist.net/rss.php?type=rw&u=${user}`,
+    hint: { key: 'myanimelist:anime', label: 'Anime list' },
+  },
+  {
+    uri: `https://myanimelist.net/rss.php?type=rm&u=${user}`,
+    hint: { key: 'myanimelist:manga', label: 'Manga list' },
+  },
+  {
+    uri: `https://myanimelist.net/rss.php?type=rrw&u=${user}`,
+    hint: { key: 'myanimelist:recently-watched', label: 'Recently watched' },
+  },
+  {
+    uri: `https://myanimelist.net/rss.php?type=rrm&u=${user}`,
+    hint: { key: 'myanimelist:recently-read', label: 'Recently read' },
+  },
+]
+
+describe('myanimelistHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://myanimelist.net/profile/Xinil', true],
+      ['https://www.myanimelist.net/animelist/Xinil', true],
+      ['https://myanimelist.net', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(myanimelistHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(myanimelistHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return all four feeds for /profile/{user}', () => {
+      const value = 'https://myanimelist.net/profile/Xinil'
+      const expected = expectedFeeds('Xinil')
+
+      expect(myanimelistHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feeds for /animelist/{user}', () => {
+      const value = 'https://myanimelist.net/animelist/Xinil'
+      const expected = expectedFeeds('Xinil')
+
+      expect(myanimelistHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feeds for /mangalist/{user}', () => {
+      const value = 'https://myanimelist.net/mangalist/Xinil'
+      const expected = expectedFeeds('Xinil')
+
+      expect(myanimelistHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feeds for /history/{user}', () => {
+      const value = 'https://myanimelist.net/history/Xinil'
+      const expected = expectedFeeds('Xinil')
+
+      expect(myanimelistHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for non-user paths', () => {
+      expect(myanimelistHandler.resolve('https://myanimelist.net/anime/1')).toEqual([])
+    })
+
+    it('should return empty array for root', () => {
+      expect(myanimelistHandler.resolve('https://myanimelist.net/')).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/myanimelist.ts
+++ b/src/feeds/platform/handlers/myanimelist.ts
@@ -1,0 +1,45 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isHostOf } from '../../../common/utils.js'
+
+// Not discoverable without handler.
+
+const hosts = ['myanimelist.net', 'www.myanimelist.net']
+const userRegex = /^\/(?:profile|animelist|mangalist|history)\/([^/]+)/
+
+export const myanimelistHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const match = pathname.match(userRegex)
+
+    if (!match?.[1]) {
+      return []
+    }
+
+    const user = match[1]
+    const uris: Array<DiscoverUriEntry> = []
+
+    uris.push({
+      uri: `https://myanimelist.net/rss.php?type=rw&u=${user}`,
+      hint: composeHint('myanimelist:anime'),
+    })
+    uris.push({
+      uri: `https://myanimelist.net/rss.php?type=rm&u=${user}`,
+      hint: composeHint('myanimelist:manga'),
+    })
+    uris.push({
+      uri: `https://myanimelist.net/rss.php?type=rrw&u=${user}`,
+      hint: composeHint('myanimelist:recently-watched'),
+    })
+    uris.push({
+      uri: `https://myanimelist.net/rss.php?type=rrm&u=${user}`,
+      hint: composeHint('myanimelist:recently-read'),
+    })
+
+    return uris
+  },
+}


### PR DESCRIPTION
Discovers RSS feeds for MyAnimeList user lists.

## Patterns supported

| URL Pattern | Feeds Generated |
|-------------|-----------------|
| `myanimelist.net/profile/{user}` | Anime list, Manga list, Recently watched, Recently read (RSS) |
| `myanimelist.net/animelist/{user}` | (same as above) |
| `myanimelist.net/mangalist/{user}` | (same as above) |
| `myanimelist.net/history/{user}` | (same as above) |
