### PR TITLE
feat: Add Odysee platform handler

### DIFF
--- a/check/feeds.json
+++ b/check/feeds.json
@@ -109,6 +109,7 @@
     "https://mastodon.social/tags/mastodon.rss",
     "https://mastodon.social/@Gargron/tagged/mastodev.rss"
   ],
+  "odysee": ["https://odysee.com/$/rss/@Odysee:8"],
   "pinterest": ["https://www.pinterest.com/pinterest/feed.rss"],
   "producthunt": [
     "https://www.producthunt.com/feed?topic=artificial-intelligence",

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -428,6 +428,14 @@ Discovers RSS feeds for Ximalaya podcast albums.
 |-------------|-----------------|
 | `www.ximalaya.com/album/{id}` | Album feed |
 
+### Odysee
+
+Discovers RSS feeds for Odysee channels.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `odysee.com/@{channel}:{id}` | Videos feed |
+
 ## Basic Usage
 
 ```typescript
@@ -484,10 +492,10 @@ import {
   deviantartHandler,
   devtoHandler,
   doubanHandler,
-  goodreadsHandler,
-  githubGistHandler,
   githubHandler,
+  githubGistHandler,
   gitlabHandler,
+  goodreadsHandler,
   hashnodeHandler,
   hatenablogHandler,
   itchioHandler,
@@ -496,6 +504,7 @@ import {
   lobstersHandler,
   mastodonHandler,
   mediumHandler,
+  odyseeHandler,
   paragraphHandler,
   producthuntHandler,
   redditHandler,

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -163,6 +163,7 @@
     "lemmy:user": "User",
     "lemmy:all": "All",
     "lemmy:local": "Local",
-    "apple-podcasts:podcast": "Podcast"
+    "apple-podcasts:podcast": "Podcast",
+    "odysee:videos": "Videos"
   }
 }

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -26,6 +26,7 @@ import { letterboxdHandler } from './platform/handlers/letterboxd.js'
 import { lobstersHandler } from './platform/handlers/lobsters.js'
 import { mastodonHandler } from './platform/handlers/mastodon.js'
 import { mediumHandler } from './platform/handlers/medium.js'
+import { odyseeHandler } from './platform/handlers/odysee.js'
 import { paragraphHandler } from './platform/handlers/paragraph.js'
 import { pinterestHandler } from './platform/handlers/pinterest.js'
 import { producthuntHandler } from './platform/handlers/producthunt.js'
@@ -152,18 +153,18 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     behanceHandler,
     blogspotHandler,
     blueskyHandler,
-    csdnHandler,
     codebergHandler,
-    doubanHandler,
-    deviantartHandler,
+    csdnHandler,
     dailymotionHandler,
+    deviantartHandler,
     devtoHandler,
-    goodreadsHandler,
+    doubanHandler,
     githubHandler,
-    hashnodeHandler,
-    hatenablogHandler,
     githubGistHandler,
     gitlabHandler,
+    goodreadsHandler,
+    hashnodeHandler,
+    hatenablogHandler,
     itchioHandler,
     kickstarterHandler,
     lemmyHandler,
@@ -171,6 +172,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     lobstersHandler,
     mastodonHandler,
     mediumHandler,
+    odyseeHandler,
     paragraphHandler,
     pinterestHandler,
     producthuntHandler,

--- a/src/feeds/platform/handlers/odysee.test.ts
+++ b/src/feeds/platform/handlers/odysee.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { odyseeHandler } from './odysee.js'
+
+describe('odyseeHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://odysee.com/@veritasium:f', true],
+      ['https://www.odysee.com/@lbry:3f', true],
+      ['https://odysee.com', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(odyseeHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(odyseeHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for channel', () => {
+      const value = 'https://odysee.com/@veritasium:f'
+      const expected = [
+        {
+          uri: 'https://odysee.com/$/rss/@veritasium:f',
+          hint: { key: 'odysee:videos', label: 'Videos' },
+        },
+      ]
+
+      expect(odyseeHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://odysee.com/@lbry:3f/some-video:abc'
+      const expected = [
+        {
+          uri: 'https://odysee.com/$/rss/@lbry:3f',
+          hint: { key: 'odysee:videos', label: 'Videos' },
+        },
+      ]
+
+      expect(odyseeHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for channel without claim ID', () => {
+      const value = 'https://odysee.com/@veritasium'
+
+      expect(odyseeHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://odysee.com/'
+
+      expect(odyseeHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/odysee.ts
+++ b/src/feeds/platform/handlers/odysee.ts
@@ -1,0 +1,29 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isHostOf } from '../../../common/utils.js'
+
+// Not discoverable without handler.
+
+const hosts = ['odysee.com', 'www.odysee.com']
+const channelRegex = /^\/(@[^/:]+:[a-f0-9]+)/i
+
+export const odyseeHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const match = pathname.match(channelRegex)
+
+    if (!match?.[1]) {
+      return []
+    }
+
+    return [
+      {
+        uri: `https://odysee.com/$/rss/${match[1]}`,
+        hint: composeHint('odysee:videos'),
+      },
+    ]
+  },
+}


### PR DESCRIPTION
Discovers RSS feeds for Odysee channels.

## Patterns supported

| URL Pattern | Feeds Generated |
|-------------|-----------------|
| `odysee.com/@{channel}:{id}` | Videos feed |
