### PR TITLE
feat: Add Transistor platform handler

### DIFF
--- a/check/feeds.json
+++ b/check/feeds.json
@@ -163,6 +163,7 @@
     "https://newsletter.pragmaticengineer.com/feed",
     "https://garymarcus.substack.com/feed"
   ],
+  "transistor": ["https://feeds.transistor.fm/build-your-saas"],
   "tumblr": ["https://staff.tumblr.com/rss", "https://staff.tumblr.com/tagged/updates/rss"],
   "vimeo": [
     "https://vimeo.com/casey/videos/rss",

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -428,6 +428,14 @@ Discovers RSS feeds for Ximalaya podcast albums.
 |-------------|-----------------|
 | `www.ximalaya.com/album/{id}` | Album feed |
 
+### Transistor
+
+Discovers RSS feeds for Transistor-hosted podcasts.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.transistor.fm` | Podcast feed |
+
 ## Basic Usage
 
 ```typescript
@@ -484,10 +492,10 @@ import {
   deviantartHandler,
   devtoHandler,
   doubanHandler,
-  goodreadsHandler,
-  githubGistHandler,
   githubHandler,
+  githubGistHandler,
   gitlabHandler,
+  goodreadsHandler,
   hashnodeHandler,
   hatenablogHandler,
   itchioHandler,
@@ -504,6 +512,7 @@ import {
   stackExchangeHandler,
   steamHandler,
   substackHandler,
+  transistorHandler,
   tumblrHandler,
   v2exHandler,
   vimeoHandler,

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -163,6 +163,7 @@
     "lemmy:user": "User",
     "lemmy:all": "All",
     "lemmy:local": "Local",
-    "apple-podcasts:podcast": "Podcast"
+    "apple-podcasts:podcast": "Podcast",
+    "transistor:podcast": "Podcast"
   }
 }

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -35,6 +35,7 @@ import { sourceforgeHandler } from './platform/handlers/sourceforge.js'
 import { stackExchangeHandler } from './platform/handlers/stackExchange.js'
 import { steamHandler } from './platform/handlers/steam.js'
 import { substackHandler } from './platform/handlers/substack.js'
+import { transistorHandler } from './platform/handlers/transistor.js'
 import { tumblrHandler } from './platform/handlers/tumblr.js'
 import { v2exHandler } from './platform/handlers/v2ex.js'
 import { vimeoHandler } from './platform/handlers/vimeo.js'
@@ -152,18 +153,18 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     behanceHandler,
     blogspotHandler,
     blueskyHandler,
-    csdnHandler,
     codebergHandler,
-    doubanHandler,
-    deviantartHandler,
+    csdnHandler,
     dailymotionHandler,
+    deviantartHandler,
     devtoHandler,
-    goodreadsHandler,
+    doubanHandler,
     githubHandler,
-    hashnodeHandler,
-    hatenablogHandler,
     githubGistHandler,
     gitlabHandler,
+    goodreadsHandler,
+    hashnodeHandler,
+    hatenablogHandler,
     itchioHandler,
     kickstarterHandler,
     lemmyHandler,
@@ -180,6 +181,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     stackExchangeHandler,
     steamHandler,
     substackHandler,
+    transistorHandler,
     tumblrHandler,
     v2exHandler,
     vimeoHandler,

--- a/src/feeds/platform/handlers/transistor.test.ts
+++ b/src/feeds/platform/handlers/transistor.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+import { transistorHandler } from './transistor.js'
+
+describe('transistorHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://build-your-saas.transistor.fm', true],
+      ['https://blog.example.transistor.fm', true],
+      ['https://transistor.fm', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(transistorHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(transistorHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for podcast', () => {
+      const value = 'https://build-your-saas.transistor.fm'
+      const expected = [
+        {
+          uri: 'https://feeds.transistor.fm/build-your-saas',
+          hint: { key: 'transistor:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(transistorHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of path', () => {
+      const value = 'https://build-your-saas.transistor.fm/episodes/some-episode'
+      const expected = [
+        {
+          uri: 'https://feeds.transistor.fm/build-your-saas',
+          hint: { key: 'transistor:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(transistorHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/transistor.ts
+++ b/src/feeds/platform/handlers/transistor.ts
@@ -1,0 +1,24 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Not discoverable without handler.
+
+const domainSuffix = /\.transistor\.fm$/i
+
+export const transistorHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'transistor.fm')
+  },
+
+  resolve: (url) => {
+    const { hostname } = new URL(url)
+    const slug = hostname.replace(domainSuffix, '')
+
+    return [
+      {
+        uri: `https://feeds.transistor.fm/${slug}`,
+        hint: composeHint('transistor:podcast'),
+      },
+    ]
+  },
+}


### PR DESCRIPTION
Discovers RSS feeds for Transistor-hosted podcasts.

## Patterns supported

| URL Pattern | Feeds Generated |
|-------------|-----------------|
| `*.transistor.fm` | Podcast feed |
