### PR TITLE
feat: Add Bear Blog platform handler

### DIFF
--- a/check/feeds.json
+++ b/check/feeds.json
@@ -1,4 +1,5 @@
 {
+  "bearblog": ["https://herman.bearblog.dev/feed/", "https://herman.bearblog.dev/feed/?type=rss"],
   "behance": [
     "https://www.behance.net/feeds/user?username=matejlatin",
     "https://www.behance.net/feeds/user?username=matejlatin&content=appreciated",

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -428,6 +428,15 @@ Discovers RSS feeds for Ximalaya podcast albums.
 |-------------|-----------------|
 | `www.ximalaya.com/album/{id}` | Album feed |
 
+### Bear Blog
+
+Discovers Atom and RSS feeds for Bear Blog, including tag-filtered feeds.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.bearblog.dev` | Posts feed (Atom + RSS) |
+| `*.bearblog.dev/?q={tag}` | Tag feed (Atom + RSS) + posts |
+
 ## Basic Usage
 
 ```typescript
@@ -475,6 +484,7 @@ Or import individual handlers:
 ```typescript
 import {
   applePodcastsHandler,
+  bearblogHandler,
   behanceHandler,
   blogspotHandler,
   blueskyHandler,
@@ -484,10 +494,10 @@ import {
   deviantartHandler,
   devtoHandler,
   doubanHandler,
-  goodreadsHandler,
-  githubGistHandler,
   githubHandler,
+  githubGistHandler,
   gitlabHandler,
+  goodreadsHandler,
   hashnodeHandler,
   hatenablogHandler,
   itchioHandler,

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -163,6 +163,10 @@
     "lemmy:user": "User",
     "lemmy:all": "All",
     "lemmy:local": "Local",
-    "apple-podcasts:podcast": "Podcast"
+    "apple-podcasts:podcast": "Podcast",
+    "bearblog:posts-atom": "Posts (Atom)",
+    "bearblog:posts-rss": "Posts (RSS)",
+    "bearblog:tag-atom": "Tag (Atom)",
+    "bearblog:tag-rss": "Tag (RSS)"
   }
 }

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -4,6 +4,7 @@ import type { HeadersMethodOptions } from '../common/uris/headers/types.js'
 import type { HtmlMethodOptions } from '../common/uris/html/types.js'
 import type { PlatformMethodOptions } from '../common/uris/platform/types.js'
 import { applePodcastsHandler } from './platform/handlers/applePodcasts.js'
+import { bearblogHandler } from './platform/handlers/bearblog.js'
 import { behanceHandler } from './platform/handlers/behance.js'
 import { blogspotHandler } from './platform/handlers/blogspot.js'
 import { blueskyHandler } from './platform/handlers/bluesky.js'
@@ -149,21 +150,22 @@ export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
 export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
   handlers: [
     applePodcastsHandler,
+    bearblogHandler,
     behanceHandler,
     blogspotHandler,
     blueskyHandler,
-    csdnHandler,
     codebergHandler,
-    doubanHandler,
-    deviantartHandler,
+    csdnHandler,
     dailymotionHandler,
+    deviantartHandler,
     devtoHandler,
-    goodreadsHandler,
+    doubanHandler,
     githubHandler,
-    hashnodeHandler,
-    hatenablogHandler,
     githubGistHandler,
     gitlabHandler,
+    goodreadsHandler,
+    hashnodeHandler,
+    hatenablogHandler,
     itchioHandler,
     kickstarterHandler,
     lemmyHandler,

--- a/src/feeds/platform/handlers/bearblog.test.ts
+++ b/src/feeds/platform/handlers/bearblog.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'bun:test'
+import { bearblogHandler } from './bearblog.js'
+
+describe('bearblogHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://herman.bearblog.dev', true],
+      ['https://blog.example.bearblog.dev', true],
+      ['https://bearblog.dev', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(bearblogHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(bearblogHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return Atom and RSS feeds for blog', () => {
+      const value = 'https://herman.bearblog.dev'
+      const expected = [
+        {
+          uri: 'https://herman.bearblog.dev/feed/',
+          hint: { key: 'bearblog:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: 'https://herman.bearblog.dev/feed/?type=rss',
+          hint: { key: 'bearblog:posts-rss', label: 'Posts (RSS)' },
+        },
+      ]
+
+      expect(bearblogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URLs regardless of path', () => {
+      const value = 'https://herman.bearblog.dev/some-article-slug'
+      const expected = [
+        {
+          uri: 'https://herman.bearblog.dev/feed/',
+          hint: { key: 'bearblog:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: 'https://herman.bearblog.dev/feed/?type=rss',
+          hint: { key: 'bearblog:posts-rss', label: 'Posts (RSS)' },
+        },
+      ]
+
+      expect(bearblogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return tag-filtered and main feeds when q query param is set', () => {
+      const value = 'https://herman.bearblog.dev/blog/?q=tips'
+      const expected = [
+        {
+          uri: 'https://herman.bearblog.dev/feed/?q=tips',
+          hint: { key: 'bearblog:tag-atom', label: 'Tag (Atom)' },
+        },
+        {
+          uri: 'https://herman.bearblog.dev/feed/?type=rss&q=tips',
+          hint: { key: 'bearblog:tag-rss', label: 'Tag (RSS)' },
+        },
+        {
+          uri: 'https://herman.bearblog.dev/feed/',
+          hint: { key: 'bearblog:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: 'https://herman.bearblog.dev/feed/?type=rss',
+          hint: { key: 'bearblog:posts-rss', label: 'Posts (RSS)' },
+        },
+      ]
+
+      expect(bearblogHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/bearblog.ts
+++ b/src/feeds/platform/handlers/bearblog.ts
@@ -1,0 +1,35 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Partially discoverable without handler.
+
+export const bearblogHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'bearblog.dev')
+  },
+
+  resolve: (url) => {
+    const { origin, searchParams } = new URL(url)
+    const uris: Array<DiscoverUriEntry> = []
+
+    // Tag filter via ?q= query param.
+    const tag = searchParams.get('q')
+
+    if (tag) {
+      uris.push({
+        uri: `${origin}/feed/?q=${encodeURIComponent(tag)}`,
+        hint: composeHint('bearblog:tag-atom'),
+      })
+      uris.push({
+        uri: `${origin}/feed/?type=rss&q=${encodeURIComponent(tag)}`,
+        hint: composeHint('bearblog:tag-rss'),
+      })
+    }
+
+    uris.push({ uri: `${origin}/feed/`, hint: composeHint('bearblog:posts-atom') })
+    uris.push({ uri: `${origin}/feed/?type=rss`, hint: composeHint('bearblog:posts-rss') })
+
+    return uris
+  },
+}


### PR DESCRIPTION
Discovers Atom and RSS feeds for Bear Blog, including tag-filtered feeds.

## Patterns supported

| URL Pattern | Feeds Generated |
|-------------|-----------------|
| `*.bearblog.dev` | Posts feed (Atom + RSS) |
| `*.bearblog.dev/?q={tag}` | Tag feed (Atom + RSS) + posts |
