### PR TITLE
feat: Add Buttondown platform handler

### DIFF
--- a/check/feeds.json
+++ b/check/feeds.json
@@ -15,6 +15,7 @@
     "https://security.googleblog.com/feeds/1469360228826887140/comments/default?alt=rss"
   ],
   "bluesky": ["https://bsky.app/profile/jay.bsky.team/rss"],
+  "buttondown": ["https://buttondown.com/jmduke/rss"],
   "codeberg": [
     "https://codeberg.org/forgejo.atom",
     "https://codeberg.org/forgejo.rss",

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -428,6 +428,14 @@ Discovers RSS feeds for Ximalaya podcast albums.
 |-------------|-----------------|
 | `www.ximalaya.com/album/{id}` | Album feed |
 
+### Buttondown
+
+Discovers RSS feeds for Buttondown newsletters.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `buttondown.com/{user}` | Newsletter feed |
+
 ## Basic Usage
 
 ```typescript
@@ -478,16 +486,17 @@ import {
   behanceHandler,
   blogspotHandler,
   blueskyHandler,
+  buttondownHandler,
   codebergHandler,
   csdnHandler,
   dailymotionHandler,
   deviantartHandler,
   devtoHandler,
   doubanHandler,
-  goodreadsHandler,
-  githubGistHandler,
   githubHandler,
+  githubGistHandler,
   gitlabHandler,
+  goodreadsHandler,
   hashnodeHandler,
   hatenablogHandler,
   itchioHandler,

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -163,6 +163,7 @@
     "lemmy:user": "User",
     "lemmy:all": "All",
     "lemmy:local": "Local",
-    "apple-podcasts:podcast": "Podcast"
+    "apple-podcasts:podcast": "Podcast",
+    "buttondown:newsletter": "Newsletter"
   }
 }

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -7,6 +7,7 @@ import { applePodcastsHandler } from './platform/handlers/applePodcasts.js'
 import { behanceHandler } from './platform/handlers/behance.js'
 import { blogspotHandler } from './platform/handlers/blogspot.js'
 import { blueskyHandler } from './platform/handlers/bluesky.js'
+import { buttondownHandler } from './platform/handlers/buttondown.js'
 import { codebergHandler } from './platform/handlers/codeberg.js'
 import { csdnHandler } from './platform/handlers/csdn.js'
 import { dailymotionHandler } from './platform/handlers/dailymotion.js'
@@ -152,18 +153,19 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     behanceHandler,
     blogspotHandler,
     blueskyHandler,
-    csdnHandler,
+    buttondownHandler,
     codebergHandler,
-    doubanHandler,
-    deviantartHandler,
+    csdnHandler,
     dailymotionHandler,
+    deviantartHandler,
     devtoHandler,
-    goodreadsHandler,
+    doubanHandler,
     githubHandler,
-    hashnodeHandler,
-    hatenablogHandler,
     githubGistHandler,
     gitlabHandler,
+    goodreadsHandler,
+    hashnodeHandler,
+    hatenablogHandler,
     itchioHandler,
     kickstarterHandler,
     lemmyHandler,

--- a/src/feeds/platform/handlers/buttondown.test.ts
+++ b/src/feeds/platform/handlers/buttondown.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { buttondownHandler } from './buttondown.js'
+
+describe('buttondownHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://buttondown.com/cassidoo', true],
+      ['https://www.buttondown.com/user', true],
+      ['https://buttondown.com', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(buttondownHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(buttondownHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for newsletter', () => {
+      const value = 'https://buttondown.com/cassidoo'
+      const expected = [
+        {
+          uri: 'https://buttondown.com/cassidoo/rss',
+          hint: { key: 'buttondown:newsletter', label: 'Newsletter' },
+        },
+      ]
+
+      expect(buttondownHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://buttondown.com/cassidoo/archive'
+      const expected = [
+        {
+          uri: 'https://buttondown.com/cassidoo/rss',
+          hint: { key: 'buttondown:newsletter', label: 'Newsletter' },
+        },
+      ]
+
+      expect(buttondownHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://buttondown.com/'
+
+      expect(buttondownHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for excluded paths', () => {
+      const value = 'https://buttondown.com/login'
+
+      expect(buttondownHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/buttondown.ts
+++ b/src/feeds/platform/handlers/buttondown.ts
@@ -1,0 +1,51 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
+
+// Partially discoverable without handler.
+
+const hosts = ['buttondown.com', 'www.buttondown.com']
+const excludedPaths = [
+  'about',
+  'api',
+  'blog',
+  'changelog',
+  'docs',
+  'features',
+  'help',
+  'legal',
+  'login',
+  'pricing',
+  'privacy',
+  'refer',
+  'register',
+  'settings',
+  'terms',
+]
+
+export const buttondownHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const pathSegments = pathname.split('/').filter(Boolean)
+
+    if (pathSegments.length === 0) {
+      return []
+    }
+
+    const username = pathSegments[0]
+
+    if (isAnyOf(username, excludedPaths)) {
+      return []
+    }
+
+    return [
+      {
+        uri: `https://buttondown.com/${username}/rss`,
+        hint: composeHint('buttondown:newsletter'),
+      },
+    ]
+  },
+}


### PR DESCRIPTION
Discovers RSS feeds for Buttondown newsletters.

## Patterns supported

| URL Pattern | Feeds Generated |
|-------------|-----------------|
| `buttondown.com/{user}` | Newsletter feed |
