### PR TITLE
feat: Add Dreamwidth platform handler

### DIFF
--- a/check/feeds.json
+++ b/check/feeds.json
@@ -40,6 +40,10 @@
     "https://backend.deviantart.com/rss.xml?q=journal:yuumei"
   ],
   "devto": ["https://dev.to/feed/ben", "https://dev.to/feed/tag/javascript"],
+  "dreamwidth": [
+    "https://dw-news.dreamwidth.org/data/rss",
+    "https://dw-news.dreamwidth.org/data/atom"
+  ],
   "gitea": [
     "https://gitea.com/gitea.rss",
     "https://gitea.com/gitea/go-sdk.rss",

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -428,6 +428,14 @@ Discovers RSS feeds for Ximalaya podcast albums.
 |-------------|-----------------|
 | `www.ximalaya.com/album/{id}` | Album feed |
 
+### Dreamwidth
+
+Discovers RSS and Atom feeds for Dreamwidth blogs.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.dreamwidth.org` | Posts feed (RSS + Atom) |
+
 ## Basic Usage
 
 ```typescript
@@ -484,10 +492,11 @@ import {
   deviantartHandler,
   devtoHandler,
   doubanHandler,
-  goodreadsHandler,
-  githubGistHandler,
+  dreamwidthHandler,
   githubHandler,
+  githubGistHandler,
   gitlabHandler,
+  goodreadsHandler,
   hashnodeHandler,
   hatenablogHandler,
   itchioHandler,

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -163,6 +163,8 @@
     "lemmy:user": "User",
     "lemmy:all": "All",
     "lemmy:local": "Local",
-    "apple-podcasts:podcast": "Podcast"
+    "apple-podcasts:podcast": "Podcast",
+    "dreamwidth:posts-rss": "Posts (RSS)",
+    "dreamwidth:posts-atom": "Posts (Atom)"
   }
 }

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -13,6 +13,7 @@ import { dailymotionHandler } from './platform/handlers/dailymotion.js'
 import { deviantartHandler } from './platform/handlers/deviantart.js'
 import { devtoHandler } from './platform/handlers/devto.js'
 import { doubanHandler } from './platform/handlers/douban.js'
+import { dreamwidthHandler } from './platform/handlers/dreamwidth.js'
 import { githubHandler } from './platform/handlers/github.js'
 import { githubGistHandler } from './platform/handlers/githubGist.js'
 import { gitlabHandler } from './platform/handlers/gitlab.js'
@@ -152,18 +153,19 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     behanceHandler,
     blogspotHandler,
     blueskyHandler,
-    csdnHandler,
     codebergHandler,
-    doubanHandler,
-    deviantartHandler,
+    csdnHandler,
     dailymotionHandler,
+    deviantartHandler,
     devtoHandler,
-    goodreadsHandler,
+    doubanHandler,
+    dreamwidthHandler,
     githubHandler,
-    hashnodeHandler,
-    hatenablogHandler,
     githubGistHandler,
     gitlabHandler,
+    goodreadsHandler,
+    hashnodeHandler,
+    hatenablogHandler,
     itchioHandler,
     kickstarterHandler,
     lemmyHandler,

--- a/src/feeds/platform/handlers/dreamwidth.test.ts
+++ b/src/feeds/platform/handlers/dreamwidth.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test'
+import { dreamwidthHandler } from './dreamwidth.js'
+
+describe('dreamwidthHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://news.dreamwidth.org', true],
+      ['https://blog.example.dreamwidth.org', true],
+      ['https://dreamwidth.org', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(dreamwidthHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(dreamwidthHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return RSS and Atom feeds for blog', () => {
+      const value = 'https://news.dreamwidth.org'
+      const expected = [
+        {
+          uri: 'https://news.dreamwidth.org/data/rss',
+          hint: { key: 'dreamwidth:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://news.dreamwidth.org/data/atom',
+          hint: { key: 'dreamwidth:posts-atom', label: 'Posts (Atom)' },
+        },
+      ]
+
+      expect(dreamwidthHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URLs regardless of path', () => {
+      const value = 'https://news.dreamwidth.org/123456.html'
+      const expected = [
+        {
+          uri: 'https://news.dreamwidth.org/data/rss',
+          hint: { key: 'dreamwidth:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://news.dreamwidth.org/data/atom',
+          hint: { key: 'dreamwidth:posts-atom', label: 'Posts (Atom)' },
+        },
+      ]
+
+      expect(dreamwidthHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/dreamwidth.ts
+++ b/src/feeds/platform/handlers/dreamwidth.ts
@@ -1,0 +1,21 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Partially discoverable without handler.
+
+export const dreamwidthHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'dreamwidth.org')
+  },
+
+  resolve: (url) => {
+    const { origin } = new URL(url)
+    const uris: Array<DiscoverUriEntry> = []
+
+    uris.push({ uri: `${origin}/data/rss`, hint: composeHint('dreamwidth:posts-rss') })
+    uris.push({ uri: `${origin}/data/atom`, hint: composeHint('dreamwidth:posts-atom') })
+
+    return uris
+  },
+}


### PR DESCRIPTION
Discovers RSS and Atom feeds for Dreamwidth blogs.

## Patterns supported

| URL Pattern | Feeds Generated |
|-------------|-----------------|
| `*.dreamwidth.org` | Posts feed (RSS + Atom) |
