### PR TITLE
feat: Add 33 new platform handlers

### DIFF
--- a/check/feeds.json
+++ b/check/feeds.json
@@ -189,6 +189,12 @@
     "https://myanimelist.net/rss.php?type=rm&u=Xinil",
     "https://myanimelist.net/rss.php?type=rrm&u=Xinil"
   ],
+  "pika": [
+    "https://pika.pika.page/posts_feed",
+    "https://pika.pika.page/posts_feed.rss",
+    "https://discardpile.pika.page/tag/tech/feed",
+    "https://discardpile.pika.page/tag/tech/feed.rss"
+  ],
   "pinterest": ["https://www.pinterest.com/pinterest/feed.rss"],
   "producthunt": [
     "https://www.producthunt.com/feed?topic=artificial-intelligence",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -478,5 +478,10 @@
     "https://www.youtube.com/feeds/videos.xml?playlist_id=UUSHXuqSBlHAE6Xw-yeJA0Tunw",
     "https://www.youtube.com/feeds/videos.xml?playlist_id=UULVXuqSBlHAE6Xw-yeJA0Tunw",
     "https://www.youtube.com/feeds/videos.xml?playlist_id=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf"
+  ],
+  "zenn": [
+    "https://zenn.dev/zenn/feed",
+    "https://zenn.dev/topics/react/feed",
+    "https://zenn.dev/p/team_zenn/feed"
   ]
 }

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -68,6 +68,7 @@
     "https://dw-news.dreamwidth.org/data/rss",
     "https://dw-news.dreamwidth.org/data/atom"
   ],
+  "friendica": ["https://libranet.de/feed/admin"],
   "gitea": [
     "https://gitea.com/gitea.rss",
     "https://gitea.com/gitea/go-sdk.rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -227,6 +227,7 @@
     "https://www.reddit.com/user/kjoneslol/m/sfwpornnetwork/.rss",
     "https://www.reddit.com/domain/github.com/.rss"
   ],
+  "rssCom": ["https://media.rss.com/podcasting101/feed.xml"],
   "soundcloud": ["https://feeds.soundcloud.com/users/soundcloud:users:1613713/sounds.rss"],
   "sourceforge": [
     "https://sourceforge.net/p/filezilla/activity/feed",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -113,6 +113,7 @@
   ],
   "hackernews": ["https://news.ycombinator.com/rss", "https://news.ycombinator.com/showrss"],
   "hearthis": ["https://hearthis.at/james-monty-montgomery/podcast/"],
+  "heyWorld": ["https://world.hey.com/dhh/feed.atom"],
   "kickstarter": [
     "https://www.kickstarter.com/projects/elanlee/exploding-kittens/posts.atom",
     "https://www.kickstarter.com/projects/feed.atom"

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -1,4 +1,5 @@
 {
+  "acast": ["https://feeds.acast.com/public/shows/my-dad-wrote-a-porno"],
   "bearblog": ["https://herman.bearblog.dev/feed/", "https://herman.bearblog.dev/feed/?type=rss"],
   "artstation": [
     "https://www.artstation.com/rossdraws.rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -279,6 +279,11 @@
     "https://vimeo.com/channels/staffpicks/videos/rss",
     "https://vimeo.com/groups/animation/videos/rss"
   ],
+  "weblogLol": [
+    "https://adam.weblog.lol/rss.xml",
+    "https://adam.weblog.lol/atom.xml",
+    "https://adam.weblog.lol/feed.json"
+  ],
   "wordpress": [
     "https://wordpress.org/news/feed/",
     "https://wordpress.org/news/?feed=rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -228,6 +228,7 @@
     "https://www.reddit.com/domain/github.com/.rss"
   ],
   "rssCom": ["https://media.rss.com/podcasting101/feed.xml"],
+  "seesaa": ["https://info.seesaa.net/index20.rdf", "https://info.seesaa.net/index.rdf"],
   "soundcloud": ["https://feeds.soundcloud.com/users/soundcloud:users:1613713/sounds.rss"],
   "sourceforge": [
     "https://sourceforge.net/p/filezilla/activity/feed",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -145,6 +145,7 @@
     "https://lobste.rs/comments.rss",
     "https://lobste.rs/rss"
   ],
+  "mataroa": ["https://hey.mataroa.blog/rss/"],
   "medium": [
     "https://medium.com/feed/@ev",
     "https://medium.com/feed/tag/programming",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -207,6 +207,12 @@
     "https://www.producthunt.com/feed"
   ],
   "prose": ["https://hey.prose.sh/rss"],
+  "qiita": [
+    "https://qiita.com/Qiita/feed.atom",
+    "https://qiita.com/tags/javascript/feed.atom",
+    "https://qiita.com/organizations/qiita-inc/activities.atom",
+    "https://qiita.com/popular-items/feed.atom"
+  ],
   "reddit": [
     "https://www.reddit.com/.rss",
     "https://www.reddit.com/r/programming/comments/1qoxwdt/.rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -6,6 +6,7 @@
     "https://rssblog.ameba.jp/shibuya/rss.html"
   ],
   "arena": ["https://www.are.na/charles-broskoski/feed/rss"],
+  "audioboom": ["https://audioboom.com/channels/5071123.rss"],
   "bearblog": ["https://herman.bearblog.dev/feed/", "https://herman.bearblog.dev/feed/?type=rss"],
   "artstation": [
     "https://www.artstation.com/rossdraws.rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -264,6 +264,12 @@
     "https://newsletter.pragmaticengineer.com/feed",
     "https://garymarcus.substack.com/feed"
   ],
+  "tildes": [
+    "https://tildes.net/topics.rss",
+    "https://tildes.net/topics.atom",
+    "https://tildes.net/~tildes/topics.rss",
+    "https://tildes.net/~tildes/topics.atom"
+  ],
   "transistor": ["https://feeds.transistor.fm/build-your-saas"],
   "tistory": ["https://notice.tistory.com/rss"],
   "tumblr": ["https://staff.tumblr.com/rss", "https://staff.tumblr.com/tagged/updates/rss"],

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -196,6 +196,7 @@
     "https://discardpile.pika.page/tag/tech/feed.rss"
   ],
   "pinterest": ["https://www.pinterest.com/pinterest/feed.rss"],
+  "pixelfed": ["https://pixelfed.social/users/dansup.atom"],
   "producthunt": [
     "https://www.producthunt.com/feed?topic=artificial-intelligence",
     "https://www.producthunt.com/feed?category=ai",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -165,6 +165,7 @@
     "https://vincent.micro.blog/photos/index.json",
     "https://vincent.micro.blog/replies.xml"
   ],
+  "misskey": ["https://misskey.io/@ai.atom"],
   "pagecord": ["https://blog.pagecord.com/feed.xml"],
   "note": [
     "https://note.com/info/rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -112,6 +112,7 @@
     "https://www.goodreads.com/review/list_rss/1?shelf=read"
   ],
   "hackernews": ["https://news.ycombinator.com/rss", "https://news.ycombinator.com/showrss"],
+  "hearthis": ["https://hearthis.at/james-monty-montgomery/podcast/"],
   "kickstarter": [
     "https://www.kickstarter.com/projects/elanlee/exploding-kittens/posts.atom",
     "https://www.kickstarter.com/projects/feed.atom"

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -166,6 +166,7 @@
     "https://vincent.micro.blog/replies.xml"
   ],
   "misskey": ["https://misskey.io/@ai.atom"],
+  "naverBlog": ["https://rss.blog.naver.com/naverofficial.xml"],
   "pagecord": ["https://blog.pagecord.com/feed.xml"],
   "note": [
     "https://note.com/info/rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -236,6 +236,7 @@
     "https://sourceforge.net/p/nmap/activity/feed",
     "https://sourceforge.net/projects/nmap/rss"
   ],
+  "spreaker": ["https://www.spreaker.com/show/1433865/episodes/feed"],
   "stackExchange": [
     "https://stackoverflow.com/feeds",
     "https://stackoverflow.com/feeds/tag/javascript",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -131,6 +131,10 @@
   "letterboxd": ["https://letterboxd.com/dave/rss/", "https://letterboxd.com/lynch/rss/"],
   "libsyn": ["https://thefeed.libsyn.com/rss"],
   "listed": ["https://listed.to/@Listed/feed.rss"],
+  "livejournal": [
+    "https://news.livejournal.com/data/rss",
+    "https://news.livejournal.com/data/atom"
+  ],
   "lobsters": [
     "https://lobste.rs/t/programming.rss",
     "https://lobste.rs/domains/github.com.rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -284,6 +284,7 @@
     "https://adam.weblog.lol/atom.xml",
     "https://adam.weblog.lol/feed.json"
   ],
+  "weebly": ["https://ukiyaseed.weebly.com/1/feed"],
   "wordpress": [
     "https://wordpress.org/news/feed/",
     "https://wordpress.org/news/?feed=rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -57,6 +57,11 @@
     "https://backend.deviantart.com/rss.xml?q=journal:yuumei"
   ],
   "devto": ["https://dev.to/feed/ben", "https://dev.to/feed/tag/javascript"],
+  "discourse": [
+    "https://users.rust-lang.org/latest.rss",
+    "https://users.rust-lang.org/c/help.rss",
+    "https://users.rust-lang.org/u/steveklabnik/activity.rss"
+  ],
   "fireside": ["https://feeds.fireside.fm/office/rss", "https://office.fireside.fm/json"],
   "exblog": ["https://petitcc.exblog.jp/index.xml", "https://petitcc.exblog.jp/atom.xml"],
   "dreamwidth": [

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -29,6 +29,7 @@
     "https://security.googleblog.com/feeds/1469360228826887140/comments/default?alt=rss"
   ],
   "bluesky": ["https://bsky.app/profile/jay.bsky.team/rss"],
+  "bookwyrm": ["https://bookwyrm.social/user/mouse/rss"],
   "buttondown": ["https://buttondown.com/jmduke/rss"],
   "codeberg": [
     "https://codeberg.org/forgejo.atom",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -200,6 +200,7 @@
   "pleroma": ["https://lain.com/users/lain/feed.atom"],
   "podbean": ["https://feed.podbean.com/podcast/feed.xml"],
   "podigee": ["https://cui-bono.podigee.io/feed/mp3"],
+  "posthaven": ["https://blog.posthaven.com/posts.atom"],
   "producthunt": [
     "https://www.producthunt.com/feed?topic=artificial-intelligence",
     "https://www.producthunt.com/feed?category=ai",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -5,6 +5,7 @@
     "https://ameblo.jp/shibuya/atom.xml",
     "https://rssblog.ameba.jp/shibuya/rss.html"
   ],
+  "arena": ["https://www.are.na/charles-broskoski/feed/rss"],
   "bearblog": ["https://herman.bearblog.dev/feed/", "https://herman.bearblog.dev/feed/?type=rss"],
   "artstation": [
     "https://www.artstation.com/rossdraws.rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -197,6 +197,7 @@
   ],
   "pinterest": ["https://www.pinterest.com/pinterest/feed.rss"],
   "pixelfed": ["https://pixelfed.social/users/dansup.atom"],
+  "pleroma": ["https://lain.com/users/lain/feed.atom"],
   "producthunt": [
     "https://www.producthunt.com/feed?topic=artificial-intelligence",
     "https://www.producthunt.com/feed?category=ai",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -31,6 +31,7 @@
   "bluesky": ["https://bsky.app/profile/jay.bsky.team/rss"],
   "bookwyrm": ["https://bookwyrm.social/user/mouse/rss"],
   "buttondown": ["https://buttondown.com/jmduke/rss"],
+  "buzzsprout": ["https://rss.buzzsprout.com/231452.rss"],
   "codeberg": [
     "https://codeberg.org/forgejo.atom",
     "https://codeberg.org/forgejo.rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -167,6 +167,10 @@
   ],
   "misskey": ["https://misskey.io/@ai.atom"],
   "naverBlog": ["https://rss.blog.naver.com/naverofficial.xml"],
+  "observable": [
+    "https://api.observablehq.com/documents/@mbostock.rss",
+    "https://api.observablehq.com/collection/@observablehq/visualization.rss"
+  ],
   "pagecord": ["https://blog.pagecord.com/feed.xml"],
   "note": [
     "https://note.com/info/rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -198,6 +198,7 @@
   "pinterest": ["https://www.pinterest.com/pinterest/feed.rss"],
   "pixelfed": ["https://pixelfed.social/users/dansup.atom"],
   "pleroma": ["https://lain.com/users/lain/feed.atom"],
+  "podbean": ["https://feed.podbean.com/podcast/feed.xml"],
   "producthunt": [
     "https://www.producthunt.com/feed?topic=artificial-intelligence",
     "https://www.producthunt.com/feed?category=ai",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -114,6 +114,10 @@
   "hackernews": ["https://news.ycombinator.com/rss", "https://news.ycombinator.com/showrss"],
   "hearthis": ["https://hearthis.at/james-monty-montgomery/podcast/"],
   "heyWorld": ["https://world.hey.com/dhh/feed.atom"],
+  "insanejournal": [
+    "https://random.insanejournal.com/data/rss",
+    "https://random.insanejournal.com/data/atom"
+  ],
   "kickstarter": [
     "https://www.kickstarter.com/projects/elanlee/exploding-kittens/posts.atom",
     "https://www.kickstarter.com/projects/feed.atom"

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -69,6 +69,11 @@
     "https://dw-news.dreamwidth.org/data/atom"
   ],
   "friendica": ["https://libranet.de/feed/admin"],
+  "ghost": [
+    "https://demo.ghost.io/rss/",
+    "https://demo.ghost.io/tag/getting-started/rss/",
+    "https://demo.ghost.io/author/ghost/rss/"
+  ],
   "gitea": [
     "https://gitea.com/gitea.rss",
     "https://gitea.com/gitea/go-sdk.rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -199,6 +199,7 @@
   "pixelfed": ["https://pixelfed.social/users/dansup.atom"],
   "pleroma": ["https://lain.com/users/lain/feed.atom"],
   "podbean": ["https://feed.podbean.com/podcast/feed.xml"],
+  "podigee": ["https://cui-bono.podigee.io/feed/mp3"],
   "producthunt": [
     "https://www.producthunt.com/feed?topic=artificial-intelligence",
     "https://www.producthunt.com/feed?category=ai",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -129,6 +129,7 @@
     "https://lemmy.ml/feeds/local.xml"
   ],
   "letterboxd": ["https://letterboxd.com/dave/rss/", "https://letterboxd.com/lynch/rss/"],
+  "libsyn": ["https://thefeed.libsyn.com/rss"],
   "listed": ["https://listed.to/@Listed/feed.rss"],
   "lobsters": [
     "https://lobste.rs/t/programming.rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -1,5 +1,10 @@
 {
   "acast": ["https://feeds.acast.com/public/shows/my-dad-wrote-a-porno"],
+  "ameblo": [
+    "https://ameblo.jp/shibuya/rss20.xml",
+    "https://ameblo.jp/shibuya/atom.xml",
+    "https://rssblog.ameba.jp/shibuya/rss.html"
+  ],
   "bearblog": ["https://herman.bearblog.dev/feed/", "https://herman.bearblog.dev/feed/?type=rss"],
   "artstation": [
     "https://www.artstation.com/rossdraws.rss",

--- a/check/feeds.json
+++ b/check/feeds.json
@@ -157,6 +157,14 @@
     "https://mastodon.social/tags/mastodon.rss",
     "https://mastodon.social/@Gargron/tagged/mastodev.rss"
   ],
+  "microblog": [
+    "https://vincent.micro.blog/feed.xml",
+    "https://vincent.micro.blog/feed.json",
+    "https://vincent.micro.blog/podcast.xml",
+    "https://vincent.micro.blog/archive/index.json",
+    "https://vincent.micro.blog/photos/index.json",
+    "https://vincent.micro.blog/replies.xml"
+  ],
   "pagecord": ["https://blog.pagecord.com/feed.xml"],
   "note": [
     "https://note.com/info/rss",

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -859,6 +859,15 @@ Discovers RSS, Atom, and JSON feeds for weblog.lol blogs.
 |-------------|-----------------|
 | `*.weblog.lol` | Posts feed (RSS + Atom + JSON) |
 
+### Weebly
+
+Discovers RSS feeds for Weebly-hosted blogs.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.weebly.com` | Blog feed |
+| `*.weebly.com/{slug}` | Blog feed (custom page slug) |
+
 ## Basic Usage
 
 ```typescript
@@ -986,6 +995,7 @@ import {
   velogHandler,
   vimeoHandler,
   weblogLolHandler,
+  weeblyHandler,
   wordpressHandler,
   wpengineHandler,
   writeasHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -602,6 +602,14 @@ Discovers RSS feeds for Acast-hosted podcasts.
 |-------------|-----------------|
 | `shows.acast.com/{slug}` | Podcast feed (RSS) |
 
+### Ameba Blog
+
+Discovers RSS, Atom, and RDF feeds for Ameba Blog.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `ameblo.jp/{user}` | Posts feed (RSS + Atom + RDF) |
+
 ## Basic Usage
 
 ```typescript
@@ -649,6 +657,7 @@ Or import individual handlers:
 ```typescript
 import {
   acastHandler,
+  amebloHandler,
   applePodcastsHandler,
   artstationHandler,
   bearblogHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -696,6 +696,14 @@ Discovers RSS and Atom feeds for InsaneJournal journals.
 |-------------|-----------------|
 | `*.insanejournal.com` | Posts feed (RSS + Atom) |
 
+### Libsyn
+
+Discovers RSS feeds for Libsyn-hosted podcasts.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.libsyn.com` | Podcast feed |
+
 ## Basic Usage
 
 ```typescript
@@ -780,6 +788,7 @@ import {
   itchioHandler,
   kickstarterHandler,
   letterboxdHandler,
+  libsynHandler,
   listedHandler,
   lobstersHandler,
   mastodonHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -799,6 +799,14 @@ Discovers RSS feeds for Podigee-hosted podcasts.
 |-------------|-----------------|
 | `*.podigee.io` | Podcast feed (RSS) |
 
+### Posthaven
+
+Discovers Atom feeds for Posthaven blogs.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.posthaven.com` | Posts feed (Atom) |
+
 ## Basic Usage
 
 ```typescript
@@ -905,6 +913,7 @@ import {
   pleromaHandler,
   podbeanHandler,
   podigeeHandler,
+  posthavenHandler,
   producthuntHandler,
   proseHandler,
   redditHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -672,6 +672,14 @@ Discovers RSS feeds for Ghost-hosted blogs, including tag and author feeds.
 | `*.ghost.io/tag/{slug}` | Tag feed + blog |
 | `*.ghost.io/author/{slug}` | Author feed + blog |
 
+### Hearthis.at
+
+Discovers RSS feeds for Hearthis.at user profiles.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `hearthis.at/{user}` | Tracks feed |
+
 ## Basic Usage
 
 ```typescript
@@ -750,6 +758,7 @@ import {
   hackernewsHandler,
   hashnodeHandler,
   hatenablogHandler,
+  hearthisHandler,
   itchioHandler,
   kickstarterHandler,
   letterboxdHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -807,6 +807,17 @@ Discovers Atom feeds for Posthaven blogs.
 |-------------|-----------------|
 | `*.posthaven.com` | Posts feed (Atom) |
 
+### Qiita
+
+Discovers Atom feeds for Qiita users, tags, organizations, and popular items.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `qiita.com/{user}` | User posts feed |
+| `qiita.com/tags/{tag}` | Tag feed |
+| `qiita.com/organizations/{org}` | Organization feed |
+| `qiita.com/popular-items` | Popular items feed |
+
 ## Basic Usage
 
 ```typescript
@@ -916,6 +927,7 @@ import {
   posthavenHandler,
   producthuntHandler,
   proseHandler,
+  qiitaHandler,
   redditHandler,
   soundcloudHandler,
   sourceforgeHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -740,6 +740,15 @@ Discovers Atom feeds for Misskey user profiles. Detected by the `Misskey` applic
 |-------------|-----------------|
 | `{instance}/@{user}` | Posts feed (Atom) |
 
+### Naver Blog
+
+Discovers RSS feeds for Naver Blog.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `blog.naver.com/{id}` | Blog feed |
+| `m.blog.naver.com/{id}` | Blog feed |
+
 ## Basic Usage
 
 ```typescript
@@ -834,6 +843,7 @@ import {
   microblogHandler,
   misskeyHandler,
   myanimelistHandler,
+  naverBlogHandler,
   nebulaHandler,
   noteHandler,
   odyseeHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -868,6 +868,17 @@ Discovers RSS feeds for Weebly-hosted blogs.
 | `*.weebly.com` | Blog feed |
 | `*.weebly.com/{slug}` | Blog feed (custom page slug) |
 
+### Zenn
+
+Discovers RSS feeds for Zenn users, topics, and publications.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `zenn.dev/{user}` | User posts feed |
+| `zenn.dev/topics/{topic}` | Topic feed |
+| `zenn.dev/p/{pub}` | Publication feed |
+| `zenn.dev/publications/{pub}` | Publication feed |
+
 ## Basic Usage
 
 ```typescript
@@ -1001,6 +1012,7 @@ import {
   writeasHandler,
   ximalayaHandler,
   youtubeHandler,
+  zennHandler,
 } from 'feedscout/platform'
 ```
 

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -643,6 +643,17 @@ Discovers RSS feeds for Buzzsprout-hosted podcasts.
 |-------------|-----------------|
 | `buzzsprout.com/{id}` | Podcast feed |
 
+### Discourse
+
+Discovers RSS feeds for Discourse forums. Detected by the `Discourse` generator meta tag.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `{instance}/u/{user}` | User activity feed (RSS) |
+| `{instance}/c/{slug}` | Category feed (RSS) |
+| `{instance}/t/{slug}/{id}` | Topic feed (RSS) |
+| `{instance}/` (or any other path) | Latest topics feed (RSS) |
+
 ## Basic Usage
 
 ```typescript
@@ -707,6 +718,7 @@ import {
   dailymotionHandler,
   deviantartHandler,
   devtoHandler,
+  discourseHandler,
   doubanHandler,
   dreamwidthHandler,
   exblogHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -704,6 +704,14 @@ Discovers RSS feeds for Libsyn-hosted podcasts.
 |-------------|-----------------|
 | `*.libsyn.com` | Podcast feed |
 
+### LiveJournal
+
+Discovers RSS and Atom feeds for LiveJournal blogs.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.livejournal.com` | Posts feed (RSS + Atom) |
+
 ## Basic Usage
 
 ```typescript
@@ -790,6 +798,7 @@ import {
   letterboxdHandler,
   libsynHandler,
   listedHandler,
+  livejournalHandler,
   lobstersHandler,
   mastodonHandler,
   mediumHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -594,6 +594,14 @@ Discovers RSS feeds for Velog users.
 |-------------|-----------------|
 | `velog.io/@{user}` | Posts feed |
 
+### Acast
+
+Discovers RSS feeds for Acast-hosted podcasts.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `shows.acast.com/{slug}` | Podcast feed (RSS) |
+
 ## Basic Usage
 
 ```typescript
@@ -640,9 +648,10 @@ Or import individual handlers:
 
 ```typescript
 import {
+  acastHandler,
   applePodcastsHandler,
-  bearblogHandler,
   artstationHandler,
+  bearblogHandler,
   behanceHandler,
   blogspotHandler,
   blueskyHandler,
@@ -670,11 +679,11 @@ import {
   lobstersHandler,
   mastodonHandler,
   mediumHandler,
-  pagecordHandler,
   myanimelistHandler,
   nebulaHandler,
   noteHandler,
   odyseeHandler,
+  pagecordHandler,
   paragraphHandler,
   producthuntHandler,
   proseHandler,
@@ -684,8 +693,8 @@ import {
   stackExchangeHandler,
   steamHandler,
   substackHandler,
-  transistorHandler,
   tistoryHandler,
+  transistorHandler,
   tumblrHandler,
   v2exHandler,
   velogHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -758,6 +758,15 @@ Discovers RSS feeds for Observable user notebooks and collections.
 | `observablehq.com/@{user}` | Notebooks feed |
 | `observablehq.com/@{user}/collection/{slug}` | Collection feed |
 
+### Pika
+
+Discovers Atom and RSS feeds for Pika blogs, including tag feeds.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.pika.page` | Posts feed (Atom + RSS) |
+| `*.pika.page/tag/{tag}` | Tag feed (Atom + RSS) + posts |
+
 ## Basic Usage
 
 ```typescript
@@ -859,6 +868,7 @@ import {
   odyseeHandler,
   pagecordHandler,
   paragraphHandler,
+  pikaHandler,
   producthuntHandler,
   proseHandler,
   redditHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -627,6 +627,14 @@ Discovers RSS and JSON feeds for Audioboom channels.
 |-------------|-----------------|
 | `audioboom.com/channels/{id}` | Podcast feed (RSS) |
 
+### BookWyrm
+
+Discovers RSS feeds for BookWyrm user reviews. Detected by the `BookWyrm` generator meta tag.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `{instance}/user/{user}` | Reviews feed (RSS) |
+
 ## Basic Usage
 
 ```typescript
@@ -683,6 +691,7 @@ import {
   behanceHandler,
   blogspotHandler,
   blueskyHandler,
+  bookwyrmHandler,
   buttondownHandler,
   codebergHandler,
   csdnHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -688,6 +688,14 @@ Discovers Atom feeds for HEY World blogs.
 |-------------|-----------------|
 | `world.hey.com/{user}` | Blog feed |
 
+### InsaneJournal
+
+Discovers RSS and Atom feeds for InsaneJournal journals.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.insanejournal.com` | Posts feed (RSS + Atom) |
+
 ## Basic Usage
 
 ```typescript
@@ -768,6 +776,7 @@ import {
   hatenablogHandler,
   hearthisHandler,
   heyWorldHandler,
+  insanejournalHandler,
   itchioHandler,
   kickstarterHandler,
   letterboxdHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -749,6 +749,15 @@ Discovers RSS feeds for Naver Blog.
 | `blog.naver.com/{id}` | Blog feed |
 | `m.blog.naver.com/{id}` | Blog feed |
 
+### Observable
+
+Discovers RSS feeds for Observable user notebooks and collections.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `observablehq.com/@{user}` | Notebooks feed |
+| `observablehq.com/@{user}/collection/{slug}` | Collection feed |
+
 ## Basic Usage
 
 ```typescript
@@ -846,6 +855,7 @@ import {
   naverBlogHandler,
   nebulaHandler,
   noteHandler,
+  observableHandler,
   odyseeHandler,
   pagecordHandler,
   paragraphHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -732,6 +732,14 @@ Discovers RSS, JSON, and podcast feeds for Micro.blog-hosted blogs, including ca
 | `*.micro.blog/photos` | Photos feed + above |
 | `*.micro.blog/replies` | Replies feed + above |
 
+### Misskey
+
+Discovers Atom feeds for Misskey user profiles. Detected by the `Misskey` application-name meta tag.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `{instance}/@{user}` | Posts feed (Atom) |
+
 ## Basic Usage
 
 ```typescript
@@ -824,6 +832,7 @@ import {
   mataroaHandler,
   mediumHandler,
   microblogHandler,
+  misskeyHandler,
   myanimelistHandler,
   nebulaHandler,
   noteHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -680,6 +680,14 @@ Discovers RSS feeds for Hearthis.at user profiles.
 |-------------|-----------------|
 | `hearthis.at/{user}` | Tracks feed |
 
+### HEY World
+
+Discovers Atom feeds for HEY World blogs.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `world.hey.com/{user}` | Blog feed |
+
 ## Basic Usage
 
 ```typescript
@@ -759,6 +767,7 @@ import {
   hashnodeHandler,
   hatenablogHandler,
   hearthisHandler,
+  heyWorldHandler,
   itchioHandler,
   kickstarterHandler,
   letterboxdHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -834,6 +834,14 @@ Discovers RSS 2.0 and RDF feeds for Seesaa Blog.
 |-------------|-----------------|
 | `*.seesaa.net` | Posts feed (RSS 2.0 + RDF) |
 
+### Spreaker
+
+Discovers RSS feeds for Spreaker-hosted podcasts.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `spreaker.com/podcast/{slug}--{id}` | Podcast feed |
+
 ## Basic Usage
 
 ```typescript
@@ -949,6 +957,7 @@ import {
   seesaaHandler,
   soundcloudHandler,
   sourceforgeHandler,
+  spreakerHandler,
   stackExchangeHandler,
   steamHandler,
   substackHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -775,6 +775,14 @@ Discovers Atom feeds for Pixelfed user profiles. Detected by the `pixelfed` gene
 |-------------|-----------------|
 | `{instance}/{user}` or `{instance}/users/{user}` | Posts feed (Atom) |
 
+### Pleroma
+
+Discovers Atom feeds for Pleroma (and Akkoma) user profiles. Detected by Pleroma-specific API endpoint references in HTML.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `{instance}/users/{user}` | Posts feed (Atom) |
+
 ## Basic Usage
 
 ```typescript
@@ -878,6 +886,7 @@ import {
   paragraphHandler,
   pikaHandler,
   pixelfedHandler,
+  pleromaHandler,
   producthuntHandler,
   proseHandler,
   redditHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -720,6 +720,18 @@ Discovers RSS feeds for Mataroa blogs.
 |-------------|-----------------|
 | `*.mataroa.blog` | Blog feed |
 
+### Micro.blog
+
+Discovers RSS, JSON, and podcast feeds for Micro.blog-hosted blogs, including category, archive, photos, and replies feeds.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.micro.blog` | Posts (RSS + JSON) + podcast |
+| `*.micro.blog/categories/{slug}` | Category (RSS + JSON) + above |
+| `*.micro.blog/archive` | Archive feed + above |
+| `*.micro.blog/photos` | Photos feed + above |
+| `*.micro.blog/replies` | Replies feed + above |
+
 ## Basic Usage
 
 ```typescript
@@ -811,6 +823,7 @@ import {
   mastodonHandler,
   mataroaHandler,
   mediumHandler,
+  microblogHandler,
   myanimelistHandler,
   nebulaHandler,
   noteHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -851,6 +851,14 @@ Discovers RSS and Atom feeds for Tildes homepage and groups.
 | `tildes.net` | Topics feed (RSS + Atom) |
 | `tildes.net/~{group}` | Group feed (RSS + Atom) |
 
+### weblog.lol
+
+Discovers RSS, Atom, and JSON feeds for weblog.lol blogs.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.weblog.lol` | Posts feed (RSS + Atom + JSON) |
+
 ## Basic Usage
 
 ```typescript
@@ -977,6 +985,7 @@ import {
   v2exHandler,
   velogHandler,
   vimeoHandler,
+  weblogLolHandler,
   wordpressHandler,
   wpengineHandler,
   writeasHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -635,6 +635,14 @@ Discovers RSS feeds for BookWyrm user reviews. Detected by the `BookWyrm` genera
 |-------------|-----------------|
 | `{instance}/user/{user}` | Reviews feed (RSS) |
 
+### Buzzsprout
+
+Discovers RSS feeds for Buzzsprout-hosted podcasts.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `buzzsprout.com/{id}` | Podcast feed |
+
 ## Basic Usage
 
 ```typescript
@@ -693,6 +701,7 @@ import {
   blueskyHandler,
   bookwyrmHandler,
   buttondownHandler,
+  buzzsproutHandler,
   codebergHandler,
   csdnHandler,
   dailymotionHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -610,6 +610,15 @@ Discovers RSS, Atom, and RDF feeds for Ameba Blog.
 |-------------|-----------------|
 | `ameblo.jp/{user}` | Posts feed (RSS + Atom + RDF) |
 
+### Are.na
+
+Discovers RSS feeds for Are.na user profiles and channels.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `are.na/{user}` | User profile feed |
+| `are.na/{user}/{channel}` | Channel feed |
+
 ## Basic Usage
 
 ```typescript
@@ -659,6 +668,7 @@ import {
   acastHandler,
   amebloHandler,
   applePodcastsHandler,
+  arenaHandler,
   artstationHandler,
   bearblogHandler,
   behanceHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -619,6 +619,14 @@ Discovers RSS feeds for Are.na user profiles and channels.
 | `are.na/{user}` | User profile feed |
 | `are.na/{user}/{channel}` | Channel feed |
 
+### Audioboom
+
+Discovers RSS and JSON feeds for Audioboom channels.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `audioboom.com/channels/{id}` | Podcast feed (RSS) |
+
 ## Basic Usage
 
 ```typescript
@@ -670,6 +678,7 @@ import {
   applePodcastsHandler,
   arenaHandler,
   artstationHandler,
+  audioboomHandler,
   bearblogHandler,
   behanceHandler,
   blogspotHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -783,6 +783,14 @@ Discovers Atom feeds for Pleroma (and Akkoma) user profiles. Detected by Pleroma
 |-------------|-----------------|
 | `{instance}/users/{user}` | Posts feed (Atom) |
 
+### Podbean
+
+Discovers RSS feeds for Podbean-hosted podcasts.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.podbean.com` | Podcast feed |
+
 ## Basic Usage
 
 ```typescript
@@ -887,6 +895,7 @@ import {
   pikaHandler,
   pixelfedHandler,
   pleromaHandler,
+  podbeanHandler,
   producthuntHandler,
   proseHandler,
   redditHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -712,6 +712,14 @@ Discovers RSS and Atom feeds for LiveJournal blogs.
 |-------------|-----------------|
 | `*.livejournal.com` | Posts feed (RSS + Atom) |
 
+### Mataroa
+
+Discovers RSS feeds for Mataroa blogs.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.mataroa.blog` | Blog feed |
+
 ## Basic Usage
 
 ```typescript
@@ -801,6 +809,7 @@ import {
   livejournalHandler,
   lobstersHandler,
   mastodonHandler,
+  mataroaHandler,
   mediumHandler,
   myanimelistHandler,
   nebulaHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -842,6 +842,15 @@ Discovers RSS feeds for Spreaker-hosted podcasts.
 |-------------|-----------------|
 | `spreaker.com/podcast/{slug}--{id}` | Podcast feed |
 
+### Tildes
+
+Discovers RSS and Atom feeds for Tildes homepage and groups.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `tildes.net` | Topics feed (RSS + Atom) |
+| `tildes.net/~{group}` | Group feed (RSS + Atom) |
+
 ## Basic Usage
 
 ```typescript
@@ -961,6 +970,7 @@ import {
   stackExchangeHandler,
   steamHandler,
   substackHandler,
+  tildesHandler,
   tistoryHandler,
   transistorHandler,
   tumblrHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -818,6 +818,14 @@ Discovers Atom feeds for Qiita users, tags, organizations, and popular items.
 | `qiita.com/organizations/{org}` | Organization feed |
 | `qiita.com/popular-items` | Popular items feed |
 
+### RSS.com
+
+Discovers RSS feeds for RSS.com-hosted podcasts.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `rss.com/podcasts/{slug}` | Podcast feed |
+
 ## Basic Usage
 
 ```typescript
@@ -929,6 +937,7 @@ import {
   proseHandler,
   qiitaHandler,
   redditHandler,
+  rssComHandler,
   soundcloudHandler,
   sourceforgeHandler,
   stackExchangeHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -662,6 +662,16 @@ Discovers Atom feeds for Friendica user profiles. Detected by the `Friendica` ge
 |-------------|-----------------|
 | `{instance}/profile/{user}` | Posts feed (Atom) |
 
+### Ghost
+
+Discovers RSS feeds for Ghost-hosted blogs, including tag and author feeds.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.ghost.io` | Blog feed |
+| `*.ghost.io/tag/{slug}` | Tag feed + blog |
+| `*.ghost.io/author/{slug}` | Author feed + blog |
+
 ## Basic Usage
 
 ```typescript
@@ -732,6 +742,7 @@ import {
   exblogHandler,
   firesideHandler,
   friendicaHandler,
+  ghostHandler,
   githubHandler,
   githubGistHandler,
   gitlabHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -791,6 +791,14 @@ Discovers RSS feeds for Podbean-hosted podcasts.
 |-------------|-----------------|
 | `*.podbean.com` | Podcast feed |
 
+### Podigee
+
+Discovers RSS feeds for Podigee-hosted podcasts.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.podigee.io` | Podcast feed (RSS) |
+
 ## Basic Usage
 
 ```typescript
@@ -896,6 +904,7 @@ import {
   pixelfedHandler,
   pleromaHandler,
   podbeanHandler,
+  podigeeHandler,
   producthuntHandler,
   proseHandler,
   redditHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -767,6 +767,14 @@ Discovers Atom and RSS feeds for Pika blogs, including tag feeds.
 | `*.pika.page` | Posts feed (Atom + RSS) |
 | `*.pika.page/tag/{tag}` | Tag feed (Atom + RSS) + posts |
 
+### Pixelfed
+
+Discovers Atom feeds for Pixelfed user profiles. Detected by the `pixelfed` generator meta tag.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `{instance}/{user}` or `{instance}/users/{user}` | Posts feed (Atom) |
+
 ## Basic Usage
 
 ```typescript
@@ -869,6 +877,7 @@ import {
   pagecordHandler,
   paragraphHandler,
   pikaHandler,
+  pixelfedHandler,
   producthuntHandler,
   proseHandler,
   redditHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -654,6 +654,14 @@ Discovers RSS feeds for Discourse forums. Detected by the `Discourse` generator 
 | `{instance}/t/{slug}/{id}` | Topic feed (RSS) |
 | `{instance}/` (or any other path) | Latest topics feed (RSS) |
 
+### Friendica
+
+Discovers Atom feeds for Friendica user profiles. Detected by the `Friendica` generator meta tag.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `{instance}/profile/{user}` | Posts feed (Atom) |
+
 ## Basic Usage
 
 ```typescript
@@ -723,6 +731,7 @@ import {
   dreamwidthHandler,
   exblogHandler,
   firesideHandler,
+  friendicaHandler,
   githubHandler,
   githubGistHandler,
   gitlabHandler,

--- a/docs/feeds/platform.md
+++ b/docs/feeds/platform.md
@@ -826,6 +826,14 @@ Discovers RSS feeds for RSS.com-hosted podcasts.
 |-------------|-----------------|
 | `rss.com/podcasts/{slug}` | Podcast feed |
 
+### Seesaa Blog
+
+Discovers RSS 2.0 and RDF feeds for Seesaa Blog.
+
+| URL Pattern | Feeds Generated |
+|-------------|-----------------|
+| `*.seesaa.net` | Posts feed (RSS 2.0 + RDF) |
+
 ## Basic Usage
 
 ```typescript
@@ -938,6 +946,7 @@ import {
   qiitaHandler,
   redditHandler,
   rssComHandler,
+  seesaaHandler,
   soundcloudHandler,
   sourceforgeHandler,
   stackExchangeHandler,

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -212,6 +212,10 @@
     "arena:channel": "Channel",
     "audioboom:podcast": "Podcast",
     "bookwyrm:reviews": "Reviews",
-    "buzzsprout:podcast": "Podcast"
+    "buzzsprout:podcast": "Podcast",
+    "discourse:latest": "Latest",
+    "discourse:category": "Category",
+    "discourse:topic": "Topic",
+    "discourse:activity": "Activity"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -257,6 +257,10 @@
     "rss-com:podcast": "Podcast",
     "seesaa:posts-rss2": "Posts (RSS 2.0)",
     "seesaa:posts-rdf": "Posts (RDF)",
-    "spreaker:podcast": "Podcast"
+    "spreaker:podcast": "Podcast",
+    "tildes:topics-rss": "Topics (RSS)",
+    "tildes:topics-atom": "Topics (Atom)",
+    "tildes:group-rss": "Group (RSS)",
+    "tildes:group-atom": "Group (Atom)"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -245,6 +245,7 @@
     "pika:posts-rss": "Posts (RSS)",
     "pika:tag-atom": "Tag (Atom)",
     "pika:tag-rss": "Tag (RSS)",
-    "pixelfed:posts": "Posts"
+    "pixelfed:posts": "Posts",
+    "pleroma:posts": "Posts"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -240,6 +240,10 @@
     "misskey:posts": "Posts",
     "naver-blog:blog": "Blog",
     "observable:notebooks": "Notebooks",
-    "observable:collection": "Collection"
+    "observable:collection": "Collection",
+    "pika:posts-atom": "Posts (Atom)",
+    "pika:posts-rss": "Posts (RSS)",
+    "pika:tag-atom": "Tag (Atom)",
+    "pika:tag-rss": "Tag (RSS)"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -227,6 +227,7 @@
     "insanejournal:posts-atom": "Posts (Atom)",
     "libsyn:podcast": "Podcast",
     "livejournal:posts-rss": "Posts (RSS)",
-    "livejournal:posts-atom": "Posts (Atom)"
+    "livejournal:posts-atom": "Posts (Atom)",
+    "mataroa:blog": "Blog"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -238,6 +238,8 @@
     "microblog:photos": "Photos",
     "microblog:replies": "Replies",
     "misskey:posts": "Posts",
-    "naver-blog:blog": "Blog"
+    "naver-blog:blog": "Blog",
+    "observable:notebooks": "Notebooks",
+    "observable:collection": "Collection"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -256,6 +256,7 @@
     "qiita:popular": "Popular items",
     "rss-com:podcast": "Podcast",
     "seesaa:posts-rss2": "Posts (RSS 2.0)",
-    "seesaa:posts-rdf": "Posts (RDF)"
+    "seesaa:posts-rdf": "Posts (RDF)",
+    "spreaker:podcast": "Podcast"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -209,6 +209,7 @@
     "ameblo:posts-atom": "Posts (Atom)",
     "ameblo:posts-rdf": "Posts (RDF)",
     "arena:profile": "Profile",
-    "arena:channel": "Channel"
+    "arena:channel": "Channel",
+    "audioboom:podcast": "Podcast"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -204,6 +204,9 @@
     "nebula:videos-all-plus": "All Videos (Plus)",
     "nebula:category": "Category",
     "nebula:category-plus": "Category (Plus)",
-    "acast:podcast": "Podcast"
+    "acast:podcast": "Podcast",
+    "ameblo:posts-rss": "Posts (RSS)",
+    "ameblo:posts-atom": "Posts (Atom)",
+    "ameblo:posts-rdf": "Posts (RDF)"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -222,6 +222,8 @@
     "ghost:tag": "Tag",
     "ghost:author": "Author",
     "hearthis:tracks": "Tracks",
-    "hey-world:blog": "Blog"
+    "hey-world:blog": "Blog",
+    "insanejournal:posts-rss": "Posts (RSS)",
+    "insanejournal:posts-atom": "Posts (Atom)"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -244,6 +244,7 @@
     "pika:posts-atom": "Posts (Atom)",
     "pika:posts-rss": "Posts (RSS)",
     "pika:tag-atom": "Tag (Atom)",
-    "pika:tag-rss": "Tag (RSS)"
+    "pika:tag-rss": "Tag (RSS)",
+    "pixelfed:posts": "Posts"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -203,6 +203,7 @@
     "nebula:videos-all": "All Videos",
     "nebula:videos-all-plus": "All Videos (Plus)",
     "nebula:category": "Category",
-    "nebula:category-plus": "Category (Plus)"
+    "nebula:category-plus": "Category (Plus)",
+    "acast:podcast": "Podcast"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -246,6 +246,7 @@
     "pika:tag-atom": "Tag (Atom)",
     "pika:tag-rss": "Tag (RSS)",
     "pixelfed:posts": "Posts",
-    "pleroma:posts": "Posts"
+    "pleroma:posts": "Posts",
+    "podbean:podcast": "Podcast"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -247,6 +247,7 @@
     "pika:tag-rss": "Tag (RSS)",
     "pixelfed:posts": "Posts",
     "pleroma:posts": "Posts",
-    "podbean:podcast": "Podcast"
+    "podbean:podcast": "Podcast",
+    "podigee:podcast": "Podcast"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -248,6 +248,7 @@
     "pixelfed:posts": "Posts",
     "pleroma:posts": "Posts",
     "podbean:podcast": "Podcast",
-    "podigee:podcast": "Podcast"
+    "podigee:podcast": "Podcast",
+    "posthaven:posts": "Posts"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -225,6 +225,8 @@
     "hey-world:blog": "Blog",
     "insanejournal:posts-rss": "Posts (RSS)",
     "insanejournal:posts-atom": "Posts (Atom)",
-    "libsyn:podcast": "Podcast"
+    "libsyn:podcast": "Podcast",
+    "livejournal:posts-rss": "Posts (RSS)",
+    "livejournal:posts-atom": "Posts (Atom)"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -264,6 +264,7 @@
     "tildes:group-atom": "Group (Atom)",
     "weblog-lol:posts-rss": "Posts (RSS)",
     "weblog-lol:posts-atom": "Posts (Atom)",
-    "weblog-lol:posts-json": "Posts (JSON)"
+    "weblog-lol:posts-json": "Posts (JSON)",
+    "weebly:blog": "Blog"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -207,6 +207,8 @@
     "acast:podcast": "Podcast",
     "ameblo:posts-rss": "Posts (RSS)",
     "ameblo:posts-atom": "Posts (Atom)",
-    "ameblo:posts-rdf": "Posts (RDF)"
+    "ameblo:posts-rdf": "Posts (RDF)",
+    "arena:profile": "Profile",
+    "arena:channel": "Channel"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -228,6 +228,14 @@
     "libsyn:podcast": "Podcast",
     "livejournal:posts-rss": "Posts (RSS)",
     "livejournal:posts-atom": "Posts (Atom)",
-    "mataroa:blog": "Blog"
+    "mataroa:blog": "Blog",
+    "microblog:posts-rss": "Posts (RSS)",
+    "microblog:posts-json": "Posts (JSON)",
+    "microblog:podcast": "Podcast",
+    "microblog:category-rss": "Category (RSS)",
+    "microblog:category-json": "Category (JSON)",
+    "microblog:archive": "Archive",
+    "microblog:photos": "Photos",
+    "microblog:replies": "Replies"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -265,6 +265,9 @@
     "weblog-lol:posts-rss": "Posts (RSS)",
     "weblog-lol:posts-atom": "Posts (Atom)",
     "weblog-lol:posts-json": "Posts (JSON)",
-    "weebly:blog": "Blog"
+    "weebly:blog": "Blog",
+    "zenn:posts": "Posts",
+    "zenn:topic": "Topic",
+    "zenn:publication": "Publication"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -236,6 +236,7 @@
     "microblog:category-json": "Category (JSON)",
     "microblog:archive": "Archive",
     "microblog:photos": "Photos",
-    "microblog:replies": "Replies"
+    "microblog:replies": "Replies",
+    "misskey:posts": "Posts"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -249,6 +249,10 @@
     "pleroma:posts": "Posts",
     "podbean:podcast": "Podcast",
     "podigee:podcast": "Podcast",
-    "posthaven:posts": "Posts"
+    "posthaven:posts": "Posts",
+    "qiita:posts": "Posts",
+    "qiita:tag": "Tag",
+    "qiita:organization": "Organization",
+    "qiita:popular": "Popular items"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -237,6 +237,7 @@
     "microblog:archive": "Archive",
     "microblog:photos": "Photos",
     "microblog:replies": "Replies",
-    "misskey:posts": "Posts"
+    "misskey:posts": "Posts",
+    "naver-blog:blog": "Blog"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -217,6 +217,9 @@
     "discourse:category": "Category",
     "discourse:topic": "Topic",
     "discourse:activity": "Activity",
-    "friendica:posts": "Posts"
+    "friendica:posts": "Posts",
+    "ghost:blog": "Blog",
+    "ghost:tag": "Tag",
+    "ghost:author": "Author"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -220,6 +220,7 @@
     "friendica:posts": "Posts",
     "ghost:blog": "Blog",
     "ghost:tag": "Tag",
-    "ghost:author": "Author"
+    "ghost:author": "Author",
+    "hearthis:tracks": "Tracks"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -224,6 +224,7 @@
     "hearthis:tracks": "Tracks",
     "hey-world:blog": "Blog",
     "insanejournal:posts-rss": "Posts (RSS)",
-    "insanejournal:posts-atom": "Posts (Atom)"
+    "insanejournal:posts-atom": "Posts (Atom)",
+    "libsyn:podcast": "Podcast"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -210,6 +210,7 @@
     "ameblo:posts-rdf": "Posts (RDF)",
     "arena:profile": "Profile",
     "arena:channel": "Channel",
-    "audioboom:podcast": "Podcast"
+    "audioboom:podcast": "Podcast",
+    "bookwyrm:reviews": "Reviews"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -261,6 +261,9 @@
     "tildes:topics-rss": "Topics (RSS)",
     "tildes:topics-atom": "Topics (Atom)",
     "tildes:group-rss": "Group (RSS)",
-    "tildes:group-atom": "Group (Atom)"
+    "tildes:group-atom": "Group (Atom)",
+    "weblog-lol:posts-rss": "Posts (RSS)",
+    "weblog-lol:posts-atom": "Posts (Atom)",
+    "weblog-lol:posts-json": "Posts (JSON)"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -253,6 +253,7 @@
     "qiita:posts": "Posts",
     "qiita:tag": "Tag",
     "qiita:organization": "Organization",
-    "qiita:popular": "Popular items"
+    "qiita:popular": "Popular items",
+    "rss-com:podcast": "Podcast"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -216,6 +216,7 @@
     "discourse:latest": "Latest",
     "discourse:category": "Category",
     "discourse:topic": "Topic",
-    "discourse:activity": "Activity"
+    "discourse:activity": "Activity",
+    "friendica:posts": "Posts"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -221,6 +221,7 @@
     "ghost:blog": "Blog",
     "ghost:tag": "Tag",
     "ghost:author": "Author",
-    "hearthis:tracks": "Tracks"
+    "hearthis:tracks": "Tracks",
+    "hey-world:blog": "Blog"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -254,6 +254,8 @@
     "qiita:tag": "Tag",
     "qiita:organization": "Organization",
     "qiita:popular": "Popular items",
-    "rss-com:podcast": "Podcast"
+    "rss-com:podcast": "Podcast",
+    "seesaa:posts-rss2": "Posts (RSS 2.0)",
+    "seesaa:posts-rdf": "Posts (RDF)"
   }
 }

--- a/src/common/locales.json
+++ b/src/common/locales.json
@@ -211,6 +211,7 @@
     "arena:profile": "Profile",
     "arena:channel": "Channel",
     "audioboom:podcast": "Podcast",
-    "bookwyrm:reviews": "Reviews"
+    "bookwyrm:reviews": "Reviews",
+    "buzzsprout:podcast": "Podcast"
   }
 }

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -13,6 +13,7 @@ import { bearblogHandler } from './platform/handlers/bearblog.js'
 import { behanceHandler } from './platform/handlers/behance.js'
 import { blogspotHandler } from './platform/handlers/blogspot.js'
 import { blueskyHandler } from './platform/handlers/bluesky.js'
+import { bookwyrmHandler } from './platform/handlers/bookwyrm.js'
 import { buttondownHandler } from './platform/handlers/buttondown.js'
 import { codebergHandler } from './platform/handlers/codeberg.js'
 import { csdnHandler } from './platform/handlers/csdn.js'
@@ -180,6 +181,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     behanceHandler,
     blogspotHandler,
     blueskyHandler,
+    bookwyrmHandler,
     buttondownHandler,
     codebergHandler,
     csdnHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -49,6 +49,7 @@ import { lobstersHandler } from './platform/handlers/lobsters.js'
 import { mastodonHandler } from './platform/handlers/mastodon.js'
 import { mataroaHandler } from './platform/handlers/mataroa.js'
 import { mediumHandler } from './platform/handlers/medium.js'
+import { microblogHandler } from './platform/handlers/microblog.js'
 import { myanimelistHandler } from './platform/handlers/myanimelist.js'
 import { nebulaHandler } from './platform/handlers/nebula.js'
 import { noteHandler } from './platform/handlers/note.js'
@@ -227,6 +228,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     mastodonHandler,
     mataroaHandler,
     mediumHandler,
+    microblogHandler,
     myanimelistHandler,
     nebulaHandler,
     noteHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -61,6 +61,7 @@ import { pagecordHandler } from './platform/handlers/pagecord.js'
 import { paragraphHandler } from './platform/handlers/paragraph.js'
 import { pikaHandler } from './platform/handlers/pika.js'
 import { pinterestHandler } from './platform/handlers/pinterest.js'
+import { pixelfedHandler } from './platform/handlers/pixelfed.js'
 import { producthuntHandler } from './platform/handlers/producthunt.js'
 import { proseHandler } from './platform/handlers/prose.js'
 import { redditHandler } from './platform/handlers/reddit.js'
@@ -244,6 +245,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     paragraphHandler,
     pikaHandler,
     pinterestHandler,
+    pixelfedHandler,
     producthuntHandler,
     proseHandler,
     redditHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -8,6 +8,7 @@ import { amebloHandler } from './platform/handlers/ameblo.js'
 import { applePodcastsHandler } from './platform/handlers/applePodcasts.js'
 import { arenaHandler } from './platform/handlers/arena.js'
 import { artstationHandler } from './platform/handlers/artstation.js'
+import { audioboomHandler } from './platform/handlers/audioboom.js'
 import { bearblogHandler } from './platform/handlers/bearblog.js'
 import { behanceHandler } from './platform/handlers/behance.js'
 import { blogspotHandler } from './platform/handlers/blogspot.js'
@@ -174,6 +175,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     applePodcastsHandler,
     arenaHandler,
     artstationHandler,
+    audioboomHandler,
     bearblogHandler,
     behanceHandler,
     blogspotHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -78,6 +78,7 @@ import { spreakerHandler } from './platform/handlers/spreaker.js'
 import { stackExchangeHandler } from './platform/handlers/stackExchange.js'
 import { steamHandler } from './platform/handlers/steam.js'
 import { substackHandler } from './platform/handlers/substack.js'
+import { tildesHandler } from './platform/handlers/tildes.js'
 import { tistoryHandler } from './platform/handlers/tistory.js'
 import { transistorHandler } from './platform/handlers/transistor.js'
 import { tumblrHandler } from './platform/handlers/tumblr.js'
@@ -270,6 +271,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     stackExchangeHandler,
     steamHandler,
     substackHandler,
+    tildesHandler,
     tistoryHandler,
     transistorHandler,
     tumblrHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -4,6 +4,7 @@ import type { HeadersMethodOptions } from '../common/uris/headers/types.js'
 import type { HtmlMethodOptions } from '../common/uris/html/types.js'
 import type { PlatformMethodOptions } from '../common/uris/platform/types.js'
 import { acastHandler } from './platform/handlers/acast.js'
+import { amebloHandler } from './platform/handlers/ameblo.js'
 import { applePodcastsHandler } from './platform/handlers/applePodcasts.js'
 import { artstationHandler } from './platform/handlers/artstation.js'
 import { bearblogHandler } from './platform/handlers/bearblog.js'
@@ -168,6 +169,7 @@ export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
 export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
   handlers: [
     acastHandler,
+    amebloHandler,
     applePodcastsHandler,
     artstationHandler,
     bearblogHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -92,6 +92,7 @@ import { wpengineHandler } from './platform/handlers/wpengine.js'
 import { writeasHandler } from './platform/handlers/writeas.js'
 import { ximalayaHandler } from './platform/handlers/ximalaya.js'
 import { youtubeHandler } from './platform/handlers/youtube.js'
+import { zennHandler } from './platform/handlers/zenn.js'
 
 export const mimeTypes = [
   // RSS:
@@ -287,5 +288,6 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     writeasHandler,
     ximalayaHandler,
     youtubeHandler,
+    zennHandler,
   ],
 }

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -35,6 +35,7 @@ import { goodreadsHandler } from './platform/handlers/goodreads.js'
 import { hackernewsHandler } from './platform/handlers/hackernews.js'
 import { hashnodeHandler } from './platform/handlers/hashnode.js'
 import { hatenablogHandler } from './platform/handlers/hatenablog.js'
+import { hearthisHandler } from './platform/handlers/hearthis.js'
 import { itchioHandler } from './platform/handlers/itchio.js'
 import { kickstarterHandler } from './platform/handlers/kickstarter.js'
 import { lemmyHandler } from './platform/handlers/lemmy.js'
@@ -207,6 +208,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     hackernewsHandler,
     hashnodeHandler,
     hatenablogHandler,
+    hearthisHandler,
     itchioHandler,
     kickstarterHandler,
     lemmyHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -50,6 +50,7 @@ import { mastodonHandler } from './platform/handlers/mastodon.js'
 import { mataroaHandler } from './platform/handlers/mataroa.js'
 import { mediumHandler } from './platform/handlers/medium.js'
 import { microblogHandler } from './platform/handlers/microblog.js'
+import { misskeyHandler } from './platform/handlers/misskey.js'
 import { myanimelistHandler } from './platform/handlers/myanimelist.js'
 import { nebulaHandler } from './platform/handlers/nebula.js'
 import { noteHandler } from './platform/handlers/note.js'
@@ -229,6 +230,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     mataroaHandler,
     mediumHandler,
     microblogHandler,
+    misskeyHandler,
     myanimelistHandler,
     nebulaHandler,
     noteHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -26,6 +26,7 @@ import { doubanHandler } from './platform/handlers/douban.js'
 import { dreamwidthHandler } from './platform/handlers/dreamwidth.js'
 import { exblogHandler } from './platform/handlers/exblog.js'
 import { firesideHandler } from './platform/handlers/fireside.js'
+import { friendicaHandler } from './platform/handlers/friendica.js'
 import { githubHandler } from './platform/handlers/github.js'
 import { githubGistHandler } from './platform/handlers/githubGist.js'
 import { gitlabHandler } from './platform/handlers/gitlab.js'
@@ -196,6 +197,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     dreamwidthHandler,
     exblogHandler,
     firesideHandler,
+    friendicaHandler,
     githubHandler,
     githubGistHandler,
     gitlabHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -74,6 +74,7 @@ import { rssComHandler } from './platform/handlers/rssCom.js'
 import { seesaaHandler } from './platform/handlers/seesaa.js'
 import { soundcloudHandler } from './platform/handlers/soundcloud.js'
 import { sourceforgeHandler } from './platform/handlers/sourceforge.js'
+import { spreakerHandler } from './platform/handlers/spreaker.js'
 import { stackExchangeHandler } from './platform/handlers/stackExchange.js'
 import { steamHandler } from './platform/handlers/steam.js'
 import { substackHandler } from './platform/handlers/substack.js'
@@ -265,6 +266,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     seesaaHandler,
     soundcloudHandler,
     sourceforgeHandler,
+    spreakerHandler,
     stackExchangeHandler,
     steamHandler,
     substackHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -42,6 +42,7 @@ import { itchioHandler } from './platform/handlers/itchio.js'
 import { kickstarterHandler } from './platform/handlers/kickstarter.js'
 import { lemmyHandler } from './platform/handlers/lemmy.js'
 import { letterboxdHandler } from './platform/handlers/letterboxd.js'
+import { libsynHandler } from './platform/handlers/libsyn.js'
 import { listedHandler } from './platform/handlers/listed.js'
 import { lobstersHandler } from './platform/handlers/lobsters.js'
 import { mastodonHandler } from './platform/handlers/mastodon.js'
@@ -217,6 +218,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     kickstarterHandler,
     lemmyHandler,
     letterboxdHandler,
+    libsynHandler,
     listedHandler,
     lobstersHandler,
     mastodonHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -64,6 +64,7 @@ import { pinterestHandler } from './platform/handlers/pinterest.js'
 import { pixelfedHandler } from './platform/handlers/pixelfed.js'
 import { pleromaHandler } from './platform/handlers/pleroma.js'
 import { podbeanHandler } from './platform/handlers/podbean.js'
+import { podigeeHandler } from './platform/handlers/podigee.js'
 import { producthuntHandler } from './platform/handlers/producthunt.js'
 import { proseHandler } from './platform/handlers/prose.js'
 import { redditHandler } from './platform/handlers/reddit.js'
@@ -250,6 +251,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     pixelfedHandler,
     pleromaHandler,
     podbeanHandler,
+    podigeeHandler,
     producthuntHandler,
     proseHandler,
     redditHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -68,6 +68,7 @@ import { podigeeHandler } from './platform/handlers/podigee.js'
 import { posthavenHandler } from './platform/handlers/posthaven.js'
 import { producthuntHandler } from './platform/handlers/producthunt.js'
 import { proseHandler } from './platform/handlers/prose.js'
+import { qiitaHandler } from './platform/handlers/qiita.js'
 import { redditHandler } from './platform/handlers/reddit.js'
 import { soundcloudHandler } from './platform/handlers/soundcloud.js'
 import { sourceforgeHandler } from './platform/handlers/sourceforge.js'
@@ -256,6 +257,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     posthavenHandler,
     producthuntHandler,
     proseHandler,
+    qiitaHandler,
     redditHandler,
     soundcloudHandler,
     sourceforgeHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -71,6 +71,7 @@ import { proseHandler } from './platform/handlers/prose.js'
 import { qiitaHandler } from './platform/handlers/qiita.js'
 import { redditHandler } from './platform/handlers/reddit.js'
 import { rssComHandler } from './platform/handlers/rssCom.js'
+import { seesaaHandler } from './platform/handlers/seesaa.js'
 import { soundcloudHandler } from './platform/handlers/soundcloud.js'
 import { sourceforgeHandler } from './platform/handlers/sourceforge.js'
 import { stackExchangeHandler } from './platform/handlers/stackExchange.js'
@@ -261,6 +262,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     qiitaHandler,
     redditHandler,
     rssComHandler,
+    seesaaHandler,
     soundcloudHandler,
     sourceforgeHandler,
     stackExchangeHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -47,6 +47,7 @@ import { listedHandler } from './platform/handlers/listed.js'
 import { livejournalHandler } from './platform/handlers/livejournal.js'
 import { lobstersHandler } from './platform/handlers/lobsters.js'
 import { mastodonHandler } from './platform/handlers/mastodon.js'
+import { mataroaHandler } from './platform/handlers/mataroa.js'
 import { mediumHandler } from './platform/handlers/medium.js'
 import { myanimelistHandler } from './platform/handlers/myanimelist.js'
 import { nebulaHandler } from './platform/handlers/nebula.js'
@@ -224,6 +225,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     livejournalHandler,
     lobstersHandler,
     mastodonHandler,
+    mataroaHandler,
     mediumHandler,
     myanimelistHandler,
     nebulaHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -63,6 +63,7 @@ import { pikaHandler } from './platform/handlers/pika.js'
 import { pinterestHandler } from './platform/handlers/pinterest.js'
 import { pixelfedHandler } from './platform/handlers/pixelfed.js'
 import { pleromaHandler } from './platform/handlers/pleroma.js'
+import { podbeanHandler } from './platform/handlers/podbean.js'
 import { producthuntHandler } from './platform/handlers/producthunt.js'
 import { proseHandler } from './platform/handlers/prose.js'
 import { redditHandler } from './platform/handlers/reddit.js'
@@ -248,6 +249,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     pinterestHandler,
     pixelfedHandler,
     pleromaHandler,
+    podbeanHandler,
     producthuntHandler,
     proseHandler,
     redditHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -59,6 +59,7 @@ import { observableHandler } from './platform/handlers/observable.js'
 import { odyseeHandler } from './platform/handlers/odysee.js'
 import { pagecordHandler } from './platform/handlers/pagecord.js'
 import { paragraphHandler } from './platform/handlers/paragraph.js'
+import { pikaHandler } from './platform/handlers/pika.js'
 import { pinterestHandler } from './platform/handlers/pinterest.js'
 import { producthuntHandler } from './platform/handlers/producthunt.js'
 import { proseHandler } from './platform/handlers/prose.js'
@@ -241,6 +242,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     odyseeHandler,
     pagecordHandler,
     paragraphHandler,
+    pikaHandler,
     pinterestHandler,
     producthuntHandler,
     proseHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -44,6 +44,7 @@ import { lemmyHandler } from './platform/handlers/lemmy.js'
 import { letterboxdHandler } from './platform/handlers/letterboxd.js'
 import { libsynHandler } from './platform/handlers/libsyn.js'
 import { listedHandler } from './platform/handlers/listed.js'
+import { livejournalHandler } from './platform/handlers/livejournal.js'
 import { lobstersHandler } from './platform/handlers/lobsters.js'
 import { mastodonHandler } from './platform/handlers/mastodon.js'
 import { mediumHandler } from './platform/handlers/medium.js'
@@ -220,6 +221,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     letterboxdHandler,
     libsynHandler,
     listedHandler,
+    livejournalHandler,
     lobstersHandler,
     mastodonHandler,
     mediumHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -6,6 +6,7 @@ import type { PlatformMethodOptions } from '../common/uris/platform/types.js'
 import { acastHandler } from './platform/handlers/acast.js'
 import { amebloHandler } from './platform/handlers/ameblo.js'
 import { applePodcastsHandler } from './platform/handlers/applePodcasts.js'
+import { arenaHandler } from './platform/handlers/arena.js'
 import { artstationHandler } from './platform/handlers/artstation.js'
 import { bearblogHandler } from './platform/handlers/bearblog.js'
 import { behanceHandler } from './platform/handlers/behance.js'
@@ -171,6 +172,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     acastHandler,
     amebloHandler,
     applePodcastsHandler,
+    arenaHandler,
     artstationHandler,
     bearblogHandler,
     behanceHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -27,6 +27,7 @@ import { dreamwidthHandler } from './platform/handlers/dreamwidth.js'
 import { exblogHandler } from './platform/handlers/exblog.js'
 import { firesideHandler } from './platform/handlers/fireside.js'
 import { friendicaHandler } from './platform/handlers/friendica.js'
+import { ghostHandler } from './platform/handlers/ghost.js'
 import { githubHandler } from './platform/handlers/github.js'
 import { githubGistHandler } from './platform/handlers/githubGist.js'
 import { gitlabHandler } from './platform/handlers/gitlab.js'
@@ -198,6 +199,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     exblogHandler,
     firesideHandler,
     friendicaHandler,
+    ghostHandler,
     githubHandler,
     githubGistHandler,
     gitlabHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -15,6 +15,7 @@ import { blogspotHandler } from './platform/handlers/blogspot.js'
 import { blueskyHandler } from './platform/handlers/bluesky.js'
 import { bookwyrmHandler } from './platform/handlers/bookwyrm.js'
 import { buttondownHandler } from './platform/handlers/buttondown.js'
+import { buzzsproutHandler } from './platform/handlers/buzzsprout.js'
 import { codebergHandler } from './platform/handlers/codeberg.js'
 import { csdnHandler } from './platform/handlers/csdn.js'
 import { dailymotionHandler } from './platform/handlers/dailymotion.js'
@@ -183,6 +184,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     blueskyHandler,
     bookwyrmHandler,
     buttondownHandler,
+    buzzsproutHandler,
     codebergHandler,
     csdnHandler,
     dailymotionHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -62,6 +62,7 @@ import { paragraphHandler } from './platform/handlers/paragraph.js'
 import { pikaHandler } from './platform/handlers/pika.js'
 import { pinterestHandler } from './platform/handlers/pinterest.js'
 import { pixelfedHandler } from './platform/handlers/pixelfed.js'
+import { pleromaHandler } from './platform/handlers/pleroma.js'
 import { producthuntHandler } from './platform/handlers/producthunt.js'
 import { proseHandler } from './platform/handlers/prose.js'
 import { redditHandler } from './platform/handlers/reddit.js'
@@ -246,6 +247,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     pikaHandler,
     pinterestHandler,
     pixelfedHandler,
+    pleromaHandler,
     producthuntHandler,
     proseHandler,
     redditHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -85,6 +85,7 @@ import { tumblrHandler } from './platform/handlers/tumblr.js'
 import { v2exHandler } from './platform/handlers/v2ex.js'
 import { velogHandler } from './platform/handlers/velog.js'
 import { vimeoHandler } from './platform/handlers/vimeo.js'
+import { weblogLolHandler } from './platform/handlers/weblogLol.js'
 import { wordpressHandler } from './platform/handlers/wordpress.js'
 import { wpengineHandler } from './platform/handlers/wpengine.js'
 import { writeasHandler } from './platform/handlers/writeas.js'
@@ -278,6 +279,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     v2exHandler,
     velogHandler,
     vimeoHandler,
+    weblogLolHandler,
     wordpressHandler,
     wpengineHandler,
     writeasHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -55,6 +55,7 @@ import { myanimelistHandler } from './platform/handlers/myanimelist.js'
 import { naverBlogHandler } from './platform/handlers/naverBlog.js'
 import { nebulaHandler } from './platform/handlers/nebula.js'
 import { noteHandler } from './platform/handlers/note.js'
+import { observableHandler } from './platform/handlers/observable.js'
 import { odyseeHandler } from './platform/handlers/odysee.js'
 import { pagecordHandler } from './platform/handlers/pagecord.js'
 import { paragraphHandler } from './platform/handlers/paragraph.js'
@@ -236,6 +237,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     naverBlogHandler,
     nebulaHandler,
     noteHandler,
+    observableHandler,
     odyseeHandler,
     pagecordHandler,
     paragraphHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -36,6 +36,7 @@ import { hackernewsHandler } from './platform/handlers/hackernews.js'
 import { hashnodeHandler } from './platform/handlers/hashnode.js'
 import { hatenablogHandler } from './platform/handlers/hatenablog.js'
 import { hearthisHandler } from './platform/handlers/hearthis.js'
+import { heyWorldHandler } from './platform/handlers/heyWorld.js'
 import { itchioHandler } from './platform/handlers/itchio.js'
 import { kickstarterHandler } from './platform/handlers/kickstarter.js'
 import { lemmyHandler } from './platform/handlers/lemmy.js'
@@ -209,6 +210,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     hashnodeHandler,
     hatenablogHandler,
     hearthisHandler,
+    heyWorldHandler,
     itchioHandler,
     kickstarterHandler,
     lemmyHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -52,6 +52,7 @@ import { mediumHandler } from './platform/handlers/medium.js'
 import { microblogHandler } from './platform/handlers/microblog.js'
 import { misskeyHandler } from './platform/handlers/misskey.js'
 import { myanimelistHandler } from './platform/handlers/myanimelist.js'
+import { naverBlogHandler } from './platform/handlers/naverBlog.js'
 import { nebulaHandler } from './platform/handlers/nebula.js'
 import { noteHandler } from './platform/handlers/note.js'
 import { odyseeHandler } from './platform/handlers/odysee.js'
@@ -232,6 +233,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     microblogHandler,
     misskeyHandler,
     myanimelistHandler,
+    naverBlogHandler,
     nebulaHandler,
     noteHandler,
     odyseeHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -37,6 +37,7 @@ import { hashnodeHandler } from './platform/handlers/hashnode.js'
 import { hatenablogHandler } from './platform/handlers/hatenablog.js'
 import { hearthisHandler } from './platform/handlers/hearthis.js'
 import { heyWorldHandler } from './platform/handlers/heyWorld.js'
+import { insanejournalHandler } from './platform/handlers/insanejournal.js'
 import { itchioHandler } from './platform/handlers/itchio.js'
 import { kickstarterHandler } from './platform/handlers/kickstarter.js'
 import { lemmyHandler } from './platform/handlers/lemmy.js'
@@ -211,6 +212,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     hatenablogHandler,
     hearthisHandler,
     heyWorldHandler,
+    insanejournalHandler,
     itchioHandler,
     kickstarterHandler,
     lemmyHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -21,6 +21,7 @@ import { csdnHandler } from './platform/handlers/csdn.js'
 import { dailymotionHandler } from './platform/handlers/dailymotion.js'
 import { deviantartHandler } from './platform/handlers/deviantart.js'
 import { devtoHandler } from './platform/handlers/devto.js'
+import { discourseHandler } from './platform/handlers/discourse.js'
 import { doubanHandler } from './platform/handlers/douban.js'
 import { dreamwidthHandler } from './platform/handlers/dreamwidth.js'
 import { exblogHandler } from './platform/handlers/exblog.js'
@@ -190,6 +191,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     dailymotionHandler,
     deviantartHandler,
     devtoHandler,
+    discourseHandler,
     doubanHandler,
     dreamwidthHandler,
     exblogHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -70,6 +70,7 @@ import { producthuntHandler } from './platform/handlers/producthunt.js'
 import { proseHandler } from './platform/handlers/prose.js'
 import { qiitaHandler } from './platform/handlers/qiita.js'
 import { redditHandler } from './platform/handlers/reddit.js'
+import { rssComHandler } from './platform/handlers/rssCom.js'
 import { soundcloudHandler } from './platform/handlers/soundcloud.js'
 import { sourceforgeHandler } from './platform/handlers/sourceforge.js'
 import { stackExchangeHandler } from './platform/handlers/stackExchange.js'
@@ -259,6 +260,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     proseHandler,
     qiitaHandler,
     redditHandler,
+    rssComHandler,
     soundcloudHandler,
     sourceforgeHandler,
     stackExchangeHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -65,6 +65,7 @@ import { pixelfedHandler } from './platform/handlers/pixelfed.js'
 import { pleromaHandler } from './platform/handlers/pleroma.js'
 import { podbeanHandler } from './platform/handlers/podbean.js'
 import { podigeeHandler } from './platform/handlers/podigee.js'
+import { posthavenHandler } from './platform/handlers/posthaven.js'
 import { producthuntHandler } from './platform/handlers/producthunt.js'
 import { proseHandler } from './platform/handlers/prose.js'
 import { redditHandler } from './platform/handlers/reddit.js'
@@ -252,6 +253,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     pleromaHandler,
     podbeanHandler,
     podigeeHandler,
+    posthavenHandler,
     producthuntHandler,
     proseHandler,
     redditHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -86,6 +86,7 @@ import { v2exHandler } from './platform/handlers/v2ex.js'
 import { velogHandler } from './platform/handlers/velog.js'
 import { vimeoHandler } from './platform/handlers/vimeo.js'
 import { weblogLolHandler } from './platform/handlers/weblogLol.js'
+import { weeblyHandler } from './platform/handlers/weebly.js'
 import { wordpressHandler } from './platform/handlers/wordpress.js'
 import { wpengineHandler } from './platform/handlers/wpengine.js'
 import { writeasHandler } from './platform/handlers/writeas.js'
@@ -280,6 +281,7 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     velogHandler,
     vimeoHandler,
     weblogLolHandler,
+    weeblyHandler,
     wordpressHandler,
     wpengineHandler,
     writeasHandler,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -3,6 +3,7 @@ import type { GuessMethodOptions } from '../common/uris/guess/types.js'
 import type { HeadersMethodOptions } from '../common/uris/headers/types.js'
 import type { HtmlMethodOptions } from '../common/uris/html/types.js'
 import type { PlatformMethodOptions } from '../common/uris/platform/types.js'
+import { acastHandler } from './platform/handlers/acast.js'
 import { applePodcastsHandler } from './platform/handlers/applePodcasts.js'
 import { artstationHandler } from './platform/handlers/artstation.js'
 import { bearblogHandler } from './platform/handlers/bearblog.js'
@@ -166,9 +167,10 @@ export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
 // Default options for Platform method.
 export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
   handlers: [
+    acastHandler,
     applePodcastsHandler,
-    bearblogHandler,
     artstationHandler,
+    bearblogHandler,
     behanceHandler,
     blogspotHandler,
     blueskyHandler,
@@ -197,11 +199,11 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     lobstersHandler,
     mastodonHandler,
     mediumHandler,
-    pagecordHandler,
     myanimelistHandler,
     nebulaHandler,
     noteHandler,
     odyseeHandler,
+    pagecordHandler,
     paragraphHandler,
     pinterestHandler,
     producthuntHandler,
@@ -212,8 +214,8 @@ export const defaultPlatformOptions: Omit<PlatformMethodOptions, 'baseUrl'> = {
     stackExchangeHandler,
     steamHandler,
     substackHandler,
-    transistorHandler,
     tistoryHandler,
+    transistorHandler,
     tumblrHandler,
     v2exHandler,
     velogHandler,

--- a/src/feeds/platform/handlers/acast.test.ts
+++ b/src/feeds/platform/handlers/acast.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { acastHandler } from './acast.js'
+
+describe('acastHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://shows.acast.com/my-dad-wrote-a-porno', true],
+      ['https://shows.acast.com', true],
+      ['https://acast.com/show', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(acastHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(acastHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return podcast feed for show', () => {
+      const value = 'https://shows.acast.com/my-dad-wrote-a-porno'
+      const expected = [
+        {
+          uri: 'https://feeds.acast.com/public/shows/my-dad-wrote-a-porno',
+          hint: { key: 'acast:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(acastHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://shows.acast.com/my-dad-wrote-a-porno/some-episode'
+      const expected = [
+        {
+          uri: 'https://feeds.acast.com/public/shows/my-dad-wrote-a-porno',
+          hint: { key: 'acast:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(acastHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://shows.acast.com/'
+
+      expect(acastHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for excluded paths', () => {
+      const value = 'https://shows.acast.com/discover'
+
+      expect(acastHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/acast.ts
+++ b/src/feeds/platform/handlers/acast.ts
@@ -1,0 +1,35 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const hosts = ['shows.acast.com']
+const excludedPaths = ['discover']
+
+export const acastHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const pathSegments = pathname.split('/').filter(Boolean)
+
+    if (pathSegments.length === 0) {
+      return []
+    }
+
+    const slug = pathSegments[0]
+
+    if (isAnyOf(slug, excludedPaths)) {
+      return []
+    }
+
+    return [
+      {
+        uri: `https://feeds.acast.com/public/shows/${slug}`,
+        hint: composeHint('acast:podcast'),
+      },
+    ]
+  },
+}

--- a/src/feeds/platform/handlers/ameblo.test.ts
+++ b/src/feeds/platform/handlers/ameblo.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'bun:test'
+import { amebloHandler } from './ameblo.js'
+
+describe('amebloHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://ameblo.jp/shibuya', true],
+      ['https://www.ameblo.jp/user', true],
+      ['https://ameblo.jp', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(amebloHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(amebloHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return RSS 2.0, Atom, and RDF feeds for blog', () => {
+      const value = 'https://ameblo.jp/shibuya'
+      const expected = [
+        {
+          uri: 'https://ameblo.jp/shibuya/rss20.xml',
+          hint: { key: 'ameblo:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://ameblo.jp/shibuya/atom.xml',
+          hint: { key: 'ameblo:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: 'https://rssblog.ameba.jp/shibuya/rss.html',
+          hint: { key: 'ameblo:posts-rdf', label: 'Posts (RDF)' },
+        },
+      ]
+
+      expect(amebloHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URLs regardless of subpath', () => {
+      const value = 'https://ameblo.jp/shibuya/entry-12345.html'
+      const expected = [
+        {
+          uri: 'https://ameblo.jp/shibuya/rss20.xml',
+          hint: { key: 'ameblo:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://ameblo.jp/shibuya/atom.xml',
+          hint: { key: 'ameblo:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: 'https://rssblog.ameba.jp/shibuya/rss.html',
+          hint: { key: 'ameblo:posts-rdf', label: 'Posts (RDF)' },
+        },
+      ]
+
+      expect(amebloHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://ameblo.jp/'
+
+      expect(amebloHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for excluded paths', () => {
+      const value = 'https://ameblo.jp/hashtag'
+
+      expect(amebloHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/ameblo.ts
+++ b/src/feeds/platform/handlers/ameblo.ts
@@ -1,0 +1,50 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+//
+// HTML autodiscovery on ameblo.jp/{user}/ pages returns the mirror URL
+// rssblog.ameba.jp/{user}/rss20.xml. Both URLs serve byte-identical content;
+// the handler emits the ameblo.jp form for consistency with the canonical site host.
+
+const hosts = ['ameblo.jp', 'www.ameblo.jp']
+const excludedPaths = ['genre', 'hashtag', 'search']
+
+export const amebloHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const pathSegments = pathname.split('/').filter(Boolean)
+
+    if (pathSegments.length === 0) {
+      return []
+    }
+
+    const username = pathSegments[0]
+
+    if (isAnyOf(username, excludedPaths)) {
+      return []
+    }
+
+    const uris: Array<DiscoverUriEntry> = []
+
+    uris.push({
+      uri: `https://ameblo.jp/${username}/rss20.xml`,
+      hint: composeHint('ameblo:posts-rss'),
+    })
+    uris.push({
+      uri: `https://ameblo.jp/${username}/atom.xml`,
+      hint: composeHint('ameblo:posts-atom'),
+    })
+    uris.push({
+      uri: `https://rssblog.ameba.jp/${username}/rss.html`,
+      hint: composeHint('ameblo:posts-rdf'),
+    })
+
+    return uris
+  },
+}

--- a/src/feeds/platform/handlers/arena.test.ts
+++ b/src/feeds/platform/handlers/arena.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'bun:test'
+import { arenaHandler } from './arena.js'
+
+describe('arenaHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://www.are.na/charles-broskoski', true],
+      ['https://are.na/meg-miller/good-sign-offs', true],
+      ['https://are.na', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(arenaHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(arenaHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for user profile', () => {
+      const value = 'https://www.are.na/charles-broskoski'
+      const expected = [
+        {
+          uri: 'https://www.are.na/charles-broskoski/feed/rss',
+          hint: { key: 'arena:profile', label: 'Profile' },
+        },
+      ]
+
+      expect(arenaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL for channel', () => {
+      const value = 'https://www.are.na/meg-miller/good-sign-offs'
+      const expected = [
+        {
+          uri: 'https://www.are.na/meg-miller/good-sign-offs/feed/rss',
+          hint: { key: 'arena:channel', label: 'Channel' },
+        },
+      ]
+
+      expect(arenaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return channel feed regardless of subpath', () => {
+      const value = 'https://www.are.na/meg-miller/good-sign-offs/some-block-slug'
+      const expected = [
+        {
+          uri: 'https://www.are.na/meg-miller/good-sign-offs/feed/rss',
+          hint: { key: 'arena:channel', label: 'Channel' },
+        },
+      ]
+
+      expect(arenaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://www.are.na/'
+
+      expect(arenaHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for excluded paths', () => {
+      const value = 'https://www.are.na/explore'
+
+      expect(arenaHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/arena.ts
+++ b/src/feeds/platform/handlers/arena.ts
@@ -1,0 +1,56 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const hosts = ['are.na', 'www.are.na']
+const excludedPaths = [
+  'about',
+  'api',
+  'explore',
+  'login',
+  'premium',
+  'privacy',
+  'search',
+  'settings',
+  'signup',
+  'support',
+  'terms',
+]
+
+export const arenaHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const pathSegments = pathname.split('/').filter(Boolean)
+
+    if (pathSegments.length === 0) {
+      return []
+    }
+
+    const username = pathSegments[0]
+
+    if (isAnyOf(username, excludedPaths)) {
+      return []
+    }
+
+    if (pathSegments[1]) {
+      return [
+        {
+          uri: `https://www.are.na/${username}/${pathSegments[1]}/feed/rss`,
+          hint: composeHint('arena:channel'),
+        },
+      ]
+    }
+
+    return [
+      {
+        uri: `https://www.are.na/${username}/feed/rss`,
+        hint: composeHint('arena:profile'),
+      },
+    ]
+  },
+}

--- a/src/feeds/platform/handlers/audioboom.test.ts
+++ b/src/feeds/platform/handlers/audioboom.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { audioboomHandler } from './audioboom.js'
+
+describe('audioboomHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://audioboom.com/channels/5071123', true],
+      ['https://www.audioboom.com/channels/5071123', true],
+      ['https://audioboom.com', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(audioboomHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(audioboomHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return podcast feed for channel', () => {
+      const value = 'https://audioboom.com/channels/5071123'
+      const expected = [
+        {
+          uri: 'https://audioboom.com/channels/5071123.rss',
+          hint: { key: 'audioboom:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(audioboomHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://audioboom.com/channels/5071123/some-episode'
+      const expected = [
+        {
+          uri: 'https://audioboom.com/channels/5071123.rss',
+          hint: { key: 'audioboom:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(audioboomHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://audioboom.com/'
+
+      expect(audioboomHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for non-channel paths', () => {
+      const value = 'https://audioboom.com/posts/12345'
+
+      expect(audioboomHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/audioboom.ts
+++ b/src/feeds/platform/handlers/audioboom.ts
@@ -1,0 +1,33 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const hosts = ['audioboom.com', 'www.audioboom.com']
+const channelRegex = /^\/channels\/(\d+)/
+
+export const audioboomHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const match = pathname.match(channelRegex)
+
+    if (!match?.[1]) {
+      return []
+    }
+
+    const channelId = match[1]
+    const uris: Array<DiscoverUriEntry> = []
+
+    uris.push({
+      uri: `https://audioboom.com/channels/${channelId}.rss`,
+      hint: composeHint('audioboom:podcast'),
+    })
+
+    return uris
+  },
+}

--- a/src/feeds/platform/handlers/bookwyrm.test.ts
+++ b/src/feeds/platform/handlers/bookwyrm.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test'
+import { bookwyrmHandler, isBookwyrmHtml } from './bookwyrm.js'
+
+const bookwyrmHtml = '<html><head><meta name="generator" content="BookWyrm"></head></html>'
+const otherHtml = '<html><head><meta name="generator" content="WordPress"></head></html>'
+
+describe('bookwyrmHandler', () => {
+  describe('isBookwyrmHtml', () => {
+    it('should return true for BookWyrm generator meta tag', () => {
+      expect(isBookwyrmHtml(bookwyrmHtml)).toBe(true)
+    })
+
+    it('should be case-insensitive', () => {
+      expect(isBookwyrmHtml('<meta name="generator" content="bookwyrm">')).toBe(true)
+      expect(isBookwyrmHtml('<meta name="generator" content="BOOKWYRM">')).toBe(true)
+    })
+
+    it('should return false for non-BookWyrm generator', () => {
+      expect(isBookwyrmHtml(otherHtml)).toBe(false)
+    })
+  })
+
+  describe('match', () => {
+    it('should return true for profile URL with BookWyrm content', () => {
+      expect(bookwyrmHandler.match('https://bookwyrm.social/user/mouse', bookwyrmHtml)).toBe(true)
+    })
+
+    it('should return false without content', () => {
+      expect(bookwyrmHandler.match('https://bookwyrm.social/user/mouse')).toBe(false)
+    })
+
+    it('should return false for non-BookWyrm content', () => {
+      expect(bookwyrmHandler.match('https://bookwyrm.social/user/mouse', otherHtml)).toBe(false)
+    })
+
+    it('should return false for non-user paths', () => {
+      expect(bookwyrmHandler.match('https://bookwyrm.social/about', bookwyrmHtml)).toBe(false)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(bookwyrmHandler.match('not-a-url', bookwyrmHtml)).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return rss feed for profile', () => {
+      const value = 'https://bookwyrm.social/user/mouse'
+      const expected = [
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss',
+          hint: { key: 'bookwyrm:reviews', label: 'Reviews' },
+        },
+      ]
+
+      expect(bookwyrmHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return rss feed regardless of subpath', () => {
+      const value = 'https://bookwyrm.social/user/mouse/books'
+      const expected = [
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss',
+          hint: { key: 'bookwyrm:reviews', label: 'Reviews' },
+        },
+      ]
+
+      expect(bookwyrmHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for non-user paths', () => {
+      expect(bookwyrmHandler.resolve('https://bookwyrm.social/about')).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/bookwyrm.ts
+++ b/src/feeds/platform/handlers/bookwyrm.ts
@@ -1,0 +1,46 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, hasMetaContent } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const profileRegex = /^\/user\/([^/]+)/
+
+export const isBookwyrmHtml = (content: string): boolean => {
+  return hasMetaContent(content, 'generator', 'BookWyrm')
+}
+
+export const bookwyrmHandler: PlatformHandler = {
+  match: (url, content) => {
+    try {
+      if (!content || !isBookwyrmHtml(content)) {
+        return false
+      }
+
+      const { pathname } = new URL(url)
+
+      return profileRegex.test(pathname)
+    } catch {}
+
+    return false
+  },
+
+  resolve: (url) => {
+    try {
+      const { origin, pathname } = new URL(url)
+      const match = pathname.match(profileRegex)
+
+      if (!match?.[1]) {
+        return []
+      }
+
+      return [
+        {
+          uri: `${origin}/user/${match[1]}/rss`,
+          hint: composeHint('bookwyrm:reviews'),
+        },
+      ]
+    } catch {}
+
+    return []
+  },
+}

--- a/src/feeds/platform/handlers/buzzsprout.test.ts
+++ b/src/feeds/platform/handlers/buzzsprout.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { buzzsproutHandler } from './buzzsprout.js'
+
+describe('buzzsproutHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://www.buzzsprout.com/1765577', true],
+      ['https://buzzsprout.com/1765577', true],
+      ['https://buzzsprout.com', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(buzzsproutHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(buzzsproutHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for podcast', () => {
+      const value = 'https://www.buzzsprout.com/1765577'
+      const expected = [
+        {
+          uri: 'https://rss.buzzsprout.com/1765577.rss',
+          hint: { key: 'buzzsprout:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(buzzsproutHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://www.buzzsprout.com/1765577/episodes/some-episode'
+      const expected = [
+        {
+          uri: 'https://rss.buzzsprout.com/1765577.rss',
+          hint: { key: 'buzzsprout:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(buzzsproutHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://www.buzzsprout.com/'
+
+      expect(buzzsproutHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for non-numeric paths', () => {
+      const value = 'https://www.buzzsprout.com/about'
+
+      expect(buzzsproutHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/buzzsprout.ts
+++ b/src/feeds/platform/handlers/buzzsprout.ts
@@ -1,0 +1,37 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+//
+// feeds.buzzsprout.com/{id}.rss also works but 301-redirects to rss.buzzsprout.com.
+
+const hosts = ['buzzsprout.com', 'www.buzzsprout.com']
+const numericRegex = /^\d+$/
+
+export const buzzsproutHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const pathSegments = pathname.split('/').filter(Boolean)
+
+    if (pathSegments.length === 0) {
+      return []
+    }
+
+    const podcastId = pathSegments[0]
+
+    if (!numericRegex.test(podcastId)) {
+      return []
+    }
+
+    return [
+      {
+        uri: `https://rss.buzzsprout.com/${podcastId}.rss`,
+        hint: composeHint('buzzsprout:podcast'),
+      },
+    ]
+  },
+}

--- a/src/feeds/platform/handlers/discourse.test.ts
+++ b/src/feeds/platform/handlers/discourse.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'bun:test'
+import { discourseHandler, isDiscourseHtml } from './discourse.js'
+
+const discourseHtml =
+  '<html><head><meta name="generator" content="Discourse 2026.4.0"></head></html>'
+const otherHtml = '<html><head><meta name="generator" content="WordPress"></head></html>'
+
+describe('discourseHandler', () => {
+  describe('isDiscourseHtml', () => {
+    it('should return true for Discourse generator meta tag', () => {
+      expect(isDiscourseHtml(discourseHtml)).toBe(true)
+    })
+
+    it('should be case-insensitive', () => {
+      expect(isDiscourseHtml('<meta name="generator" content="discourse">')).toBe(true)
+      expect(isDiscourseHtml('<meta name="generator" content="DISCOURSE">')).toBe(true)
+    })
+
+    it('should return false for non-Discourse generator', () => {
+      expect(isDiscourseHtml(otherHtml)).toBe(false)
+    })
+  })
+
+  describe('match', () => {
+    it('should return true for any URL with Discourse content', () => {
+      expect(discourseHandler.match('https://users.rust-lang.org/', discourseHtml)).toBe(true)
+      expect(
+        discourseHandler.match('https://users.rust-lang.org/u/steveklabnik', discourseHtml),
+      ).toBe(true)
+    })
+
+    it('should return false without content', () => {
+      expect(discourseHandler.match('https://users.rust-lang.org/')).toBe(false)
+    })
+
+    it('should return false for non-Discourse content', () => {
+      expect(discourseHandler.match('https://users.rust-lang.org/', otherHtml)).toBe(false)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(discourseHandler.match('not-a-url', discourseHtml)).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return user activity feed for /u/{user} path', () => {
+      const value = 'https://users.rust-lang.org/u/steveklabnik'
+      const expected = [
+        {
+          uri: 'https://users.rust-lang.org/u/steveklabnik/activity.rss',
+          hint: { key: 'discourse:activity', label: 'Activity' },
+        },
+      ]
+
+      expect(discourseHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return category feed for /c/{slug} path', () => {
+      const value = 'https://users.rust-lang.org/c/help'
+      const expected = [
+        {
+          uri: 'https://users.rust-lang.org/c/help.rss',
+          hint: { key: 'discourse:category', label: 'Category' },
+        },
+      ]
+
+      expect(discourseHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return topic feed for /t/{slug}/{id} path', () => {
+      const value = 'https://users.rust-lang.org/t/welcome-to-the-rust-users-forum/2'
+      const expected = [
+        {
+          uri: 'https://users.rust-lang.org/t/welcome-to-the-rust-users-forum/2.rss',
+          hint: { key: 'discourse:topic', label: 'Topic' },
+        },
+      ]
+
+      expect(discourseHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return latest feed for root path', () => {
+      const value = 'https://users.rust-lang.org/'
+      const expected = [
+        {
+          uri: 'https://users.rust-lang.org/latest.rss',
+          hint: { key: 'discourse:latest', label: 'Latest' },
+        },
+      ]
+
+      expect(discourseHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return latest feed for unknown paths', () => {
+      const value = 'https://users.rust-lang.org/about'
+      const expected = [
+        {
+          uri: 'https://users.rust-lang.org/latest.rss',
+          hint: { key: 'discourse:latest', label: 'Latest' },
+        },
+      ]
+
+      expect(discourseHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/discourse.ts
+++ b/src/feeds/platform/handlers/discourse.ts
@@ -1,0 +1,76 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, hasMetaContent } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const userRegex = /^\/u\/([^/]+)/
+const categoryRegex = /^\/c\/([^/]+)/
+const topicRegex = /^\/t\/([^/]+)\/(\d+)/
+
+export const isDiscourseHtml = (content: string): boolean => {
+  return hasMetaContent(content, 'generator', 'Discourse')
+}
+
+export const discourseHandler: PlatformHandler = {
+  match: (url, content) => {
+    try {
+      if (!content || !isDiscourseHtml(content)) {
+        return false
+      }
+
+      new URL(url)
+
+      return true
+    } catch {}
+
+    return false
+  },
+
+  resolve: (url) => {
+    try {
+      const { origin, pathname } = new URL(url)
+
+      const topicMatch = pathname.match(topicRegex)
+
+      if (topicMatch?.[1] && topicMatch?.[2]) {
+        return [
+          {
+            uri: `${origin}/t/${topicMatch[1]}/${topicMatch[2]}.rss`,
+            hint: composeHint('discourse:topic'),
+          },
+        ]
+      }
+
+      const userMatch = pathname.match(userRegex)
+
+      if (userMatch?.[1]) {
+        return [
+          {
+            uri: `${origin}/u/${userMatch[1]}/activity.rss`,
+            hint: composeHint('discourse:activity'),
+          },
+        ]
+      }
+
+      const categoryMatch = pathname.match(categoryRegex)
+
+      if (categoryMatch?.[1]) {
+        return [
+          {
+            uri: `${origin}/c/${categoryMatch[1]}.rss`,
+            hint: composeHint('discourse:category'),
+          },
+        ]
+      }
+
+      return [
+        {
+          uri: `${origin}/latest.rss`,
+          hint: composeHint('discourse:latest'),
+        },
+      ]
+    } catch {}
+
+    return []
+  },
+}

--- a/src/feeds/platform/handlers/friendica.test.ts
+++ b/src/feeds/platform/handlers/friendica.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'bun:test'
+import { friendicaHandler, isFriendicaHtml } from './friendica.js'
+
+const friendicaHtml =
+  '<html><head><meta name="generator" content="Friendica 2026.01"></head></html>'
+const otherHtml = '<html><head><meta name="generator" content="WordPress"></head></html>'
+
+describe('friendicaHandler', () => {
+  describe('isFriendicaHtml', () => {
+    it('should return true for Friendica generator meta tag', () => {
+      expect(isFriendicaHtml(friendicaHtml)).toBe(true)
+    })
+
+    it('should be case-insensitive', () => {
+      expect(isFriendicaHtml('<meta name="generator" content="friendica 2026">')).toBe(true)
+      expect(isFriendicaHtml('<meta name="generator" content="FRIENDICA">')).toBe(true)
+    })
+
+    it('should return false for non-Friendica generator', () => {
+      expect(isFriendicaHtml(otherHtml)).toBe(false)
+    })
+  })
+
+  describe('match', () => {
+    it('should return true for profile URL with Friendica content', () => {
+      expect(friendicaHandler.match('https://libranet.de/profile/admin', friendicaHtml)).toBe(true)
+    })
+
+    it('should return false without content', () => {
+      expect(friendicaHandler.match('https://libranet.de/profile/admin')).toBe(false)
+    })
+
+    it('should return false for non-Friendica content', () => {
+      expect(friendicaHandler.match('https://libranet.de/profile/admin', otherHtml)).toBe(false)
+    })
+
+    it('should return false for non-profile paths', () => {
+      expect(friendicaHandler.match('https://libranet.de/about', friendicaHtml)).toBe(false)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(friendicaHandler.match('not-a-url', friendicaHtml)).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return atom feed for profile', () => {
+      const value = 'https://libranet.de/profile/admin'
+      const expected = [
+        {
+          uri: 'https://libranet.de/feed/admin',
+          hint: { key: 'friendica:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(friendicaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return atom feed regardless of subpath', () => {
+      const value = 'https://libranet.de/profile/admin/photos'
+      const expected = [
+        {
+          uri: 'https://libranet.de/feed/admin',
+          hint: { key: 'friendica:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(friendicaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for non-profile paths', () => {
+      expect(friendicaHandler.resolve('https://libranet.de/about')).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/friendica.ts
+++ b/src/feeds/platform/handlers/friendica.ts
@@ -1,0 +1,46 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, hasMetaContent } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const profileRegex = /^\/profile\/([^/]+)/
+
+export const isFriendicaHtml = (content: string): boolean => {
+  return hasMetaContent(content, 'generator', 'Friendica')
+}
+
+export const friendicaHandler: PlatformHandler = {
+  match: (url, content) => {
+    try {
+      if (!content || !isFriendicaHtml(content)) {
+        return false
+      }
+
+      const { pathname } = new URL(url)
+
+      return profileRegex.test(pathname)
+    } catch {}
+
+    return false
+  },
+
+  resolve: (url) => {
+    try {
+      const { origin, pathname } = new URL(url)
+      const match = pathname.match(profileRegex)
+
+      if (!match?.[1]) {
+        return []
+      }
+
+      return [
+        {
+          uri: `${origin}/feed/${match[1]}`,
+          hint: composeHint('friendica:posts'),
+        },
+      ]
+    } catch {}
+
+    return []
+  },
+}

--- a/src/feeds/platform/handlers/ghost.test.ts
+++ b/src/feeds/platform/handlers/ghost.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'bun:test'
+import { ghostHandler } from './ghost.js'
+
+describe('ghostHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://demo.ghost.io', true],
+      ['https://blog.example.ghost.io', true],
+      ['https://ghost.io', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(ghostHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(ghostHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for blog', () => {
+      const value = 'https://demo.ghost.io'
+      const expected = [
+        {
+          uri: 'https://demo.ghost.io/rss/',
+          hint: { key: 'ghost:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(ghostHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return tag and blog feeds for tag page', () => {
+      const value = 'https://demo.ghost.io/tag/getting-started'
+      const expected = [
+        {
+          uri: 'https://demo.ghost.io/tag/getting-started/rss/',
+          hint: { key: 'ghost:tag', label: 'Tag' },
+        },
+        {
+          uri: 'https://demo.ghost.io/rss/',
+          hint: { key: 'ghost:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(ghostHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return author and blog feeds for author page', () => {
+      const value = 'https://demo.ghost.io/author/ghost'
+      const expected = [
+        {
+          uri: 'https://demo.ghost.io/author/ghost/rss/',
+          hint: { key: 'ghost:author', label: 'Author' },
+        },
+        {
+          uri: 'https://demo.ghost.io/rss/',
+          hint: { key: 'ghost:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(ghostHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of path', () => {
+      const value = 'https://demo.ghost.io/some-article-slug'
+      const expected = [
+        {
+          uri: 'https://demo.ghost.io/rss/',
+          hint: { key: 'ghost:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(ghostHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/ghost.ts
+++ b/src/feeds/platform/handlers/ghost.ts
@@ -1,0 +1,43 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const tagRegex = /^\/tag\/([^/]+)/
+const authorRegex = /^\/author\/([^/]+)/
+
+export const ghostHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'ghost.io')
+  },
+
+  resolve: (url) => {
+    const { origin, pathname } = new URL(url)
+    const uris: Array<DiscoverUriEntry> = []
+
+    // Tag page: /tag/{slug}
+    const tagMatch = pathname.match(tagRegex)
+
+    if (tagMatch?.[1]) {
+      uris.push({
+        uri: `${origin}/tag/${tagMatch[1]}/rss/`,
+        hint: composeHint('ghost:tag'),
+      })
+    }
+
+    // Author page: /author/{slug}
+    const authorMatch = pathname.match(authorRegex)
+
+    if (authorMatch?.[1]) {
+      uris.push({
+        uri: `${origin}/author/${authorMatch[1]}/rss/`,
+        hint: composeHint('ghost:author'),
+      })
+    }
+
+    uris.push({ uri: `${origin}/rss/`, hint: composeHint('ghost:blog') })
+
+    return uris
+  },
+}

--- a/src/feeds/platform/handlers/hearthis.test.ts
+++ b/src/feeds/platform/handlers/hearthis.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { hearthisHandler } from './hearthis.js'
+
+describe('hearthisHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://hearthis.at/james-monty-montgomery', true],
+      ['https://www.hearthis.at/user', true],
+      ['https://hearthis.at', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(hearthisHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(hearthisHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for user', () => {
+      const value = 'https://hearthis.at/james-monty-montgomery'
+      const expected = [
+        {
+          uri: 'https://hearthis.at/james-monty-montgomery/podcast/',
+          hint: { key: 'hearthis:tracks', label: 'Tracks' },
+        },
+      ]
+
+      expect(hearthisHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://hearthis.at/james-monty-montgomery/some-track'
+      const expected = [
+        {
+          uri: 'https://hearthis.at/james-monty-montgomery/podcast/',
+          hint: { key: 'hearthis:tracks', label: 'Tracks' },
+        },
+      ]
+
+      expect(hearthisHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://hearthis.at/'
+
+      expect(hearthisHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for excluded paths', () => {
+      const value = 'https://hearthis.at/login'
+
+      expect(hearthisHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/hearthis.ts
+++ b/src/feeds/platform/handlers/hearthis.ts
@@ -1,0 +1,47 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+//
+// hearthis.at/{user}/podcast.xml also serves the same feed.
+
+const hosts = ['hearthis.at', 'www.hearthis.at']
+const excludedPaths = [
+  'about',
+  'api',
+  'feed',
+  'login',
+  'privacy',
+  'search',
+  'set',
+  'signup',
+  'terms',
+]
+
+export const hearthisHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const pathSegments = pathname.split('/').filter(Boolean)
+
+    if (pathSegments.length === 0) {
+      return []
+    }
+
+    const username = pathSegments[0]
+
+    if (isAnyOf(username, excludedPaths)) {
+      return []
+    }
+
+    return [
+      {
+        uri: `https://hearthis.at/${username}/podcast/`,
+        hint: composeHint('hearthis:tracks'),
+      },
+    ]
+  },
+}

--- a/src/feeds/platform/handlers/heyWorld.test.ts
+++ b/src/feeds/platform/handlers/heyWorld.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test'
+import { heyWorldHandler } from './heyWorld.js'
+
+describe('heyWorldHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://world.hey.com/dhh', true],
+      ['https://world.hey.com', true],
+      ['https://hey.com', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(heyWorldHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(heyWorldHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for blog', () => {
+      const value = 'https://world.hey.com/dhh'
+      const expected = [
+        {
+          uri: 'https://world.hey.com/dhh/feed.atom',
+          hint: { key: 'hey-world:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(heyWorldHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://world.hey.com/dhh/some-post-title'
+      const expected = [
+        {
+          uri: 'https://world.hey.com/dhh/feed.atom',
+          hint: { key: 'hey-world:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(heyWorldHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://world.hey.com/'
+
+      expect(heyWorldHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/heyWorld.ts
+++ b/src/feeds/platform/handlers/heyWorld.ts
@@ -1,0 +1,28 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+export const heyWorldHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, 'world.hey.com')
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const pathSegments = pathname.split('/').filter(Boolean)
+
+    if (pathSegments.length === 0) {
+      return []
+    }
+
+    const username = pathSegments[0]
+
+    return [
+      {
+        uri: `https://world.hey.com/${username}/feed.atom`,
+        hint: composeHint('hey-world:blog'),
+      },
+    ]
+  },
+}

--- a/src/feeds/platform/handlers/insanejournal.test.ts
+++ b/src/feeds/platform/handlers/insanejournal.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test'
+import { insanejournalHandler } from './insanejournal.js'
+
+describe('insanejournalHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://random.insanejournal.com', true],
+      ['https://anything.insanejournal.com/post', true],
+      ['https://insanejournal.com', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(insanejournalHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(insanejournalHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return RSS and Atom feeds for journal', () => {
+      const value = 'https://random.insanejournal.com'
+      const expected = [
+        {
+          uri: 'https://random.insanejournal.com/data/rss',
+          hint: { key: 'insanejournal:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://random.insanejournal.com/data/atom',
+          hint: { key: 'insanejournal:posts-atom', label: 'Posts (Atom)' },
+        },
+      ]
+
+      expect(insanejournalHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feeds regardless of path', () => {
+      const value = 'https://random.insanejournal.com/123456.html'
+      const expected = [
+        {
+          uri: 'https://random.insanejournal.com/data/rss',
+          hint: { key: 'insanejournal:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://random.insanejournal.com/data/atom',
+          hint: { key: 'insanejournal:posts-atom', label: 'Posts (Atom)' },
+        },
+      ]
+
+      expect(insanejournalHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/insanejournal.ts
+++ b/src/feeds/platform/handlers/insanejournal.ts
@@ -1,0 +1,21 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+export const insanejournalHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'insanejournal.com')
+  },
+
+  resolve: (url) => {
+    const { origin } = new URL(url)
+    const uris: Array<DiscoverUriEntry> = []
+
+    uris.push({ uri: `${origin}/data/rss`, hint: composeHint('insanejournal:posts-rss') })
+    uris.push({ uri: `${origin}/data/atom`, hint: composeHint('insanejournal:posts-atom') })
+
+    return uris
+  },
+}

--- a/src/feeds/platform/handlers/libsyn.test.ts
+++ b/src/feeds/platform/handlers/libsyn.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+import { libsynHandler } from './libsyn.js'
+
+describe('libsynHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://podcastingforcoaches.libsyn.com', true],
+      ['https://blog.example.libsyn.com', true],
+      ['https://libsyn.com', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(libsynHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(libsynHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for podcast', () => {
+      const value = 'https://podcastingforcoaches.libsyn.com'
+      const expected = [
+        {
+          uri: 'https://podcastingforcoaches.libsyn.com/rss',
+          hint: { key: 'libsyn:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(libsynHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of path', () => {
+      const value = 'https://podcastingforcoaches.libsyn.com/website'
+      const expected = [
+        {
+          uri: 'https://podcastingforcoaches.libsyn.com/rss',
+          hint: { key: 'libsyn:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(libsynHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/libsyn.ts
+++ b/src/feeds/platform/handlers/libsyn.ts
@@ -1,0 +1,21 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+//
+// HTML autodiscovery on libsyn pages returns the underlying
+// rss.libsyn.com/shows/{showId}/destinations/{destId}.xml whose IDs aren't derivable
+// from the user's slug. The handler emits {slug}.libsyn.com/rss which 302-redirects
+// to that resolved URL.
+
+export const libsynHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'libsyn.com')
+  },
+
+  resolve: (url) => {
+    const { origin } = new URL(url)
+
+    return [{ uri: `${origin}/rss`, hint: composeHint('libsyn:podcast') }]
+  },
+}

--- a/src/feeds/platform/handlers/livejournal.test.ts
+++ b/src/feeds/platform/handlers/livejournal.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test'
+import { livejournalHandler } from './livejournal.js'
+
+describe('livejournalHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://ohnotheydidnt.livejournal.com', true],
+      ['https://blog.example.livejournal.com', true],
+      ['https://livejournal.com', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(livejournalHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(livejournalHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return RSS and Atom feeds for blog', () => {
+      const value = 'https://ohnotheydidnt.livejournal.com'
+      const expected = [
+        {
+          uri: 'https://ohnotheydidnt.livejournal.com/data/rss',
+          hint: { key: 'livejournal:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://ohnotheydidnt.livejournal.com/data/atom',
+          hint: { key: 'livejournal:posts-atom', label: 'Posts (Atom)' },
+        },
+      ]
+
+      expect(livejournalHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URLs regardless of path', () => {
+      const value = 'https://ohnotheydidnt.livejournal.com/123456.html'
+      const expected = [
+        {
+          uri: 'https://ohnotheydidnt.livejournal.com/data/rss',
+          hint: { key: 'livejournal:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://ohnotheydidnt.livejournal.com/data/atom',
+          hint: { key: 'livejournal:posts-atom', label: 'Posts (Atom)' },
+        },
+      ]
+
+      expect(livejournalHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/livejournal.ts
+++ b/src/feeds/platform/handlers/livejournal.ts
@@ -1,0 +1,21 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+export const livejournalHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'livejournal.com')
+  },
+
+  resolve: (url) => {
+    const { origin } = new URL(url)
+    const uris: Array<DiscoverUriEntry> = []
+
+    uris.push({ uri: `${origin}/data/rss`, hint: composeHint('livejournal:posts-rss') })
+    uris.push({ uri: `${origin}/data/atom`, hint: composeHint('livejournal:posts-atom') })
+
+    return uris
+  },
+}

--- a/src/feeds/platform/handlers/mataroa.test.ts
+++ b/src/feeds/platform/handlers/mataroa.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+import { mataroaHandler } from './mataroa.js'
+
+describe('mataroaHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://hey.mataroa.blog', true],
+      ['https://blog.example.mataroa.blog', true],
+      ['https://mataroa.blog', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(mataroaHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(mataroaHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for blog', () => {
+      const value = 'https://hey.mataroa.blog'
+      const expected = [
+        {
+          uri: 'https://hey.mataroa.blog/rss/',
+          hint: { key: 'mataroa:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(mataroaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of path', () => {
+      const value = 'https://hey.mataroa.blog/some-article-slug'
+      const expected = [
+        {
+          uri: 'https://hey.mataroa.blog/rss/',
+          hint: { key: 'mataroa:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(mataroaHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/mataroa.ts
+++ b/src/feeds/platform/handlers/mataroa.ts
@@ -1,0 +1,16 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+export const mataroaHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'mataroa.blog')
+  },
+
+  resolve: (url) => {
+    const { origin } = new URL(url)
+
+    return [{ uri: `${origin}/rss/`, hint: composeHint('mataroa:blog') }]
+  },
+}

--- a/src/feeds/platform/handlers/microblog.test.ts
+++ b/src/feeds/platform/handlers/microblog.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'bun:test'
+import { microblogHandler } from './microblog.js'
+
+describe('microblogHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://manton.micro.blog', true],
+      ['https://blog.example.micro.blog', true],
+      ['https://micro.blog', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(microblogHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(microblogHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return RSS, JSON, and podcast feeds for blog', () => {
+      const value = 'https://manton.micro.blog'
+      const expected = [
+        {
+          uri: 'https://manton.micro.blog/feed.xml',
+          hint: { key: 'microblog:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/feed.json',
+          hint: { key: 'microblog:posts-json', label: 'Posts (JSON)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/podcast.xml',
+          hint: { key: 'microblog:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(microblogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return category feeds for category page', () => {
+      const value = 'https://manton.micro.blog/categories/test'
+      const expected = [
+        {
+          uri: 'https://manton.micro.blog/categories/test/feed.xml',
+          hint: { key: 'microblog:category-rss', label: 'Category (RSS)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/categories/test/feed.json',
+          hint: { key: 'microblog:category-json', label: 'Category (JSON)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/feed.xml',
+          hint: { key: 'microblog:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/feed.json',
+          hint: { key: 'microblog:posts-json', label: 'Posts (JSON)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/podcast.xml',
+          hint: { key: 'microblog:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(microblogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return archive feed for archive page', () => {
+      const value = 'https://manton.micro.blog/archive'
+      const expected = [
+        {
+          uri: 'https://manton.micro.blog/archive/index.json',
+          hint: { key: 'microblog:archive', label: 'Archive' },
+        },
+        {
+          uri: 'https://manton.micro.blog/feed.xml',
+          hint: { key: 'microblog:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/feed.json',
+          hint: { key: 'microblog:posts-json', label: 'Posts (JSON)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/podcast.xml',
+          hint: { key: 'microblog:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(microblogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return photos feed for photos page', () => {
+      const value = 'https://manton.micro.blog/photos'
+      const expected = [
+        {
+          uri: 'https://manton.micro.blog/photos/index.json',
+          hint: { key: 'microblog:photos', label: 'Photos' },
+        },
+        {
+          uri: 'https://manton.micro.blog/feed.xml',
+          hint: { key: 'microblog:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/feed.json',
+          hint: { key: 'microblog:posts-json', label: 'Posts (JSON)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/podcast.xml',
+          hint: { key: 'microblog:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(microblogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return replies feed for replies page', () => {
+      const value = 'https://manton.micro.blog/replies'
+      const expected = [
+        {
+          uri: 'https://manton.micro.blog/replies.xml',
+          hint: { key: 'microblog:replies', label: 'Replies' },
+        },
+        {
+          uri: 'https://manton.micro.blog/feed.xml',
+          hint: { key: 'microblog:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/feed.json',
+          hint: { key: 'microblog:posts-json', label: 'Posts (JSON)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/podcast.xml',
+          hint: { key: 'microblog:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(microblogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URLs regardless of path', () => {
+      const value = 'https://manton.micro.blog/2024/01/01/some-post'
+      const expected = [
+        {
+          uri: 'https://manton.micro.blog/feed.xml',
+          hint: { key: 'microblog:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/feed.json',
+          hint: { key: 'microblog:posts-json', label: 'Posts (JSON)' },
+        },
+        {
+          uri: 'https://manton.micro.blog/podcast.xml',
+          hint: { key: 'microblog:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(microblogHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/microblog.ts
+++ b/src/feeds/platform/handlers/microblog.ts
@@ -1,0 +1,70 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+//
+// Some Micro.blog users configure custom domains; HTML autodiscovery on those blogs
+// may point to off-platform URLs (e.g. manton.micro.blog → www.manton.org/feed.xml).
+// The handler always returns the {slug}.micro.blog/* form (the platform itself may
+// still 302-redirect to the user's custom domain).
+
+const categoryRegex = /^\/categories\/([^/]+)/
+
+export const microblogHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'micro.blog')
+  },
+
+  resolve: (url) => {
+    const { origin, pathname } = new URL(url)
+    const uris: Array<DiscoverUriEntry> = []
+
+    // Category page: /categories/{slug}
+    const categoryMatch = pathname.match(categoryRegex)
+
+    if (categoryMatch?.[1]) {
+      const category = categoryMatch[1]
+
+      uris.push({
+        uri: `${origin}/categories/${category}/feed.xml`,
+        hint: composeHint('microblog:category-rss'),
+      })
+      uris.push({
+        uri: `${origin}/categories/${category}/feed.json`,
+        hint: composeHint('microblog:category-json'),
+      })
+    }
+
+    // Archive page: /archive
+    if (pathname.startsWith('/archive')) {
+      uris.push({
+        uri: `${origin}/archive/index.json`,
+        hint: composeHint('microblog:archive'),
+      })
+    }
+
+    // Photos page: /photos
+    if (pathname.startsWith('/photos')) {
+      uris.push({
+        uri: `${origin}/photos/index.json`,
+        hint: composeHint('microblog:photos'),
+      })
+    }
+
+    // Replies page: /replies
+    if (pathname.startsWith('/replies')) {
+      uris.push({
+        uri: `${origin}/replies.xml`,
+        hint: composeHint('microblog:replies'),
+      })
+    }
+
+    // Always include main feeds.
+    uris.push({ uri: `${origin}/feed.xml`, hint: composeHint('microblog:posts-rss') })
+    uris.push({ uri: `${origin}/feed.json`, hint: composeHint('microblog:posts-json') })
+    uris.push({ uri: `${origin}/podcast.xml`, hint: composeHint('microblog:podcast') })
+
+    return uris
+  },
+}

--- a/src/feeds/platform/handlers/misskey.test.ts
+++ b/src/feeds/platform/handlers/misskey.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test'
+import { isMisskeyHtml, misskeyHandler } from './misskey.js'
+
+const misskeyHtml = '<html><head><meta name="application-name" content="Misskey"></head></html>'
+const otherHtml = '<html><head><meta name="application-name" content="Mastodon"></head></html>'
+
+describe('misskeyHandler', () => {
+  describe('isMisskeyHtml', () => {
+    it('should return true for Misskey application-name meta tag', () => {
+      expect(isMisskeyHtml(misskeyHtml)).toBe(true)
+    })
+
+    it('should be case-insensitive', () => {
+      expect(isMisskeyHtml('<meta name="application-name" content="misskey">')).toBe(true)
+      expect(isMisskeyHtml('<meta name="application-name" content="MISSKEY">')).toBe(true)
+    })
+
+    it('should return false for non-Misskey application-name', () => {
+      expect(isMisskeyHtml(otherHtml)).toBe(false)
+    })
+  })
+
+  describe('match', () => {
+    it('should return true for profile URL with Misskey content', () => {
+      expect(misskeyHandler.match('https://misskey.io/@ai', misskeyHtml)).toBe(true)
+    })
+
+    it('should return false without content', () => {
+      expect(misskeyHandler.match('https://misskey.io/@ai')).toBe(false)
+    })
+
+    it('should return false for non-Misskey content', () => {
+      expect(misskeyHandler.match('https://misskey.io/@ai', otherHtml)).toBe(false)
+    })
+
+    it('should return false for non-profile paths', () => {
+      expect(misskeyHandler.match('https://misskey.io/explore', misskeyHtml)).toBe(false)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(misskeyHandler.match('not-a-url', misskeyHtml)).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return atom feed for profile', () => {
+      const value = 'https://misskey.io/@ai'
+      const expected = [
+        {
+          uri: 'https://misskey.io/@ai.atom',
+          hint: { key: 'misskey:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(misskeyHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return atom feed regardless of subpath', () => {
+      const value = 'https://misskey.io/@ai/notes'
+      const expected = [
+        {
+          uri: 'https://misskey.io/@ai.atom',
+          hint: { key: 'misskey:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(misskeyHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for non-profile paths', () => {
+      expect(misskeyHandler.resolve('https://misskey.io/explore')).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/misskey.ts
+++ b/src/feeds/platform/handlers/misskey.ts
@@ -1,0 +1,46 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, hasMetaContent } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const profileRegex = /^\/@([^/.]+)/
+
+export const isMisskeyHtml = (content: string): boolean => {
+  return hasMetaContent(content, 'application-name', 'Misskey')
+}
+
+export const misskeyHandler: PlatformHandler = {
+  match: (url, content) => {
+    try {
+      if (!content || !isMisskeyHtml(content)) {
+        return false
+      }
+
+      const { pathname } = new URL(url)
+
+      return profileRegex.test(pathname)
+    } catch {}
+
+    return false
+  },
+
+  resolve: (url) => {
+    try {
+      const { origin, pathname } = new URL(url)
+      const match = pathname.match(profileRegex)
+
+      if (!match?.[1]) {
+        return []
+      }
+
+      return [
+        {
+          uri: `${origin}/@${match[1]}.atom`,
+          hint: composeHint('misskey:posts'),
+        },
+      ]
+    } catch {}
+
+    return []
+  },
+}

--- a/src/feeds/platform/handlers/naverBlog.test.ts
+++ b/src/feeds/platform/handlers/naverBlog.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test'
+import { naverBlogHandler } from './naverBlog.js'
+
+describe('naverBlogHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://blog.naver.com/prologue', true],
+      ['https://m.blog.naver.com/prologue', true],
+      ['https://blog.naver.com', true],
+      ['https://naver.com', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(naverBlogHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(naverBlogHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for blog', () => {
+      const value = 'https://blog.naver.com/prologue'
+      const expected = [
+        {
+          uri: 'https://rss.blog.naver.com/prologue.xml',
+          hint: { key: 'naver-blog:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(naverBlogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL for mobile domain', () => {
+      const value = 'https://m.blog.naver.com/prologue'
+      const expected = [
+        {
+          uri: 'https://rss.blog.naver.com/prologue.xml',
+          hint: { key: 'naver-blog:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(naverBlogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://blog.naver.com/prologue/123'
+      const expected = [
+        {
+          uri: 'https://rss.blog.naver.com/prologue.xml',
+          hint: { key: 'naver-blog:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(naverBlogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://blog.naver.com/'
+
+      expect(naverBlogHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for paths with dots', () => {
+      const value = 'https://blog.naver.com/BlogList.naver'
+
+      expect(naverBlogHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/naverBlog.ts
+++ b/src/feeds/platform/handlers/naverBlog.ts
@@ -1,0 +1,34 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const hosts = ['blog.naver.com', 'm.blog.naver.com']
+
+export const naverBlogHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const pathSegments = pathname.split('/').filter(Boolean)
+
+    if (pathSegments.length === 0) {
+      return []
+    }
+
+    const blogId = pathSegments[0]
+
+    if (blogId.includes('.')) {
+      return []
+    }
+
+    return [
+      {
+        uri: `https://rss.blog.naver.com/${blogId}.xml`,
+        hint: composeHint('naver-blog:blog'),
+      },
+    ]
+  },
+}

--- a/src/feeds/platform/handlers/observable.test.ts
+++ b/src/feeds/platform/handlers/observable.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'bun:test'
+import { observableHandler } from './observable.js'
+
+describe('observableHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://observablehq.com/@mbostock', true],
+      ['https://www.observablehq.com/@user', true],
+      ['https://observablehq.com', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(observableHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(observableHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for user', () => {
+      const value = 'https://observablehq.com/@mbostock'
+      const expected = [
+        {
+          uri: 'https://api.observablehq.com/documents/@mbostock.rss',
+          hint: { key: 'observable:notebooks', label: 'Notebooks' },
+        },
+      ]
+
+      expect(observableHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://observablehq.com/@mbostock/some-notebook'
+      const expected = [
+        {
+          uri: 'https://api.observablehq.com/documents/@mbostock.rss',
+          hint: { key: 'observable:notebooks', label: 'Notebooks' },
+        },
+      ]
+
+      expect(observableHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL for collection', () => {
+      const value = 'https://observablehq.com/@observablehq/collection/visualization'
+      const expected = [
+        {
+          uri: 'https://api.observablehq.com/collection/@observablehq/visualization.rss',
+          hint: { key: 'observable:collection', label: 'Collection' },
+        },
+      ]
+
+      expect(observableHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://observablehq.com/'
+
+      expect(observableHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for paths without @ prefix', () => {
+      const value = 'https://observablehq.com/trending'
+
+      expect(observableHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/observable.ts
+++ b/src/feeds/platform/handlers/observable.ts
@@ -1,0 +1,43 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const hosts = ['observablehq.com', 'www.observablehq.com']
+const collectionRegex = /^\/@([^/]+)\/collection\/([^/]+)/
+const userRegex = /^\/@([^/]+)/
+
+export const observableHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+
+    // Collection page: /@{user}/collection/{slug}
+    const collectionMatch = pathname.match(collectionRegex)
+
+    if (collectionMatch?.[1] && collectionMatch?.[2]) {
+      return [
+        {
+          uri: `https://api.observablehq.com/collection/@${collectionMatch[1]}/${collectionMatch[2]}.rss`,
+          hint: composeHint('observable:collection'),
+        },
+      ]
+    }
+
+    const userMatch = pathname.match(userRegex)
+
+    if (!userMatch?.[1]) {
+      return []
+    }
+
+    return [
+      {
+        uri: `https://api.observablehq.com/documents/@${userMatch[1]}.rss`,
+        hint: composeHint('observable:notebooks'),
+      },
+    ]
+  },
+}

--- a/src/feeds/platform/handlers/pika.test.ts
+++ b/src/feeds/platform/handlers/pika.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'bun:test'
+import { pikaHandler } from './pika.js'
+
+describe('pikaHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://pika.pika.page', true],
+      ['https://blog.example.pika.page', true],
+      ['https://pika.page', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(pikaHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(pikaHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return Atom and RSS feeds for blog', () => {
+      const value = 'https://pika.pika.page'
+      const expected = [
+        {
+          uri: 'https://pika.pika.page/posts_feed',
+          hint: { key: 'pika:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: 'https://pika.pika.page/posts_feed.rss',
+          hint: { key: 'pika:posts-rss', label: 'Posts (RSS)' },
+        },
+      ]
+
+      expect(pikaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return tag and main feeds for tag page', () => {
+      const value = 'https://discardpile.pika.page/tag/tech'
+      const expected = [
+        {
+          uri: 'https://discardpile.pika.page/tag/tech/feed',
+          hint: { key: 'pika:tag-atom', label: 'Tag (Atom)' },
+        },
+        {
+          uri: 'https://discardpile.pika.page/tag/tech/feed.rss',
+          hint: { key: 'pika:tag-rss', label: 'Tag (RSS)' },
+        },
+        {
+          uri: 'https://discardpile.pika.page/posts_feed',
+          hint: { key: 'pika:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: 'https://discardpile.pika.page/posts_feed.rss',
+          hint: { key: 'pika:posts-rss', label: 'Posts (RSS)' },
+        },
+      ]
+
+      expect(pikaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URLs regardless of path', () => {
+      const value = 'https://pika.pika.page/some-article-slug'
+      const expected = [
+        {
+          uri: 'https://pika.pika.page/posts_feed',
+          hint: { key: 'pika:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: 'https://pika.pika.page/posts_feed.rss',
+          hint: { key: 'pika:posts-rss', label: 'Posts (RSS)' },
+        },
+      ]
+
+      expect(pikaHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/pika.ts
+++ b/src/feeds/platform/handlers/pika.ts
@@ -1,0 +1,39 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const tagRegex = /^\/tag\/([^/]+)/
+
+export const pikaHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'pika.page')
+  },
+
+  resolve: (url) => {
+    const { origin, pathname } = new URL(url)
+    const uris: Array<DiscoverUriEntry> = []
+
+    // Tag page: /tag/{tag}
+    const tagMatch = pathname.match(tagRegex)
+
+    if (tagMatch?.[1]) {
+      const tag = tagMatch[1]
+
+      uris.push({
+        uri: `${origin}/tag/${tag}/feed`,
+        hint: composeHint('pika:tag-atom'),
+      })
+      uris.push({
+        uri: `${origin}/tag/${tag}/feed.rss`,
+        hint: composeHint('pika:tag-rss'),
+      })
+    }
+
+    uris.push({ uri: `${origin}/posts_feed`, hint: composeHint('pika:posts-atom') })
+    uris.push({ uri: `${origin}/posts_feed.rss`, hint: composeHint('pika:posts-rss') })
+
+    return uris
+  },
+}

--- a/src/feeds/platform/handlers/pixelfed.test.ts
+++ b/src/feeds/platform/handlers/pixelfed.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'bun:test'
+import { isPixelfedHtml, pixelfedHandler } from './pixelfed.js'
+
+const pixelfedHtml = '<html><head><meta name="generator" content="pixelfed"></head></html>'
+const otherHtml = '<html><head><meta name="generator" content="WordPress"></head></html>'
+
+describe('pixelfedHandler', () => {
+  describe('isPixelfedHtml', () => {
+    it('should return true for Pixelfed generator meta tag', () => {
+      expect(isPixelfedHtml(pixelfedHtml)).toBe(true)
+    })
+
+    it('should be case-insensitive', () => {
+      expect(isPixelfedHtml('<meta name="generator" content="Pixelfed">')).toBe(true)
+      expect(isPixelfedHtml('<meta name="generator" content="PIXELFED">')).toBe(true)
+    })
+
+    it('should return false for non-Pixelfed generator', () => {
+      expect(isPixelfedHtml(otherHtml)).toBe(false)
+    })
+  })
+
+  describe('match', () => {
+    it('should return true for profile URL with Pixelfed content', () => {
+      expect(pixelfedHandler.match('https://pixelfed.social/dansup', pixelfedHtml)).toBe(true)
+    })
+
+    it('should return true for /users/{user} URL with Pixelfed content', () => {
+      expect(pixelfedHandler.match('https://pixelfed.social/users/dansup', pixelfedHtml)).toBe(true)
+    })
+
+    it('should return false without content', () => {
+      expect(pixelfedHandler.match('https://pixelfed.social/dansup')).toBe(false)
+    })
+
+    it('should return false for non-Pixelfed content', () => {
+      expect(pixelfedHandler.match('https://pixelfed.social/dansup', otherHtml)).toBe(false)
+    })
+
+    it('should return false for excluded paths', () => {
+      expect(pixelfedHandler.match('https://pixelfed.social/discover', pixelfedHtml)).toBe(false)
+      expect(pixelfedHandler.match('https://pixelfed.social/api', pixelfedHtml)).toBe(false)
+    })
+
+    it('should return false for non-profile paths', () => {
+      expect(pixelfedHandler.match('https://pixelfed.social/p/12345', pixelfedHtml)).toBe(false)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(pixelfedHandler.match('not-a-url', pixelfedHtml)).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return atom feed for profile', () => {
+      const value = 'https://pixelfed.social/dansup'
+      const expected = [
+        {
+          uri: 'https://pixelfed.social/users/dansup.atom',
+          hint: { key: 'pixelfed:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(pixelfedHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return atom feed for /users/{user} URL', () => {
+      const value = 'https://pixelfed.social/users/dansup'
+      const expected = [
+        {
+          uri: 'https://pixelfed.social/users/dansup.atom',
+          hint: { key: 'pixelfed:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(pixelfedHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for non-profile paths', () => {
+      expect(pixelfedHandler.resolve('https://pixelfed.social/p/12345')).toEqual([])
+    })
+
+    it('should return empty array for excluded paths', () => {
+      expect(pixelfedHandler.resolve('https://pixelfed.social/discover')).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/pixelfed.ts
+++ b/src/feeds/platform/handlers/pixelfed.ts
@@ -1,0 +1,62 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, hasMetaContent } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const profileRegex = /^\/(?:users\/)?([a-zA-Z0-9_]+)\/?$/
+const excludedPaths = [
+  'admin',
+  'api',
+  'discover',
+  'i',
+  'login',
+  'notifications',
+  'p',
+  'register',
+  'settings',
+  'site',
+  'storage',
+  'timeline',
+  'users',
+]
+
+export const isPixelfedHtml = (content: string): boolean => {
+  return hasMetaContent(content, 'generator', 'pixelfed')
+}
+
+export const pixelfedHandler: PlatformHandler = {
+  match: (url, content) => {
+    try {
+      if (!content || !isPixelfedHtml(content)) {
+        return false
+      }
+
+      const { pathname } = new URL(url)
+      const match = pathname.match(profileRegex)
+
+      return Boolean(match?.[1] && !excludedPaths.includes(match[1]))
+    } catch {}
+
+    return false
+  },
+
+  resolve: (url) => {
+    try {
+      const { origin, pathname } = new URL(url)
+      const match = pathname.match(profileRegex)
+
+      if (!match?.[1] || excludedPaths.includes(match[1])) {
+        return []
+      }
+
+      return [
+        {
+          uri: `${origin}/users/${match[1]}.atom`,
+          hint: composeHint('pixelfed:posts'),
+        },
+      ]
+    } catch {}
+
+    return []
+  },
+}

--- a/src/feeds/platform/handlers/pleroma.test.ts
+++ b/src/feeds/platform/handlers/pleroma.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test'
+import { isPleromaHtml, pleromaHandler } from './pleroma.js'
+
+const pleromaHtml =
+  '<html><head><link rel="preload" href="/api/pleroma/frontend_configurations" as="fetch"></head></html>'
+const otherHtml = '<html><head><meta name="generator" content="WordPress"></head></html>'
+
+describe('pleromaHandler', () => {
+  describe('isPleromaHtml', () => {
+    it('should return true for content referencing /api/pleroma/', () => {
+      expect(isPleromaHtml(pleromaHtml)).toBe(true)
+    })
+
+    it('should be case-insensitive', () => {
+      expect(isPleromaHtml('<a href="/API/Pleroma/admin">x</a>')).toBe(true)
+    })
+
+    it('should return false for non-Pleroma content', () => {
+      expect(isPleromaHtml(otherHtml)).toBe(false)
+    })
+  })
+
+  describe('match', () => {
+    it('should return true for profile URL with Pleroma content', () => {
+      expect(pleromaHandler.match('https://lain.com/users/lain', pleromaHtml)).toBe(true)
+    })
+
+    it('should return false without content', () => {
+      expect(pleromaHandler.match('https://lain.com/users/lain')).toBe(false)
+    })
+
+    it('should return false for non-Pleroma content', () => {
+      expect(pleromaHandler.match('https://lain.com/users/lain', otherHtml)).toBe(false)
+    })
+
+    it('should return false for non-profile paths', () => {
+      expect(pleromaHandler.match('https://lain.com/about', pleromaHtml)).toBe(false)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(pleromaHandler.match('not-a-url', pleromaHtml)).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return atom feed for profile', () => {
+      const value = 'https://lain.com/users/lain'
+      const expected = [
+        {
+          uri: 'https://lain.com/users/lain/feed.atom',
+          hint: { key: 'pleroma:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(pleromaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return atom feed regardless of subpath', () => {
+      const value = 'https://lain.com/users/lain/statuses'
+      const expected = [
+        {
+          uri: 'https://lain.com/users/lain/feed.atom',
+          hint: { key: 'pleroma:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(pleromaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for non-profile paths', () => {
+      expect(pleromaHandler.resolve('https://lain.com/about')).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/pleroma.ts
+++ b/src/feeds/platform/handlers/pleroma.ts
@@ -1,0 +1,47 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const profileRegex = /^\/users\/([^/]+)/
+const pleromaApiRegex = /\/api\/pleroma\//i
+
+export const isPleromaHtml = (content: string): boolean => {
+  return pleromaApiRegex.test(content)
+}
+
+export const pleromaHandler: PlatformHandler = {
+  match: (url, content) => {
+    try {
+      if (!content || !isPleromaHtml(content)) {
+        return false
+      }
+
+      const { pathname } = new URL(url)
+
+      return profileRegex.test(pathname)
+    } catch {}
+
+    return false
+  },
+
+  resolve: (url) => {
+    try {
+      const { origin, pathname } = new URL(url)
+      const match = pathname.match(profileRegex)
+
+      if (!match?.[1]) {
+        return []
+      }
+
+      return [
+        {
+          uri: `${origin}/users/${match[1]}/feed.atom`,
+          hint: composeHint('pleroma:posts'),
+        },
+      ]
+    } catch {}
+
+    return []
+  },
+}

--- a/src/feeds/platform/handlers/podbean.test.ts
+++ b/src/feeds/platform/handlers/podbean.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+import { podbeanHandler } from './podbean.js'
+
+describe('podbeanHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://kickstartcommerce.podbean.com', true],
+      ['https://blog.example.podbean.com', true],
+      ['https://podbean.com', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(podbeanHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(podbeanHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for podcast', () => {
+      const value = 'https://kickstartcommerce.podbean.com'
+      const expected = [
+        {
+          uri: 'https://feed.podbean.com/kickstartcommerce/feed.xml',
+          hint: { key: 'podbean:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(podbeanHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of path', () => {
+      const value = 'https://kickstartcommerce.podbean.com/e/some-episode'
+      const expected = [
+        {
+          uri: 'https://feed.podbean.com/kickstartcommerce/feed.xml',
+          hint: { key: 'podbean:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(podbeanHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/podbean.ts
+++ b/src/feeds/platform/handlers/podbean.ts
@@ -1,0 +1,26 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+//
+// {slug}.podbean.com/feed.xml also works but 302-redirects to feed.podbean.com.
+
+const domainSuffix = /\.podbean\.com$/i
+
+export const podbeanHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'podbean.com')
+  },
+
+  resolve: (url) => {
+    const { hostname } = new URL(url)
+    const slug = hostname.replace(domainSuffix, '')
+
+    return [
+      {
+        uri: `https://feed.podbean.com/${slug}/feed.xml`,
+        hint: composeHint('podbean:podcast'),
+      },
+    ]
+  },
+}

--- a/src/feeds/platform/handlers/podigee.test.ts
+++ b/src/feeds/platform/handlers/podigee.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+import { podigeeHandler } from './podigee.js'
+
+describe('podigeeHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://cui-bono.podigee.io', true],
+      ['https://anything.podigee.io/episodes', true],
+      ['https://podigee.io', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(podigeeHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(podigeeHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return podcast feed for show', () => {
+      const value = 'https://cui-bono.podigee.io'
+      const expected = [
+        {
+          uri: 'https://cui-bono.podigee.io/feed/mp3',
+          hint: { key: 'podigee:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(podigeeHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of path', () => {
+      const value = 'https://cui-bono.podigee.io/episodes/123'
+      const expected = [
+        {
+          uri: 'https://cui-bono.podigee.io/feed/mp3',
+          hint: { key: 'podigee:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(podigeeHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/podigee.ts
+++ b/src/feeds/platform/handlers/podigee.ts
@@ -1,0 +1,16 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+export const podigeeHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'podigee.io')
+  },
+
+  resolve: (url) => {
+    const { origin } = new URL(url)
+
+    return [{ uri: `${origin}/feed/mp3`, hint: composeHint('podigee:podcast') }]
+  },
+}

--- a/src/feeds/platform/handlers/posthaven.test.ts
+++ b/src/feeds/platform/handlers/posthaven.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+import { posthavenHandler } from './posthaven.js'
+
+describe('posthavenHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://blog.posthaven.com', true],
+      ['https://anything.posthaven.com/post', true],
+      ['https://posthaven.com', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(posthavenHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(posthavenHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return posts feed for blog', () => {
+      const value = 'https://blog.posthaven.com'
+      const expected = [
+        {
+          uri: 'https://blog.posthaven.com/posts.atom',
+          hint: { key: 'posthaven:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(posthavenHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of path', () => {
+      const value = 'https://blog.posthaven.com/some-post-slug'
+      const expected = [
+        {
+          uri: 'https://blog.posthaven.com/posts.atom',
+          hint: { key: 'posthaven:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(posthavenHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/posthaven.ts
+++ b/src/feeds/platform/handlers/posthaven.ts
@@ -1,0 +1,16 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+export const posthavenHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'posthaven.com')
+  },
+
+  resolve: (url) => {
+    const { origin } = new URL(url)
+
+    return [{ uri: `${origin}/posts.atom`, hint: composeHint('posthaven:posts') }]
+  },
+}

--- a/src/feeds/platform/handlers/qiita.test.ts
+++ b/src/feeds/platform/handlers/qiita.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'bun:test'
+import { qiitaHandler } from './qiita.js'
+
+describe('qiitaHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://qiita.com/Qiita', true],
+      ['https://www.qiita.com/user', true],
+      ['https://qiita.com', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(qiitaHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(qiitaHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for user', () => {
+      const value = 'https://qiita.com/Qiita'
+      const expected = [
+        {
+          uri: 'https://qiita.com/Qiita/feed.atom',
+          hint: { key: 'qiita:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(qiitaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://qiita.com/Qiita/items/some-article'
+      const expected = [
+        {
+          uri: 'https://qiita.com/Qiita/feed.atom',
+          hint: { key: 'qiita:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(qiitaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL for tag page', () => {
+      const value = 'https://qiita.com/tags/javascript'
+      const expected = [
+        {
+          uri: 'https://qiita.com/tags/javascript/feed.atom',
+          hint: { key: 'qiita:tag', label: 'Tag' },
+        },
+      ]
+
+      expect(qiitaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL for organization page', () => {
+      const value = 'https://qiita.com/organizations/qiita-inc'
+      const expected = [
+        {
+          uri: 'https://qiita.com/organizations/qiita-inc/activities.atom',
+          hint: { key: 'qiita:organization', label: 'Organization' },
+        },
+      ]
+
+      expect(qiitaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL for popular items page', () => {
+      const value = 'https://qiita.com/popular-items'
+      const expected = [
+        {
+          uri: 'https://qiita.com/popular-items/feed.atom',
+          hint: { key: 'qiita:popular', label: 'Popular items' },
+        },
+      ]
+
+      expect(qiitaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://qiita.com/'
+
+      expect(qiitaHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for bare tags path', () => {
+      const value = 'https://qiita.com/tags'
+
+      expect(qiitaHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/qiita.ts
+++ b/src/feeds/platform/handlers/qiita.ts
@@ -1,0 +1,86 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const hosts = ['qiita.com', 'www.qiita.com']
+const excludedPaths = [
+  'about',
+  'api',
+  'login',
+  'organizations',
+  'popular-items',
+  'privacy',
+  'search',
+  'settings',
+  'signup',
+  'tags',
+  'terms',
+  'trend',
+]
+const tagRegex = /^\/tags\/([^/]+)/
+const organizationRegex = /^\/organizations\/([^/]+)/
+const popularItemsRegex = /^\/popular-items(\/|$)/
+
+export const qiitaHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+
+    // Tag page: /tags/{tag}
+    const tagMatch = pathname.match(tagRegex)
+
+    if (tagMatch?.[1]) {
+      return [
+        {
+          uri: `https://qiita.com/tags/${tagMatch[1]}/feed.atom`,
+          hint: composeHint('qiita:tag'),
+        },
+      ]
+    }
+
+    // Organization page: /organizations/{org}
+    const orgMatch = pathname.match(organizationRegex)
+
+    if (orgMatch?.[1]) {
+      return [
+        {
+          uri: `https://qiita.com/organizations/${orgMatch[1]}/activities.atom`,
+          hint: composeHint('qiita:organization'),
+        },
+      ]
+    }
+
+    // Popular items page
+    if (popularItemsRegex.test(pathname)) {
+      return [
+        {
+          uri: 'https://qiita.com/popular-items/feed.atom',
+          hint: composeHint('qiita:popular'),
+        },
+      ]
+    }
+
+    const pathSegments = pathname.split('/').filter(Boolean)
+
+    if (pathSegments.length === 0) {
+      return []
+    }
+
+    const username = pathSegments[0]
+
+    if (isAnyOf(username, excludedPaths)) {
+      return []
+    }
+
+    return [
+      {
+        uri: `https://qiita.com/${username}/feed.atom`,
+        hint: composeHint('qiita:posts'),
+      },
+    ]
+  },
+}

--- a/src/feeds/platform/handlers/rssCom.test.ts
+++ b/src/feeds/platform/handlers/rssCom.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { rssComHandler } from './rssCom.js'
+
+describe('rssComHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://rss.com/podcasts/podcasting101', true],
+      ['https://www.rss.com/podcasts/some-show', true],
+      ['https://rss.com', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(rssComHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(rssComHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for podcast', () => {
+      const value = 'https://rss.com/podcasts/podcasting101'
+      const expected = [
+        {
+          uri: 'https://media.rss.com/podcasting101/feed.xml',
+          hint: { key: 'rss-com:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(rssComHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://rss.com/podcasts/podcasting101/episodes/some-episode'
+      const expected = [
+        {
+          uri: 'https://media.rss.com/podcasting101/feed.xml',
+          hint: { key: 'rss-com:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(rssComHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://rss.com/'
+
+      expect(rssComHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for non-podcast paths', () => {
+      const value = 'https://rss.com/about'
+
+      expect(rssComHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/rssCom.ts
+++ b/src/feeds/platform/handlers/rssCom.ts
@@ -1,0 +1,29 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const hosts = ['rss.com', 'www.rss.com']
+const podcastRegex = /^\/podcasts\/([^/]+)/
+
+export const rssComHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const match = pathname.match(podcastRegex)
+
+    if (!match?.[1]) {
+      return []
+    }
+
+    return [
+      {
+        uri: `https://media.rss.com/${match[1]}/feed.xml`,
+        hint: composeHint('rss-com:podcast'),
+      },
+    ]
+  },
+}

--- a/src/feeds/platform/handlers/seesaa.test.ts
+++ b/src/feeds/platform/handlers/seesaa.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test'
+import { seesaaHandler } from './seesaa.js'
+
+describe('seesaaHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://jetstream777.seesaa.net', true],
+      ['https://blog.example.seesaa.net', true],
+      ['https://seesaa.net', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(seesaaHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(seesaaHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return RSS 2.0 and RDF feeds for blog', () => {
+      const value = 'https://jetstream777.seesaa.net'
+      const expected = [
+        {
+          uri: 'https://jetstream777.seesaa.net/index20.rdf',
+          hint: { key: 'seesaa:posts-rss2', label: 'Posts (RSS 2.0)' },
+        },
+        {
+          uri: 'https://jetstream777.seesaa.net/index.rdf',
+          hint: { key: 'seesaa:posts-rdf', label: 'Posts (RDF)' },
+        },
+      ]
+
+      expect(seesaaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URLs regardless of path', () => {
+      const value = 'https://jetstream777.seesaa.net/article/123.html'
+      const expected = [
+        {
+          uri: 'https://jetstream777.seesaa.net/index20.rdf',
+          hint: { key: 'seesaa:posts-rss2', label: 'Posts (RSS 2.0)' },
+        },
+        {
+          uri: 'https://jetstream777.seesaa.net/index.rdf',
+          hint: { key: 'seesaa:posts-rdf', label: 'Posts (RDF)' },
+        },
+      ]
+
+      expect(seesaaHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/seesaa.ts
+++ b/src/feeds/platform/handlers/seesaa.ts
@@ -1,0 +1,21 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+export const seesaaHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'seesaa.net')
+  },
+
+  resolve: (url) => {
+    const { origin } = new URL(url)
+    const uris: Array<DiscoverUriEntry> = []
+
+    uris.push({ uri: `${origin}/index20.rdf`, hint: composeHint('seesaa:posts-rss2') })
+    uris.push({ uri: `${origin}/index.rdf`, hint: composeHint('seesaa:posts-rdf') })
+
+    return uris
+  },
+}

--- a/src/feeds/platform/handlers/spreaker.test.ts
+++ b/src/feeds/platform/handlers/spreaker.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { spreakerHandler } from './spreaker.js'
+
+describe('spreakerHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://www.spreaker.com/podcast/spreaker-live-show--1433865', true],
+      ['https://spreaker.com/podcast/my-show--12345', true],
+      ['https://spreaker.com', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(spreakerHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(spreakerHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for podcast', () => {
+      const value = 'https://www.spreaker.com/podcast/spreaker-live-show--1433865'
+      const expected = [
+        {
+          uri: 'https://www.spreaker.com/show/1433865/episodes/feed',
+          hint: { key: 'spreaker:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(spreakerHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://www.spreaker.com/podcast/spreaker-live-show--1433865/episodes/456'
+      const expected = [
+        {
+          uri: 'https://www.spreaker.com/show/1433865/episodes/feed',
+          hint: { key: 'spreaker:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(spreakerHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://www.spreaker.com/'
+
+      expect(spreakerHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for paths without podcast ID', () => {
+      const value = 'https://www.spreaker.com/podcast/my-show'
+
+      expect(spreakerHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/spreaker.ts
+++ b/src/feeds/platform/handlers/spreaker.ts
@@ -1,0 +1,29 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const hosts = ['spreaker.com', 'www.spreaker.com']
+const podcastRegex = /^\/podcast\/[\w-]+--(\d+)/
+
+export const spreakerHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const match = pathname.match(podcastRegex)
+
+    if (!match?.[1]) {
+      return []
+    }
+
+    return [
+      {
+        uri: `https://www.spreaker.com/show/${match[1]}/episodes/feed`,
+        hint: composeHint('spreaker:podcast'),
+      },
+    ]
+  },
+}

--- a/src/feeds/platform/handlers/tildes.test.ts
+++ b/src/feeds/platform/handlers/tildes.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'bun:test'
+import { tildesHandler } from './tildes.js'
+
+describe('tildesHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://tildes.net/~tech', true],
+      ['https://www.tildes.net/~science', true],
+      ['https://tildes.net', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(tildesHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(tildesHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return RSS and Atom feeds for group', () => {
+      const value = 'https://tildes.net/~tech'
+      const expected = [
+        {
+          uri: 'https://tildes.net/~tech/topics.rss',
+          hint: { key: 'tildes:group-rss', label: 'Group (RSS)' },
+        },
+        {
+          uri: 'https://tildes.net/~tech/topics.atom',
+          hint: { key: 'tildes:group-atom', label: 'Group (Atom)' },
+        },
+      ]
+
+      expect(tildesHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return group feeds regardless of subpath', () => {
+      const value = 'https://tildes.net/~tech/some-topic'
+      const expected = [
+        {
+          uri: 'https://tildes.net/~tech/topics.rss',
+          hint: { key: 'tildes:group-rss', label: 'Group (RSS)' },
+        },
+        {
+          uri: 'https://tildes.net/~tech/topics.atom',
+          hint: { key: 'tildes:group-atom', label: 'Group (Atom)' },
+        },
+      ]
+
+      expect(tildesHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return global topics feeds for root path', () => {
+      const value = 'https://tildes.net/'
+      const expected = [
+        {
+          uri: 'https://tildes.net/topics.rss',
+          hint: { key: 'tildes:topics-rss', label: 'Topics (RSS)' },
+        },
+        {
+          uri: 'https://tildes.net/topics.atom',
+          hint: { key: 'tildes:topics-atom', label: 'Topics (Atom)' },
+        },
+      ]
+
+      expect(tildesHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for paths without ~ prefix', () => {
+      const value = 'https://tildes.net/login'
+
+      expect(tildesHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/tildes.ts
+++ b/src/feeds/platform/handlers/tildes.ts
@@ -1,0 +1,49 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const hosts = ['tildes.net', 'www.tildes.net']
+const groupRegex = /^\/~([^/]+)/
+
+export const tildesHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+    const groupMatch = pathname.match(groupRegex)
+    const uris: Array<DiscoverUriEntry> = []
+
+    if (groupMatch?.[1]) {
+      const group = groupMatch[1]
+
+      uris.push({
+        uri: `https://tildes.net/~${group}/topics.rss`,
+        hint: composeHint('tildes:group-rss'),
+      })
+      uris.push({
+        uri: `https://tildes.net/~${group}/topics.atom`,
+        hint: composeHint('tildes:group-atom'),
+      })
+
+      return uris
+    }
+
+    // Global home feed only for root path.
+    if (pathname === '/' || pathname === '') {
+      uris.push({
+        uri: 'https://tildes.net/topics.rss',
+        hint: composeHint('tildes:topics-rss'),
+      })
+      uris.push({
+        uri: 'https://tildes.net/topics.atom',
+        hint: composeHint('tildes:topics-atom'),
+      })
+    }
+
+    return uris
+  },
+}

--- a/src/feeds/platform/handlers/weblogLol.test.ts
+++ b/src/feeds/platform/handlers/weblogLol.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test'
+import { weblogLolHandler } from './weblogLol.js'
+
+describe('weblogLolHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://robb.weblog.lol', true],
+      ['https://blog.example.weblog.lol', true],
+      ['https://weblog.lol', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(weblogLolHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(weblogLolHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return RSS, Atom, and JSON feeds for blog', () => {
+      const value = 'https://robb.weblog.lol'
+      const expected = [
+        {
+          uri: 'https://robb.weblog.lol/rss.xml',
+          hint: { key: 'weblog-lol:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://robb.weblog.lol/atom.xml',
+          hint: { key: 'weblog-lol:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: 'https://robb.weblog.lol/feed.json',
+          hint: { key: 'weblog-lol:posts-json', label: 'Posts (JSON)' },
+        },
+      ]
+
+      expect(weblogLolHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URLs regardless of path', () => {
+      const value = 'https://robb.weblog.lol/some-article-slug'
+      const expected = [
+        {
+          uri: 'https://robb.weblog.lol/rss.xml',
+          hint: { key: 'weblog-lol:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://robb.weblog.lol/atom.xml',
+          hint: { key: 'weblog-lol:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: 'https://robb.weblog.lol/feed.json',
+          hint: { key: 'weblog-lol:posts-json', label: 'Posts (JSON)' },
+        },
+      ]
+
+      expect(weblogLolHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/weblogLol.ts
+++ b/src/feeds/platform/handlers/weblogLol.ts
@@ -1,0 +1,22 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+export const weblogLolHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'weblog.lol')
+  },
+
+  resolve: (url) => {
+    const { origin } = new URL(url)
+    const uris: Array<DiscoverUriEntry> = []
+
+    uris.push({ uri: `${origin}/rss.xml`, hint: composeHint('weblog-lol:posts-rss') })
+    uris.push({ uri: `${origin}/atom.xml`, hint: composeHint('weblog-lol:posts-atom') })
+    uris.push({ uri: `${origin}/feed.json`, hint: composeHint('weblog-lol:posts-json') })
+
+    return uris
+  },
+}

--- a/src/feeds/platform/handlers/weebly.test.ts
+++ b/src/feeds/platform/handlers/weebly.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test'
+import { weeblyHandler } from './weebly.js'
+
+describe('weeblyHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://example.weebly.com', true],
+      ['https://blog.example.weebly.com', true],
+      ['https://weebly.com', false],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(weeblyHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(weeblyHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return default feed for blog root', () => {
+      const value = 'https://example.weebly.com'
+      const expected = [
+        {
+          uri: 'https://example.weebly.com/1/feed',
+          hint: { key: 'weebly:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(weeblyHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return custom slug and default feeds for named blog page', () => {
+      const value = 'https://example.weebly.com/blog'
+      const expected = [
+        {
+          uri: 'https://example.weebly.com/blog/feed',
+          hint: { key: 'weebly:blog', label: 'Blog' },
+        },
+        {
+          uri: 'https://example.weebly.com/1/feed',
+          hint: { key: 'weebly:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(weeblyHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should skip custom slug for numeric segments', () => {
+      const value = 'https://example.weebly.com/1/feed'
+      const expected = [
+        {
+          uri: 'https://example.weebly.com/1/feed',
+          hint: { key: 'weebly:blog', label: 'Blog' },
+        },
+      ]
+
+      expect(weeblyHandler.resolve(value)).toEqual(expected)
+    })
+  })
+})

--- a/src/feeds/platform/handlers/weebly.ts
+++ b/src/feeds/platform/handlers/weebly.ts
@@ -1,0 +1,33 @@
+import type { DiscoverUriEntry } from '../../../common/types.js'
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isSubdomainOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const numericRegex = /^\d+$/
+
+export const weeblyHandler: PlatformHandler = {
+  match: (url) => {
+    return isSubdomainOf(url, 'weebly.com')
+  },
+
+  resolve: (url) => {
+    const { origin, pathname } = new URL(url)
+    const pathSegments = pathname.split('/').filter(Boolean)
+    const uris: Array<DiscoverUriEntry> = []
+
+    // Custom blog page slug (e.g., /blog/feed when page is named "blog").
+    const firstSegment = pathSegments[0]
+
+    if (firstSegment && !numericRegex.test(firstSegment)) {
+      uris.push({
+        uri: `${origin}/${firstSegment}/feed`,
+        hint: composeHint('weebly:blog'),
+      })
+    }
+
+    uris.push({ uri: `${origin}/1/feed`, hint: composeHint('weebly:blog') })
+
+    return uris
+  },
+}

--- a/src/feeds/platform/handlers/zenn.test.ts
+++ b/src/feeds/platform/handlers/zenn.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'bun:test'
+import { zennHandler } from './zenn.js'
+
+describe('zennHandler', () => {
+  describe('match', () => {
+    const cases = [
+      ['https://zenn.dev/zenn', true],
+      ['https://www.zenn.dev/user', true],
+      ['https://zenn.dev', true],
+      ['https://example.com', false],
+    ] as const
+
+    it.each(cases)('%s -> %s', (url, expected) => {
+      expect(zennHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(zennHandler.match('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('resolve', () => {
+    it('should return feed URL for user', () => {
+      const value = 'https://zenn.dev/catnose99'
+      const expected = [
+        {
+          uri: 'https://zenn.dev/catnose99/feed',
+          hint: { key: 'zenn:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(zennHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL regardless of subpath', () => {
+      const value = 'https://zenn.dev/catnose99/articles/some-article'
+      const expected = [
+        {
+          uri: 'https://zenn.dev/catnose99/feed',
+          hint: { key: 'zenn:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(zennHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL for topic page', () => {
+      const value = 'https://zenn.dev/topics/react'
+      const expected = [
+        {
+          uri: 'https://zenn.dev/topics/react/feed',
+          hint: { key: 'zenn:topic', label: 'Topic' },
+        },
+      ]
+
+      expect(zennHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL for short publication page', () => {
+      const value = 'https://zenn.dev/p/team_zenn'
+      const expected = [
+        {
+          uri: 'https://zenn.dev/p/team_zenn/feed',
+          hint: { key: 'zenn:publication', label: 'Publication' },
+        },
+      ]
+
+      expect(zennHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL for long publication page', () => {
+      const value = 'https://zenn.dev/publications/team_zenn'
+      const expected = [
+        {
+          uri: 'https://zenn.dev/p/team_zenn/feed',
+          hint: { key: 'zenn:publication', label: 'Publication' },
+        },
+      ]
+
+      expect(zennHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for root path', () => {
+      const value = 'https://zenn.dev/'
+
+      expect(zennHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for excluded paths', () => {
+      const value = 'https://zenn.dev/topics'
+
+      expect(zennHandler.resolve(value)).toEqual([])
+    })
+  })
+})

--- a/src/feeds/platform/handlers/zenn.ts
+++ b/src/feeds/platform/handlers/zenn.ts
@@ -1,0 +1,79 @@
+import type { PlatformHandler } from '../../../common/uris/platform/types.js'
+import { composeHint, isAnyOf, isHostOf } from '../../../common/utils.js'
+
+// Discoverable without handler.
+
+const hosts = ['zenn.dev', 'www.zenn.dev']
+const excludedPaths = [
+  'about',
+  'api',
+  'articles',
+  'books',
+  'login',
+  'notifications',
+  'p',
+  'privacy',
+  'publications',
+  'scraps',
+  'search',
+  'settings',
+  'signup',
+  'terms',
+  'topics',
+]
+const topicRegex = /^\/topics\/([^/]+)/
+const publicationShortRegex = /^\/p\/([^/]+)/
+const publicationLongRegex = /^\/publications\/([^/]+)/
+
+export const zennHandler: PlatformHandler = {
+  match: (url) => {
+    return isHostOf(url, hosts)
+  },
+
+  resolve: (url) => {
+    const { pathname } = new URL(url)
+
+    // Topic page: /topics/{topic}
+    const topicMatch = pathname.match(topicRegex)
+
+    if (topicMatch?.[1]) {
+      return [
+        {
+          uri: `https://zenn.dev/topics/${topicMatch[1]}/feed`,
+          hint: composeHint('zenn:topic'),
+        },
+      ]
+    }
+
+    // Publication page: /p/{pub} or /publications/{pub}
+    const pubMatch = pathname.match(publicationShortRegex) ?? pathname.match(publicationLongRegex)
+
+    if (pubMatch?.[1]) {
+      return [
+        {
+          uri: `https://zenn.dev/p/${pubMatch[1]}/feed`,
+          hint: composeHint('zenn:publication'),
+        },
+      ]
+    }
+
+    const pathSegments = pathname.split('/').filter(Boolean)
+
+    if (pathSegments.length === 0) {
+      return []
+    }
+
+    const username = pathSegments[0]
+
+    if (isAnyOf(username, excludedPaths)) {
+      return []
+    }
+
+    return [
+      {
+        uri: `https://zenn.dev/${username}/feed`,
+        hint: composeHint('zenn:posts'),
+      },
+    ]
+  },
+}


### PR DESCRIPTION
Adds 33 new platform handlers from the `feat/new-feed-platform-handlers` exploration branch. Each is a separate commit so individual handlers can be reverted or bisected independently.

These were the "fully discoverable" tier. HTML autodiscovery already finds these feeds, so the handler is a fast-path / convenience that bypasses the HTTP fetch when only a URL is known.

## Platforms added

**Podcast hosts (9):** Acast, Audioboom, Buzzsprout, Hearthis.at, Libsyn, Podbean, Podigee, RSS.com, Spreaker

**Blogging platforms (15):** Ameba Blog, Ghost, HEY World, InsaneJournal, LiveJournal, Mataroa, Micro.blog, Naver Blog, Pika, Posthaven, Qiita, Seesaa Blog, weblog.lol, Weebly, Zenn

**Fediverse / social (6):** BookWyrm, Discourse, Friendica, Misskey, Pixelfed, Pleroma

**Forums / aggregators (1):** Tildes

**Creative (2):** Are.na, Observable

## Validation

- 304/304 unit tests pass across the 33 handlers
- All sample URLs in `check/feeds.json` (75 total) returned valid feeds when run live without proxy
- TypeScript clean (`tsc --noEmit`)
- Each commit includes the handler, tests, locale hints, registration in `defaultPlatformOptions`, the docs section, and check fixture entries
