### PR TITLE
test: Align tests with shared conventions and expand coverage

### DIFF
--- a/src/blogrolls/extractors.test.ts
+++ b/src/blogrolls/extractors.test.ts
@@ -34,7 +34,8 @@ describe('defaultExtractFn', () => {
   })
 
   it('should detect OPML 1.0 format', async () => {
-    const opml = `<?xml version="1.0" encoding="UTF-8"?>
+    const opml = `
+      <?xml version="1.0" encoding="UTF-8"?>
       <opml version="1.0">
         <head>
           <title>My Blogroll</title>
@@ -59,7 +60,8 @@ describe('defaultExtractFn', () => {
   })
 
   it('should detect OPML 2.0 format', async () => {
-    const opml = `<?xml version="1.0" encoding="UTF-8"?>
+    const opml = `
+      <?xml version="1.0" encoding="UTF-8"?>
       <opml version="2.0">
         <head>
           <title>Subscriptions</title>
@@ -67,7 +69,7 @@ describe('defaultExtractFn', () => {
         </head>
         <body>
           <outline text="Tech" title="Technology">
-            <outline type="rss" text="TechCrunch" xmlUrl="https://techcrunch.com/feed/"/>
+            <outline type="rss" text="Example Tech Blog" xmlUrl="https://tech.example.com/feed/"/>
           </outline>
         </body>
       </opml>
@@ -87,7 +89,8 @@ describe('defaultExtractFn', () => {
   })
 
   it('should handle OPML without title', async () => {
-    const opml = `<?xml version="1.0" encoding="UTF-8"?>
+    const opml = `
+      <?xml version="1.0" encoding="UTF-8"?>
       <opml version="2.0">
         <head></head>
         <body>
@@ -125,7 +128,8 @@ describe('defaultExtractFn', () => {
   })
 
   it('should return isValid: false for RSS content', async () => {
-    const rss = `<?xml version="1.0" encoding="UTF-8"?>
+    const rss = `
+      <?xml version="1.0" encoding="UTF-8"?>
       <rss version="2.0">
         <channel>
           <title>Test</title>
@@ -147,7 +151,8 @@ describe('defaultExtractFn', () => {
   })
 
   it('should include URL in result', async () => {
-    const opml = `<?xml version="1.0" encoding="UTF-8"?>
+    const opml = `
+      <?xml version="1.0" encoding="UTF-8"?>
       <opml version="2.0">
         <head><title>Test</title></head>
         <body></body>

--- a/src/blogrolls/index.test.ts
+++ b/src/blogrolls/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import locales from '../common/locales.json' with { type: 'json' }
 import type { DiscoverFetchFn, DiscoverResult } from '../common/types.js'
 import { urisBalanced, urisComprehensive, urisMinimal } from './defaults.js'
 import { discoverBlogrolls } from './index.js'
@@ -14,7 +15,8 @@ const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => 
   })
 }
 
-const opml = `<?xml version="1.0" encoding="UTF-8"?>
+const opml = `
+  <?xml version="1.0" encoding="UTF-8"?>
   <opml version="2.0">
     <head><title>My Blogroll</title></head>
     <body>
@@ -255,6 +257,66 @@ describe('discoverBlogrolls', () => {
     ]
 
     expect(value).toEqual(expected)
+  })
+
+  it('should discover blogrolls from Link header with rel="blogroll"', async () => {
+    const mockFetch = createMockFetch({
+      'https://example.com/blogroll.opml': opml,
+    })
+    const headers = new Headers({
+      Link: '</blogroll.opml>; rel="blogroll"',
+    })
+    const value = await discoverBlogrolls(
+      { url: 'https://example.com', headers },
+      {
+        methods: ['headers'],
+        fetchFn: mockFetch,
+      },
+    )
+    const expected: Array<DiscoverResult<BlogrollResult>> = [
+      {
+        url: 'https://example.com/blogroll.opml',
+        isValid: true,
+        method: 'headers',
+        title: 'My Blogroll',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should discover blogrolls from Link header with rel="outline" and OPML type', async () => {
+    const mockFetch = createMockFetch({
+      'https://example.com/subscriptions.opml': opml,
+    })
+    const headers = new Headers({
+      Link: '</subscriptions.opml>; rel="outline"; type="text/x-opml"',
+    })
+    const value = await discoverBlogrolls(
+      { url: 'https://example.com', headers },
+      {
+        methods: ['headers'],
+        fetchFn: mockFetch,
+      },
+    )
+    const expected: Array<DiscoverResult<BlogrollResult>> = [
+      {
+        url: 'https://example.com/subscriptions.opml',
+        isValid: true,
+        method: 'headers',
+        title: 'My Blogroll',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should throw error when html method requested without content', () => {
+    const mockFetch = createMockFetch({})
+    const throwing = () =>
+      discoverBlogrolls({ url: 'https://example.com' }, { methods: ['html'], fetchFn: mockFetch })
+
+    expect(throwing()).rejects.toThrow(locales.errors.htmlMethodRequiresContent)
   })
 
   it('should test additional base URLs alongside main baseUrl', async () => {

--- a/src/common/discover/index.test.ts
+++ b/src/common/discover/index.test.ts
@@ -31,7 +31,13 @@ const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => 
   })
 }
 
-describe('discover', () => {
+// These tests cover the generic discover engine co-located with this file (stop flags,
+// alternatives, progress, error handling, concurrency, fn injection). They drive it through
+// discoverFeeds because discover itself takes an internal options object where every fn is
+// mandatory plus a per-method defaults bundle; the wrapper is the public API that supplies those,
+// so each test only has to inject a mock fetchFn. Feed-specific behavior (platform/html/headers
+// methods, default options wiring) is covered in src/feeds/index.test.ts instead.
+describe('discoverFeeds', () => {
   describe('stopOnFirstMethod', () => {
     it('should fall through to next method when first method URIs are all invalid', async () => {
       const platformHandler: PlatformHandler = {
@@ -454,10 +460,11 @@ describe('discover', () => {
           url: 'https://example.com/feed',
           isValid: false,
           method: 'guess',
+          error: expect.any(Error),
         },
       ]
 
-      expect(value).toMatchObject(expected)
+      expect(value).toEqual(expected)
     })
   })
 
@@ -1001,20 +1008,20 @@ describe('discover', () => {
     it('should throw error when html method requested without content', () => {
       const throwing = () => discoverFeeds({ url: 'https://example.com' }, { methods: ['html'] })
 
-      expect(throwing).toThrow(locales.errors.htmlMethodRequiresContent)
+      expect(throwing()).rejects.toThrow(locales.errors.htmlMethodRequiresContent)
     })
 
     it('should throw error when headers method requested without headers', () => {
       const throwing = () => discoverFeeds({ url: 'https://example.com' }, { methods: ['headers'] })
 
-      expect(throwing).toThrow(locales.errors.headersMethodRequiresHeaders)
+      expect(throwing()).rejects.toThrow(locales.errors.headersMethodRequiresHeaders)
     })
 
     it('should throw error when guess method requested without url', () => {
       // @ts-expect-error: This is for testing purposes.
       const throwing = () => discoverFeeds({ content: '<html></html>' }, { methods: ['guess'] })
 
-      expect(throwing).toThrow(locales.errors.guessMethodRequiresUrl)
+      expect(throwing()).rejects.toThrow(locales.errors.guessMethodRequiresUrl)
     })
   })
 
@@ -1071,6 +1078,27 @@ describe('discover', () => {
       )
 
       expect(receivedHeaders).toBe(inputHeaders)
+    })
+  })
+
+  describe.todo('resolveSiteUrlFn', () => {
+    it.todo('should fetch resolved site URL and run html method against site content', () => {
+      // Pass resolveSiteUrlFn returning a site URL for feed-like input, with fetchFn serving HTML
+      // containing a feed link for that site URL.
+      // Expected: the html method discovers URIs from the fetched site content, not the feed
+      // content.
+    })
+
+    it.todo('should fall back to source input when site fetch throws', () => {
+      // Pass resolveSiteUrlFn returning a site URL while fetchFn rejects for that URL.
+      // Expected: discovery continues using the original input content without throwing.
+    })
+  })
+
+  describe('default concurrency', () => {
+    it.todo('should process at most three URIs at once when concurrency is not specified', () => {
+      // Run discoverFeeds with five guess URIs, a fetchFn that tracks concurrent calls, and no
+      // concurrency option. Expected: maximum observed concurrency is 3 (the default).
     })
   })
 })

--- a/src/common/discover/utils.test.ts
+++ b/src/common/discover/utils.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it, spyOn } from 'bun:test'
 import { parseFeed } from 'feedsmith'
 import locales from '../locales.json' with { type: 'json' }
-import type { DiscoverFetchFn, DiscoverResolveUrlFn } from '../types.js'
+import type {
+  DiscoverFetchFn,
+  DiscoverMethodsConfig,
+  DiscoverMethodsConfigDefaults,
+  DiscoverResolveUrlFn,
+} from '../types.js'
 import { defaultFetchFn, defaultResolveSiteUrlFn, defaultResolveUrlFn } from './defaults.js'
 import {
   getFeedSiteUrl,
@@ -11,23 +16,29 @@ import {
 } from './utils.js'
 
 describe('defaultFetchFn', () => {
-  // biome-ignore lint/suspicious/noExplicitAny: Mock helper needs flexible signature.
-  const createFetchMock = <T extends (...args: Array<any>) => Response | Promise<Response>>(
-    implementation: T,
-  ) => {
-    return implementation as unknown as typeof fetch
-  }
-
   type MockResponse = Pick<Response, 'headers' | 'text' | 'url' | 'status' | 'statusText'>
 
-  const createMockResponse = (partial: Partial<MockResponse>): Response => {
+  type MockFetchImplementation = (
+    url: string,
+    options?: RequestInit,
+  ) => MockResponse | Promise<MockResponse>
+
+  const createFetchMock = (implementation: MockFetchImplementation): typeof fetch => {
+    const fetchMock = async (input: URL | RequestInfo, init?: RequestInit) => {
+      return (await implementation(input.toString(), init)) as Response
+    }
+
+    return fetchMock as typeof fetch
+  }
+
+  const createMockResponse = (partial: Partial<MockResponse>): MockResponse => {
     return {
       headers: partial.headers ?? new Headers(),
       text: partial.text ?? (async () => ''),
       url: partial.url ?? '',
       status: partial.status ?? 200,
       statusText: partial.statusText ?? 'OK',
-    } as Response
+    }
   }
 
   const fetchSpy = spyOn(globalThis, 'fetch')
@@ -45,7 +56,6 @@ describe('defaultFetchFn', () => {
         })
       }),
     )
-    const result = await defaultFetchFn('https://example.com/feed.xml')
     const expected = {
       url: 'https://example.com/feed.xml',
       body: 'response body',
@@ -54,7 +64,7 @@ describe('defaultFetchFn', () => {
       statusText: 'OK',
     }
 
-    expect(result).toEqual(expected)
+    expect(await defaultFetchFn('https://example.com/feed.xml')).toEqual(expected)
   })
 
   it('should default to GET method when not specified', async () => {
@@ -134,7 +144,6 @@ describe('defaultFetchFn', () => {
         })
       }),
     )
-    const result = await defaultFetchFn('https://example.com/feed.xml')
     const expected = {
       url: 'https://redirect.example.com/feed.xml',
       body: '',
@@ -143,7 +152,7 @@ describe('defaultFetchFn', () => {
       statusText: 'OK',
     }
 
-    expect(result).toEqual(expected)
+    expect(await defaultFetchFn('https://example.com/feed.xml')).toEqual(expected)
   })
 
   it('should convert response body to text', async () => {
@@ -154,7 +163,6 @@ describe('defaultFetchFn', () => {
         })
       }),
     )
-    const result = await defaultFetchFn('https://example.com/feed.xml')
     const expected = {
       url: '',
       body: '<rss>feed content</rss>',
@@ -163,7 +171,7 @@ describe('defaultFetchFn', () => {
       statusText: 'OK',
     }
 
-    expect(result).toEqual(expected)
+    expect(await defaultFetchFn('https://example.com/feed.xml')).toEqual(expected)
   })
 
   it('should pass through status and statusText', async () => {
@@ -175,7 +183,6 @@ describe('defaultFetchFn', () => {
         })
       }),
     )
-    const result = await defaultFetchFn('https://example.com/feed.xml')
     const expected = {
       url: '',
       body: '',
@@ -184,7 +191,7 @@ describe('defaultFetchFn', () => {
       statusText: 'Not Found',
     }
 
-    expect(result).toEqual(expected)
+    expect(await defaultFetchFn('https://example.com/feed.xml')).toEqual(expected)
   })
 })
 
@@ -258,14 +265,13 @@ describe('normalizeInput', () => {
         statusText: 'OK',
       })
     }
-    const result = await normalizeInput('https://example.com', headersFetchFn)
     const expected = {
       url: 'https://example.com',
       content: '<html></html>',
       headers,
     }
 
-    expect(result).toEqual(expected)
+    expect(await normalizeInput('https://example.com', headersFetchFn)).toEqual(expected)
   })
 
   it('should return object input as-is', async () => {
@@ -380,10 +386,9 @@ describe('normalizeInput', () => {
     const throwingFetchFn: DiscoverFetchFn = () => {
       throw new Error('Network error')
     }
-    const value = await normalizeInput('https://example.com', throwingFetchFn)
     const expected = { url: 'https://example.com' }
 
-    expect(value).toEqual(expected)
+    expect(await normalizeInput('https://example.com', throwingFetchFn)).toEqual(expected)
   })
 })
 
@@ -451,8 +456,8 @@ describe('normalizeMethodsConfig', () => {
   const ignoredUris = ['wp-json/oembed/', 'wp-json/wp/']
   const anchorLabels = ['rss', 'feed', 'atom', 'subscribe', 'syndicate', 'json feed']
   const linkSelectors = [{ rel: 'alternate', types: feedMimeTypes }, { rel: 'feed' }]
-  const extractUrls = () => [] as Array<string>
-  const defaults = {
+  const extractUrls = (): Array<string> => []
+  const defaults: DiscoverMethodsConfigDefaults = {
     platform: {
       handlers: [],
     },
@@ -472,27 +477,35 @@ describe('normalizeMethodsConfig', () => {
       uris: feedUrisBalanced,
     },
   }
+  const expectedHtmlOptions = {
+    linkSelectors,
+    anchorUris: feedUrisComprehensive,
+    anchorIgnoredUris: ignoredUris,
+    anchorLabels,
+    baseUrl: 'https://example.com',
+  }
+  const expectedHeadersOptions = {
+    linkSelectors,
+    baseUrl: 'https://example.com',
+  }
+  const expectedGuessOptions = {
+    uris: feedUrisBalanced,
+    baseUrl: 'https://example.com',
+  }
 
   it('should normalize array with single method to config with defaults', () => {
     const value = {
       url: 'https://example.com',
       content: '<html></html>',
     }
-    const result = normalizeMethodsConfig(value, undefined, ['html'], defaults)
     const expected = {
       html: {
         html: '<html></html>',
-        options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedHtmlOptions,
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, ['html'], defaults)).toEqual(expected)
   })
 
   it('should normalize array with multiple methods to config with defaults', () => {
@@ -502,34 +515,22 @@ describe('normalizeMethodsConfig', () => {
       content: '<html></html>',
       headers,
     }
-    const result = normalizeMethodsConfig(value, undefined, ['html', 'headers', 'guess'], defaults)
+    const methods: DiscoverMethodsConfig = ['html', 'headers', 'guess']
     const expected = {
       html: {
         html: '<html></html>',
-        options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedHtmlOptions,
       },
       headers: {
         headers,
-        options: {
-          linkSelectors,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedHeadersOptions,
       },
       guess: {
-        options: {
-          uris: feedUrisBalanced,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedGuessOptions,
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, methods, defaults)).toEqual(expected)
   })
 
   it('should normalize object with true values to config with defaults', () => {
@@ -537,43 +538,31 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '<html></html>',
     }
-    const result = normalizeMethodsConfig(value, undefined, { html: true }, defaults)
     const expected = {
       html: {
         html: '<html></html>',
-        options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedHtmlOptions,
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, { html: true }, defaults)).toEqual(expected)
   })
 
   it('should normalize object with custom options and merge with defaults', () => {
     const value = {
       url: 'https://example.com',
     }
-    const result = normalizeMethodsConfig(
-      value,
-      undefined,
-      { guess: { uris: ['/custom-feed'] } },
-      defaults,
-    )
+    const methods: DiscoverMethodsConfig = { guess: { uris: ['/custom-feed'] } }
     const expected = {
       guess: {
         options: {
+          ...expectedGuessOptions,
           uris: ['/custom-feed'],
-          baseUrl: 'https://example.com',
         },
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, methods, defaults)).toEqual(expected)
   })
 
   it('should normalize mixed object with true and custom options', () => {
@@ -581,32 +570,21 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '<html></html>',
     }
-    const result = normalizeMethodsConfig(
-      value,
-      undefined,
-      { html: true, guess: { uris: ['/custom'] } },
-      defaults,
-    )
+    const methods: DiscoverMethodsConfig = { html: true, guess: { uris: ['/custom'] } }
     const expected = {
       html: {
         html: '<html></html>',
-        options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedHtmlOptions,
       },
       guess: {
         options: {
+          ...expectedGuessOptions,
           uris: ['/custom'],
-          baseUrl: 'https://example.com',
         },
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, methods, defaults)).toEqual(expected)
   })
 
   it('should override default options with custom options', () => {
@@ -614,46 +592,36 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '<html></html>',
     }
-    const result = normalizeMethodsConfig(
-      value,
-      undefined,
-      { html: { anchorLabels: ['custom-label'] } },
-      defaults,
-    )
+    const methods: DiscoverMethodsConfig = { html: { anchorLabels: ['custom-label'] } }
     const expected = {
       html: {
         html: '<html></html>',
         options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
+          ...expectedHtmlOptions,
           anchorLabels: ['custom-label'],
-          baseUrl: 'https://example.com',
         },
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, methods, defaults)).toEqual(expected)
   })
 
   it('should handle empty array', () => {
     const value = {
       url: 'https://example.com',
     }
-    const result = normalizeMethodsConfig(value, undefined, [], defaults)
     const expected = {}
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, [], defaults)).toEqual(expected)
   })
 
   it('should handle empty object', () => {
     const value = {
       url: 'https://example.com',
     }
-    const result = normalizeMethodsConfig(value, undefined, {}, defaults)
     const expected = {}
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, {}, defaults)).toEqual(expected)
   })
 
   it('should include baseUrl from input in all method configs', () => {
@@ -663,34 +631,31 @@ describe('normalizeMethodsConfig', () => {
       content: '<html></html>',
       headers,
     }
-    const result = normalizeMethodsConfig(value, undefined, ['html', 'headers', 'guess'], defaults)
+    const methods: DiscoverMethodsConfig = ['html', 'headers', 'guess']
     const expected = {
       html: {
         html: '<html></html>',
         options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels,
+          ...expectedHtmlOptions,
           baseUrl: 'https://blog.example.com',
         },
       },
       headers: {
         headers,
         options: {
-          linkSelectors,
+          ...expectedHeadersOptions,
           baseUrl: 'https://blog.example.com',
         },
       },
       guess: {
         options: {
-          uris: feedUrisBalanced,
+          ...expectedGuessOptions,
           baseUrl: 'https://blog.example.com',
         },
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, methods, defaults)).toEqual(expected)
   })
 
   it('should pass headers object to headers method config', () => {
@@ -699,18 +664,14 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       headers,
     }
-    const result = normalizeMethodsConfig(value, undefined, ['headers'], defaults)
     const expected = {
       headers: {
         headers,
-        options: {
-          linkSelectors,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedHeadersOptions,
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, ['headers'], defaults)).toEqual(expected)
   })
 
   it('should pass html content to html method config', () => {
@@ -720,21 +681,14 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: htmlContent,
     }
-    const result = normalizeMethodsConfig(value, undefined, ['html'], defaults)
     const expected = {
       html: {
         html: htmlContent,
-        options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedHtmlOptions,
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, ['html'], defaults)).toEqual(expected)
   })
 
   it('should preserve custom options when merging with defaults', () => {
@@ -742,62 +696,24 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '<html></html>',
     }
-    const customOptions = {
-      anchorLabels: ['custom1', 'custom2'],
-      anchorUris: ['/custom-feed'],
+    const methods: DiscoverMethodsConfig = {
+      html: {
+        anchorLabels: ['custom1', 'custom2'],
+        anchorUris: ['/custom-feed'],
+      },
     }
-    const result = normalizeMethodsConfig(value, undefined, { html: customOptions }, defaults)
     const expected = {
       html: {
         html: '<html></html>',
         options: {
-          linkSelectors,
+          ...expectedHtmlOptions,
           anchorUris: ['/custom-feed'],
-          anchorIgnoredUris: ignoredUris,
           anchorLabels: ['custom1', 'custom2'],
-          baseUrl: 'https://example.com',
         },
       },
     }
 
-    expect(result).toEqual(expected)
-  })
-
-  it('should handle all three methods with array format', () => {
-    const headers = new Headers()
-    const value = {
-      url: 'https://example.com',
-      content: '<html></html>',
-      headers,
-    }
-    const result = normalizeMethodsConfig(value, undefined, ['html', 'headers', 'guess'], defaults)
-    const expected = {
-      html: {
-        html: '<html></html>',
-        options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels,
-          baseUrl: 'https://example.com',
-        },
-      },
-      headers: {
-        headers,
-        options: {
-          linkSelectors,
-          baseUrl: 'https://example.com',
-        },
-      },
-      guess: {
-        options: {
-          uris: feedUrisBalanced,
-          baseUrl: 'https://example.com',
-        },
-      },
-    }
-
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, methods, defaults)).toEqual(expected)
   })
 
   it('should handle all three methods with object format', () => {
@@ -807,39 +723,22 @@ describe('normalizeMethodsConfig', () => {
       content: '<html></html>',
       headers,
     }
-    const result = normalizeMethodsConfig(
-      value,
-      undefined,
-      { html: true, headers: true, guess: true },
-      defaults,
-    )
+    const methods: DiscoverMethodsConfig = { html: true, headers: true, guess: true }
     const expected = {
       html: {
         html: '<html></html>',
-        options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedHtmlOptions,
       },
       headers: {
         headers,
-        options: {
-          linkSelectors,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedHeadersOptions,
       },
       guess: {
-        options: {
-          uris: feedUrisBalanced,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedGuessOptions,
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, methods, defaults)).toEqual(expected)
   })
 
   it('should throw error when platform method requested without url', () => {
@@ -857,7 +756,6 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '<feed>content</feed>',
     }
-    const result = normalizeMethodsConfig(value, undefined, ['feed'], defaults)
     const expected = {
       feed: {
         content: '<feed>content</feed>',
@@ -867,7 +765,7 @@ describe('normalizeMethodsConfig', () => {
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, ['feed'], defaults)).toEqual(expected)
   })
 
   it('should normalize feed method with custom extractUrls', () => {
@@ -876,12 +774,7 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '<feed>content</feed>',
     }
-    const result = normalizeMethodsConfig(
-      value,
-      undefined,
-      { feed: { extractUrls: customExtractUrls } },
-      defaults,
-    )
+    const methods: DiscoverMethodsConfig = { feed: { extractUrls: customExtractUrls } }
     const expected = {
       feed: {
         content: '<feed>content</feed>',
@@ -891,7 +784,7 @@ describe('normalizeMethodsConfig', () => {
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, methods, defaults)).toEqual(expected)
   })
 
   it('should throw error when feed method requested without content', () => {
@@ -977,90 +870,33 @@ describe('normalizeMethodsConfig', () => {
     expect(throwing).toThrow(locales.errors.guessMethodRequiresUrl)
   })
 
-  it('should return complete html config with all default values', () => {
-    const value = {
-      url: 'https://example.com',
-      content: '<html></html>',
-    }
-    const result = normalizeMethodsConfig(value, undefined, ['html'], defaults)
-    const expected = {
-      html: {
-        html: '<html></html>',
-        options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels,
-          baseUrl: 'https://example.com',
-        },
-      },
-    }
-
-    expect(result).toEqual(expected)
-  })
-
   it('should return complete headers config with all default values', () => {
     const headers = new Headers()
     const value = {
       url: 'https://example.com',
       headers,
     }
-    const result = normalizeMethodsConfig(value, undefined, ['headers'], defaults)
     const expected = {
       headers: {
         headers,
-        options: {
-          linkSelectors,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedHeadersOptions,
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, ['headers'], defaults)).toEqual(expected)
   })
 
   it('should return complete guess config with all default values', () => {
     const value = {
       url: 'https://example.com',
     }
-    const result = normalizeMethodsConfig(value, undefined, ['guess'], defaults)
     const expected = {
       guess: {
-        options: {
-          uris: feedUrisBalanced,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedGuessOptions,
       },
     }
 
-    expect(result).toEqual(expected)
-  })
-
-  it('should keep all defaults when overriding html anchorLabels', () => {
-    const value = {
-      url: 'https://example.com',
-      content: '<html></html>',
-    }
-    const result = normalizeMethodsConfig(
-      value,
-      undefined,
-      { html: { anchorLabels: ['custom-label'] } },
-      defaults,
-    )
-    const expected = {
-      html: {
-        html: '<html></html>',
-        options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels: ['custom-label'],
-          baseUrl: 'https://example.com',
-        },
-      },
-    }
-
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, ['guess'], defaults)).toEqual(expected)
   })
 
   it('should keep all defaults when overriding html anchorUris', () => {
@@ -1068,26 +904,18 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '<html></html>',
     }
-    const result = normalizeMethodsConfig(
-      value,
-      undefined,
-      { html: { anchorUris: ['/custom-feed'] } },
-      defaults,
-    )
+    const methods: DiscoverMethodsConfig = { html: { anchorUris: ['/custom-feed'] } }
     const expected = {
       html: {
         html: '<html></html>',
         options: {
-          linkSelectors,
+          ...expectedHtmlOptions,
           anchorUris: ['/custom-feed'],
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels,
-          baseUrl: 'https://example.com',
         },
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, methods, defaults)).toEqual(expected)
   })
 
   it('should keep all defaults when overriding html anchorIgnoredUris', () => {
@@ -1095,26 +923,18 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '<html></html>',
     }
-    const result = normalizeMethodsConfig(
-      value,
-      undefined,
-      { html: { anchorIgnoredUris: ['custom-ignore'] } },
-      defaults,
-    )
+    const methods: DiscoverMethodsConfig = { html: { anchorIgnoredUris: ['custom-ignore'] } }
     const expected = {
       html: {
         html: '<html></html>',
         options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
+          ...expectedHtmlOptions,
           anchorIgnoredUris: ['custom-ignore'],
-          anchorLabels,
-          baseUrl: 'https://example.com',
         },
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, methods, defaults)).toEqual(expected)
   })
 
   it('should keep all defaults when overriding html linkSelectors', () => {
@@ -1123,48 +943,18 @@ describe('normalizeMethodsConfig', () => {
       content: '<html></html>',
     }
     const customSelectors = [{ rel: 'custom', types: ['custom/mime'] }]
-    const result = normalizeMethodsConfig(
-      value,
-      undefined,
-      { html: { linkSelectors: customSelectors } },
-      defaults,
-    )
+    const methods: DiscoverMethodsConfig = { html: { linkSelectors: customSelectors } }
     const expected = {
       html: {
         html: '<html></html>',
         options: {
+          ...expectedHtmlOptions,
           linkSelectors: customSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels,
-          baseUrl: 'https://example.com',
         },
       },
     }
 
-    expect(result).toEqual(expected)
-  })
-
-  it('should keep all defaults when overriding guess feedUris', () => {
-    const value = {
-      url: 'https://example.com',
-    }
-    const result = normalizeMethodsConfig(
-      value,
-      undefined,
-      { guess: { uris: ['/custom-feed'] } },
-      defaults,
-    )
-    const expected = {
-      guess: {
-        options: {
-          uris: ['/custom-feed'],
-          baseUrl: 'https://example.com',
-        },
-      },
-    }
-
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, methods, defaults)).toEqual(expected)
   })
 
   it('should keep all defaults when overriding headers linkSelectors', () => {
@@ -1174,23 +964,18 @@ describe('normalizeMethodsConfig', () => {
       headers,
     }
     const customSelectors = [{ rel: 'custom', types: ['custom/mime'] }]
-    const result = normalizeMethodsConfig(
-      value,
-      undefined,
-      { headers: { linkSelectors: customSelectors } },
-      defaults,
-    )
+    const methods: DiscoverMethodsConfig = { headers: { linkSelectors: customSelectors } }
     const expected = {
       headers: {
         headers,
         options: {
+          ...expectedHeadersOptions,
           linkSelectors: customSelectors,
-          baseUrl: 'https://example.com',
         },
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, methods, defaults)).toEqual(expected)
   })
 
   it('should handle empty string content for html method', () => {
@@ -1198,21 +983,14 @@ describe('normalizeMethodsConfig', () => {
       url: 'https://example.com',
       content: '',
     }
-    const result = normalizeMethodsConfig(value, undefined, ['html'], defaults)
     const expected = {
       html: {
         html: '',
-        options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels,
-          baseUrl: 'https://example.com',
-        },
+        options: expectedHtmlOptions,
       },
     }
 
-    expect(result).toEqual(expected)
+    expect(normalizeMethodsConfig(value, undefined, ['html'], defaults)).toEqual(expected)
   })
 
   it('should handle undefined url as falsy', () => {
@@ -1225,41 +1003,117 @@ describe('normalizeMethodsConfig', () => {
     expect(throwing).toThrow(locales.errors.guessMethodRequiresUrl)
   })
 
-  it('should return all three method configs with complete defaults', () => {
-    const headers = new Headers()
-    const value = {
-      url: 'https://example.com',
-      content: '<html></html>',
-      headers,
-    }
-    const result = normalizeMethodsConfig(value, undefined, ['html', 'headers', 'guess'], defaults)
-    const expected = {
+  it.todo('should omit method entry when defaults lack that method', () => {
+    // Request a method (e.g. ['html']) with a defaults object that has no html entry.
+    // Expected: the returned config omits the method instead of throwing.
+  })
+
+  describe('siteInput', () => {
+    const siteDefaults: DiscoverMethodsConfigDefaults = {
+      feed: { extractUrls: () => [] },
       html: {
-        html: '<html></html>',
-        options: {
-          linkSelectors,
-          anchorUris: feedUrisComprehensive,
-          anchorIgnoredUris: ignoredUris,
-          anchorLabels,
-          baseUrl: 'https://example.com',
-        },
+        linkSelectors: [{ rel: 'icon' }],
+        anchorUris: [],
+        anchorIgnoredUris: [],
+        anchorLabels: [],
       },
-      headers: {
-        headers,
-        options: {
-          linkSelectors,
-          baseUrl: 'https://example.com',
-        },
-      },
-      guess: {
-        options: {
-          uris: feedUrisBalanced,
-          baseUrl: 'https://example.com',
-        },
-      },
+      headers: { linkSelectors: [{ rel: 'icon' }] },
+      guess: { uris: ['/favicon.ico'] },
     }
 
-    expect(result).toEqual(expected)
+    it('should use siteInput for html, headers, and guess methods', () => {
+      const siteHeaders = new Headers({ 'content-type': 'text/html' })
+      const value = {
+        url: 'https://example.com/feed.xml',
+        content: '<rss>feed content</rss>',
+        headers: new Headers({ 'content-type': 'application/rss+xml' }),
+      }
+      const siteValue = {
+        url: 'https://example.com',
+        content: '<html><link rel="icon" href="/favicon.ico"></html>',
+        headers: siteHeaders,
+      }
+      const methods: DiscoverMethodsConfig = ['html', 'headers', 'guess']
+      const expected = {
+        html: {
+          html: '<html><link rel="icon" href="/favicon.ico"></html>',
+          options: {
+            linkSelectors: [{ rel: 'icon' }],
+            anchorUris: [],
+            anchorIgnoredUris: [],
+            anchorLabels: [],
+            baseUrl: 'https://example.com',
+          },
+        },
+        headers: {
+          headers: siteHeaders,
+          options: {
+            linkSelectors: [{ rel: 'icon' }],
+            baseUrl: 'https://example.com',
+          },
+        },
+        guess: {
+          options: {
+            uris: ['/favicon.ico'],
+            baseUrl: 'https://example.com',
+          },
+        },
+      }
+
+      expect(normalizeMethodsConfig(value, siteValue, methods, siteDefaults)).toEqual(expected)
+    })
+
+    it('should use original input for feed method when siteInput provided', () => {
+      const value = {
+        url: 'https://example.com/feed.xml',
+        content: '<rss>feed content</rss>',
+        headers: new Headers(),
+      }
+      const siteValue = {
+        url: 'https://example.com',
+        content: '<html>site content</html>',
+        headers: new Headers(),
+      }
+      const expected = {
+        feed: {
+          content: '<rss>feed content</rss>',
+          options: {
+            extractUrls: expect.any(Function),
+          },
+        },
+      }
+
+      expect(normalizeMethodsConfig(value, siteValue, ['feed'], siteDefaults)).toEqual(expected)
+    })
+
+    it('should fall back to sourceInput when siteInput is undefined', () => {
+      const value = {
+        url: 'https://example.com',
+        content: '<html>content</html>',
+        headers: new Headers(),
+      }
+      const methods: DiscoverMethodsConfig = ['html', 'guess']
+      const expected = {
+        html: {
+          html: '<html>content</html>',
+          options: {
+            linkSelectors: [{ rel: 'icon' }],
+            anchorUris: [],
+            anchorIgnoredUris: [],
+            anchorLabels: [],
+            baseUrl: 'https://example.com',
+          },
+        },
+        guess: {
+          options: {
+            uris: ['/favicon.ico'],
+            baseUrl: 'https://example.com',
+          },
+        },
+      }
+
+      expect(normalizeMethodsConfig(value, undefined, methods, siteDefaults)).toEqual(expected)
+    })
   })
 })
 
@@ -1284,9 +1138,9 @@ describe('getFeedSiteUrl', () => {
 
   it('should prefer atom:link alternate over channel link in RSS', () => {
     const value = parseFeed(
-      '<?xml version="1.0"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><link>https://fallback.com</link><atom:link rel="alternate" href="https://preferred.com"/></channel></rss>',
+      '<?xml version="1.0"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><link>https://fallback.example.com</link><atom:link rel="alternate" href="https://preferred.example.com"/></channel></rss>',
     )
-    const expected = 'https://preferred.com'
+    const expected = 'https://preferred.example.com'
 
     expect(getFeedSiteUrl(value)).toBe(expected)
   })
@@ -1341,6 +1195,15 @@ describe('getFeedSiteUrl', () => {
 
     expect(getFeedSiteUrl(value)).toBeUndefined()
   })
+
+  it('should return site URL from RDF feed with channel link', () => {
+    const value = parseFeed(
+      '<?xml version="1.0"?><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/"><channel><title>Example</title><link>https://example.com</link></channel></rdf:RDF>',
+    )
+    const expected = 'https://example.com'
+
+    expect(getFeedSiteUrl(value)).toBe(expected)
+  })
 })
 
 describe('defaultResolveUrlFn', () => {
@@ -1361,9 +1224,9 @@ describe('defaultResolveUrlFn', () => {
   })
 
   it('should preserve absolute URL when base URL provided', () => {
-    const value = 'https://other.com/feed.xml'
+    const value = 'https://other.example.com/feed.xml'
     const baseUrl = 'https://example.com'
-    const expected = 'https://other.com/feed.xml'
+    const expected = 'https://other.example.com/feed.xml'
 
     expect(defaultResolveUrlFn(value, baseUrl)).toBe(expected)
   })
@@ -1658,115 +1521,6 @@ describe('defaultResolveSiteUrlFn', () => {
   })
 })
 
-describe('normalizeMethodsConfig with siteInput', () => {
-  const defaults = {
-    feed: { extractUrls: () => [] as Array<string> },
-    html: {
-      linkSelectors: [{ rel: 'icon' }],
-      anchorUris: [] as Array<string>,
-      anchorIgnoredUris: [] as Array<string>,
-      anchorLabels: [] as Array<string>,
-    },
-    headers: { linkSelectors: [{ rel: 'icon' }] },
-    guess: { uris: ['/favicon.ico'] },
-  }
-
-  it('should use siteInput for html, headers, and guess methods', () => {
-    const siteHeaders = new Headers({ 'content-type': 'text/html' })
-    const value = {
-      url: 'https://example.com/feed.xml',
-      content: '<rss>feed content</rss>',
-      headers: new Headers({ 'content-type': 'application/rss+xml' }),
-    }
-    const siteValue = {
-      url: 'https://example.com',
-      content: '<html><link rel="icon" href="/favicon.ico"></html>',
-      headers: siteHeaders,
-    }
-    const expected = {
-      html: {
-        html: '<html><link rel="icon" href="/favicon.ico"></html>',
-        options: {
-          linkSelectors: [{ rel: 'icon' }],
-          anchorUris: [],
-          anchorIgnoredUris: [],
-          anchorLabels: [],
-          baseUrl: 'https://example.com',
-        },
-      },
-      headers: {
-        headers: siteHeaders,
-        options: {
-          linkSelectors: [{ rel: 'icon' }],
-          baseUrl: 'https://example.com',
-        },
-      },
-      guess: {
-        options: {
-          uris: ['/favicon.ico'],
-          baseUrl: 'https://example.com',
-        },
-      },
-    }
-    const result = normalizeMethodsConfig(value, siteValue, ['html', 'headers', 'guess'], defaults)
-
-    expect(result).toEqual(expected)
-  })
-
-  it('should use original input for feed method when siteInput provided', () => {
-    const value = {
-      url: 'https://example.com/feed.xml',
-      content: '<rss>feed content</rss>',
-      headers: new Headers(),
-    }
-    const siteValue = {
-      url: 'https://example.com',
-      content: '<html>site content</html>',
-      headers: new Headers(),
-    }
-    const expected = {
-      feed: {
-        content: '<rss>feed content</rss>',
-        options: {
-          extractUrls: expect.any(Function),
-        },
-      },
-    }
-    const result = normalizeMethodsConfig(value, siteValue, ['feed'], defaults)
-
-    expect(result).toEqual(expected)
-  })
-
-  it('should fall back to sourceInput when siteInput is undefined', () => {
-    const value = {
-      url: 'https://example.com',
-      content: '<html>content</html>',
-      headers: new Headers(),
-    }
-    const expected = {
-      html: {
-        html: '<html>content</html>',
-        options: {
-          linkSelectors: [{ rel: 'icon' }],
-          anchorUris: [],
-          anchorIgnoredUris: [],
-          anchorLabels: [],
-          baseUrl: 'https://example.com',
-        },
-      },
-      guess: {
-        options: {
-          uris: ['/favicon.ico'],
-          baseUrl: 'https://example.com',
-        },
-      },
-    }
-    const result = normalizeMethodsConfig(value, undefined, ['html', 'guess'], defaults)
-
-    expect(result).toEqual(expected)
-  })
-})
-
 describe('normalizeUriEntry', () => {
   const resolveUrlFn: DiscoverResolveUrlFn = (url, baseUrl) => {
     try {
@@ -1842,5 +1596,21 @@ describe('normalizeUriEntry', () => {
     }
 
     expect(normalizeUriEntry(value, resolveUrlFn, 'https://example.com')).toEqual(expected)
+  })
+
+  it('should keep original string uri when resolveUrlFn returns undefined', () => {
+    const resolveNothingFn: DiscoverResolveUrlFn = () => undefined
+    const value = { uri: '/feed.xml' }
+    const expected = { uri: '/feed.xml' }
+
+    expect(normalizeUriEntry(value, resolveNothingFn, undefined)).toEqual(expected)
+  })
+
+  it('should keep original array uris when resolveUrlFn returns undefined', () => {
+    const resolveNothingFn: DiscoverResolveUrlFn = () => undefined
+    const value = { uri: ['/feed/', '?feed=rss'] }
+    const expected = { uri: ['/feed/', '?feed=rss'] }
+
+    expect(normalizeUriEntry(value, resolveNothingFn, undefined)).toEqual(expected)
   })
 })

--- a/src/common/uris/feed/index.test.ts
+++ b/src/common/uris/feed/index.test.ts
@@ -4,13 +4,15 @@ import { discoverUrisFromFeed } from './index.js'
 
 describe('discoverUrisFromFeed', () => {
   it('should extract icon from Atom feed', () => {
-    const content = `<?xml version="1.0" encoding="utf-8"?>
+    const content = `
+      <?xml version="1.0" encoding="utf-8"?>
       <feed xmlns="http://www.w3.org/2005/Atom">
         <title>Example</title>
         <icon>https://example.com/icon.png</icon>
         <id>urn:uuid:1</id>
         <updated>2024-01-01T00:00:00Z</updated>
-      </feed>`
+      </feed>
+    `
     const value = discoverUrisFromFeed(content, {
       extractUrls: ({ format, feed }) => {
         if (format === 'atom') {
@@ -46,13 +48,15 @@ describe('discoverUrisFromFeed', () => {
   })
 
   it('should return empty array for RSS feed', () => {
-    const content = `<?xml version="1.0"?>
+    const content = `
+      <?xml version="1.0"?>
       <rss version="2.0">
         <channel>
           <title>Example</title>
           <link>https://example.com</link>
         </channel>
-      </rss>`
+      </rss>
+    `
     const value = discoverUrisFromFeed(content, {
       extractUrls: ({ format }) => {
         if (format === 'atom' || format === 'json') {
@@ -67,6 +71,14 @@ describe('discoverUrisFromFeed', () => {
 
   it('should return empty array for invalid content', () => {
     const value = discoverUrisFromFeed('not a feed', {
+      extractUrls: () => ['should-not-reach'],
+    })
+
+    expect(value).toEqual([])
+  })
+
+  it('should return empty array for empty string content', () => {
+    const value = discoverUrisFromFeed('', {
       extractUrls: () => ['should-not-reach'],
     })
 

--- a/src/common/uris/guess/index.test.ts
+++ b/src/common/uris/guess/index.test.ts
@@ -17,17 +17,13 @@ describe('discoverUrisFromGuess', () => {
       baseUrl: 'https://example.com',
       uris: ['/feed', '/rss', '/atom.xml'],
     })
+    const expected = [
+      'https://example.com/feed',
+      'https://example.com/rss',
+      'https://example.com/atom.xml',
+    ]
 
-    expect(
-      value.some((url) => {
-        return url.includes('/feed')
-      }),
-    ).toBe(true)
-    expect(
-      value.some((url) => {
-        return url.includes('/rss')
-      }),
-    ).toBe(true)
+    expect(value).toEqual(expected)
   })
 
   it('should accept balanced URIs array', () => {
@@ -35,12 +31,13 @@ describe('discoverUrisFromGuess', () => {
       baseUrl: 'https://example.com',
       uris: ['/feed', '/feed/', '/feed.json'],
     })
+    const expected = [
+      'https://example.com/feed',
+      'https://example.com/feed/',
+      'https://example.com/feed.json',
+    ]
 
-    expect(
-      value.some((url) => {
-        return url.includes('/feed.json')
-      }),
-    ).toBe(true)
+    expect(value).toEqual(expected)
   })
 
   it('should accept comprehensive URIs array', () => {
@@ -48,17 +45,9 @@ describe('discoverUrisFromGuess', () => {
       baseUrl: 'https://example.com',
       uris: ['/?feed=rss', '/feeds/posts/default'],
     })
+    const expected = ['https://example.com/?feed=rss', 'https://example.com/feeds/posts/default']
 
-    expect(
-      value.some((url) => {
-        return url.includes('?feed=rss')
-      }),
-    ).toBe(true)
-    expect(
-      value.some((url) => {
-        return url.includes('/feeds/posts/default')
-      }),
-    ).toBe(true)
+    expect(value).toEqual(expected)
   })
 
   it('should accept custom array of URIs', () => {
@@ -119,5 +108,11 @@ describe('discoverUrisFromGuess', () => {
     const expected = ['https://example.com/feed.xml']
 
     expect(value).toEqual(expected)
+  })
+
+  it('should throw for invalid base URL', () => {
+    const throwing = () => discoverUrisFromGuess({ baseUrl: 'not-a-url', uris: ['/feed'] })
+
+    expect(throwing).toThrow(TypeError)
   })
 })

--- a/src/common/uris/guess/utils.test.ts
+++ b/src/common/uris/guess/utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import type { UriEntry } from '../../types.js'
 import { generateUrlCombinations, getSubdomainVariants, getWwwCounterpart } from './utils.js'
 
 describe('generateUrlCombinations', () => {
@@ -217,7 +218,7 @@ describe('generateUrlCombinations', () => {
   it('should resolve empty array entry as empty alternatives group', () => {
     const baseUrls = ['https://example.com']
     const feedUris: Array<Array<string>> = [[]]
-    const expected = [[] as Array<string>]
+    const expected: Array<UriEntry> = [[]]
 
     expect(generateUrlCombinations(baseUrls, feedUris)).toEqual(expected)
   })
@@ -303,6 +304,12 @@ describe('getWwwCounterpart', () => {
     const expected = 'https://xn--mnchen-3ya.de'
 
     expect(getWwwCounterpart(value)).toBe(expected)
+  })
+
+  it('should throw for invalid base URL', () => {
+    const throwing = () => getWwwCounterpart('not-a-url')
+
+    expect(throwing).toThrow(TypeError)
   })
 })
 
@@ -400,5 +407,18 @@ describe('getSubdomainVariants', () => {
     const expected: Array<string> = []
 
     expect(getSubdomainVariants(value, ['blog'])).toEqual(expected)
+  })
+
+  it('should return empty array for single-label hostname', () => {
+    const value = 'http://intranet'
+    const expected: Array<string> = []
+
+    expect(getSubdomainVariants(value, ['blog'])).toEqual(expected)
+  })
+
+  it('should throw for invalid base URL', () => {
+    const throwing = () => getSubdomainVariants('not-a-url', ['blog'])
+
+    expect(throwing).toThrow(TypeError)
   })
 })

--- a/src/common/uris/headers/index.test.ts
+++ b/src/common/uris/headers/index.test.ts
@@ -19,281 +19,314 @@ const defaultOptions: HeadersMethodOptions = {
 }
 
 describe('discoverUrisFromHeaders', () => {
-  describe('should discover feeds from Link header', () => {
+  describe('Link header discovery', () => {
     it('should find single Link header with rel="alternate"', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should find multiple Link headers (comma-separated)', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; type="application/rss+xml", </atom.xml>; rel="alternate"; type="application/atom+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml', '/atom.xml'])
+      const expected = ['/feed.xml', '/atom.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should find multiple separate Link header entries', () => {
       const headers = new Headers()
       headers.append('Link', '</feed.xml>; rel="alternate"; type="application/rss+xml"')
       headers.append('Link', '</atom.xml>; rel="alternate"; type="application/atom+xml"')
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml', '/atom.xml'])
+      const expected = ['/feed.xml', '/atom.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should find Link with absolute URL', () => {
       const headers = new Headers({
         Link: '<https://example.com/feed.xml>; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['https://example.com/feed.xml'])
+      const expected = ['https://example.com/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle Link header with additional parameters', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; type="application/rss+xml"; title="RSS Feed"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
   })
 
-  describe('should filter by MIME type', () => {
+  describe('MIME type filtering', () => {
     it('should only return feeds with matching MIME types', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; type="application/rss+xml", </other>; rel="alternate"; type="text/html"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should be case-insensitive for MIME type matching', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; type="APPLICATION/RSS+XML"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should trim whitespace from MIME types', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; type=" application/rss+xml "',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle MIME type with charset parameter', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; type="application/rss+xml; charset=utf-8"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle MIME type with multiple parameters', () => {
       const headers = new Headers({
         Link: '</atom.xml>; rel="alternate"; type="application/atom+xml; charset=utf-8; boundary=test"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/atom.xml'])
+      const expected = ['/atom.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
   })
 
-  describe('should handle missing or malformed headers', () => {
+  describe('missing or malformed headers', () => {
     it('should return empty array when Link header is missing', () => {
       const headers = new Headers()
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual([])
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should skip malformed Link entries (no URL)', () => {
       const headers = new Headers({
         Link: 'rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual([])
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should skip Link entries without rel attribute', () => {
       const headers = new Headers({
         Link: '</feed.xml>; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual([])
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should skip Link entries without type attribute', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual([])
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should skip Link entries with non-alternate rel', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="canonical"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual([])
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle empty Link header value', () => {
       const headers = new Headers({
         Link: '',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual([])
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle Link header with only whitespace', () => {
       const headers = new Headers({
         Link: '   ',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual([])
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should skip malformed angle brackets (missing opening bracket)', () => {
       const headers = new Headers({
         Link: 'feed.xml>; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual([])
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should skip malformed angle brackets (missing closing bracket)', () => {
       const headers = new Headers({
         Link: '<feed.xml; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual([])
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
   })
 
-  describe('should handle case sensitivity', () => {
+  describe('case sensitivity', () => {
     it('should match rel="alternate" case-insensitively', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="ALTERNATE"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should match rel="Alternate" case-insensitively', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="Alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
   })
 
-  describe('should return raw URIs', () => {
+  describe('raw URI passthrough', () => {
     it('should return relative URIs as-is', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should return absolute URIs as-is', () => {
       const headers = new Headers({
         Link: '<https://example.com/feed.xml>; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['https://example.com/feed.xml'])
+      const expected = ['https://example.com/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should return path-only URIs as-is', () => {
       const headers = new Headers({
         Link: '<feed.xml>; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['feed.xml'])
+      const expected = ['feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
   })
 
-  describe('should deduplicate URIs', () => {
+  describe('URI deduplication', () => {
     it('should deduplicate identical URIs', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; type="application/rss+xml", </feed.xml>; rel="alternate"; type="application/atom+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
   })
 
-  describe('should handle various MIME types', () => {
+  describe('various MIME types', () => {
     it('should find application/atom+xml feeds', () => {
       const headers = new Headers({
         Link: '</atom.xml>; rel="alternate"; type="application/atom+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/atom.xml'])
+      const expected = ['/atom.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should find application/json feeds', () => {
       const headers = new Headers({
         Link: '</feed.json>; rel="alternate"; type="application/json"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.json'])
+      const expected = ['/feed.json']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should find text/xml feeds', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; type="text/xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
   })
 
-  describe('should handle quoted and unquoted attribute values', () => {
+  describe('quoted and unquoted attribute values', () => {
     it('should handle unquoted rel attribute', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel=alternate; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle single-quoted attributes', () => {
       const headers = new Headers({
         Link: "</feed.xml>; rel='alternate'; type='application/rss+xml'",
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle mixed quote styles', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; type=\'application/rss+xml\'',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle parameters in different order', () => {
       const headers = new Headers({
         Link: '</feed.xml>; type="application/rss+xml"; rel="alternate"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle parameters with title before type and rel', () => {
       const headers = new Headers({
         Link: '</atom.xml>; title="Atom Feed"; type="application/atom+xml"; rel="alternate"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/atom.xml'])
+      const expected = ['/atom.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
   })
 
@@ -303,112 +336,126 @@ describe('discoverUrisFromHeaders', () => {
       const headers = new Headers({
         Link: `<${longUrl}>; rel="alternate"; type="application/rss+xml"`,
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual([longUrl])
+      const expected = [longUrl]
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle URL-encoded characters in URL', () => {
       const headers = new Headers({
         Link: '</feed%20rss.xml>; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed%20rss.xml'])
+      const expected = ['/feed%20rss.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle punycode domains in URL', () => {
       const headers = new Headers({
         Link: '<https://xn--r8jz45g.jp/feed.xml>; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['https://xn--r8jz45g.jp/feed.xml'])
+      const expected = ['https://xn--r8jz45g.jp/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle URL with fragment identifier', () => {
       const headers = new Headers({
         Link: '</feed.xml#latest>; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml#latest'])
+      const expected = ['/feed.xml#latest']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle URL with complex query parameters', () => {
       const headers = new Headers({
         Link: '</feed?cat=tech&sort=date&limit=10>; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed?cat=tech&sort=date&limit=10'])
+      const expected = ['/feed?cat=tech&sort=date&limit=10']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle extra whitespace around parameters', () => {
       const headers = new Headers({
         Link: '</feed.xml>  ;  rel = "alternate"  ;  type = "application/rss+xml"  ',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle semicolons in quoted parameter values', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; title="Feed; Main"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle commas in quoted parameter values', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; title="News, Updates"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should match alternate in space-separated rel value', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="hub alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle escaped quotes in parameter values', () => {
       const headers = new Headers({
         Link: '</feed.xml>; rel="alternate"; title="The \\"Best\\" Feed"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['/feed.xml'])
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle data URI (should not extract)', () => {
       const headers = new Headers({
         Link: '<data:text/plain,feed>; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual(['data:text/plain,feed'])
+      const expected = ['data:text/plain,feed']
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle missing closing angle bracket', () => {
       const headers = new Headers({
         Link: '</feed.xml; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual([])
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle missing opening angle bracket', () => {
       const headers = new Headers({
         Link: '/feed.xml>; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual([])
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
 
     it('should handle angle brackets in wrong order', () => {
       const headers = new Headers({
         Link: '>/feed.xml<; rel="alternate"; type="application/rss+xml"',
       })
-      const result = discoverUrisFromHeaders(headers, defaultOptions)
-      expect(result).toEqual([])
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHeaders(headers, defaultOptions)).toEqual(expected)
     })
   })
 })

--- a/src/common/uris/html/handlers.test.ts
+++ b/src/common/uris/html/handlers.test.ts
@@ -407,9 +407,9 @@ describe('handleCloseTag', () => {
     value.currentAnchor.text = 'RSS Feed'
 
     handleCloseTag(value, 'a')
+    const expected = { href: '', text: '' }
 
-    expect(value.currentAnchor.href).toBe('')
-    expect(value.currentAnchor.text).toBe('')
+    expect(value.currentAnchor).toEqual(expected)
   })
 
   it('should ignore non-anchor close tags', () => {
@@ -418,9 +418,9 @@ describe('handleCloseTag', () => {
     value.currentAnchor.text = 'RSS Feed'
 
     handleCloseTag(value, 'div')
+    const expected = { href: '/custom-feed', text: 'RSS Feed' }
 
-    expect(value.currentAnchor.href).toBe('/custom-feed')
-    expect(value.currentAnchor.text).toBe('RSS Feed')
+    expect(value.currentAnchor).toEqual(expected)
   })
 
   it('should deduplicate URI matched by both href suffix and text', () => {

--- a/src/common/uris/html/index.test.ts
+++ b/src/common/uris/html/index.test.ts
@@ -170,13 +170,6 @@ describe('discoverUrisFromHtml', () => {
       expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
     })
 
-    it('should handle uppercase rel="ALTERNATE"', () => {
-      const value = '<link rel="ALTERNATE" type="application/rss+xml" href="/feed.xml">'
-      const expected = ['/feed.xml']
-
-      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
-    })
-
     it('should handle mixed case rel="Feed Alternate"', () => {
       const value = '<link rel="Feed Alternate" type="application/rss+xml" href="/feed.xml">'
       const expected = ['/feed.xml']
@@ -205,15 +198,13 @@ describe('discoverUrisFromHtml', () => {
       expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
     })
 
-    it.skip('should ignore feed stylesheet', () => {
-      // This is not supported for now as the chance of such thing happening is quite
-      // low anyway. It's better to incorrectly treat such as valid than to treat
-      // `rel="feed home"` or `rel="feed alternate"` as invalid.
-
-      const value = '<link rel="feed stylesheet" href="/feed.xml">'
-      const expected: Array<string> = []
-
-      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    it.todo('should ignore feed stylesheet', () => {
+      // '<link rel="feed stylesheet" href="/feed.xml">' is currently treated as a feed link because
+      // any rel containing "feed" matches.
+      // Rejecting it is intentionally unsupported for now: filtering out "stylesheet" risks also
+      // rejecting valid compound values like "feed home" or "feed alternate", and the combination
+      // is rare in the wild.
+      // Expected once supported: this markup yields an empty array.
     })
 
     it('should find multiple feed links with different MIME types', () => {
@@ -228,13 +219,6 @@ describe('discoverUrisFromHtml', () => {
     })
 
     it('should handle self-closing link tags', () => {
-      const value = '<link rel="alternate" type="application/rss+xml" href="/feed.xml" />'
-      const expected = ['/feed.xml']
-
-      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
-    })
-
-    it('should handle self-closing link tags with type attribute', () => {
       const value = '<link rel="alternate" type="application/rss+xml" href="/feed.xml" />'
       const expected = ['/feed.xml']
 
@@ -353,13 +337,6 @@ describe('discoverUrisFromHtml', () => {
   })
 
   describe('anchor elements by text content', () => {
-    it('should find anchor with "RSS" text', () => {
-      const value = '<a href="/my-feed">RSS</a>'
-      const expected = ['/my-feed']
-
-      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
-    })
-
     it('should find anchor with "feed" text', () => {
       const value = '<a href="/custom-url">Subscribe to our feed</a>'
       const expected = ['/custom-url']
@@ -370,13 +347,6 @@ describe('discoverUrisFromHtml', () => {
     it('should find anchor with "Atom" text', () => {
       const value = '<a href="/articles.xml">Atom Feed</a>'
       const expected = ['/articles.xml']
-
-      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
-    })
-
-    it('should find anchor with "subscribe" text', () => {
-      const value = '<a href="/updates">Subscribe</a>'
-      const expected = ['/updates']
 
       expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
     })
@@ -615,7 +585,7 @@ describe('discoverUrisFromHtml', () => {
     it('should handle very large HTML document', () => {
       const feedLink = '<link rel="alternate" type="application/rss+xml" href="/feed.xml">'
       const fillerContent = '<p>filler content</p>'.repeat(10000)
-      const value = feedLink + fillerContent
+      const value = `${feedLink}${fillerContent}`
       const expected = ['/feed.xml']
 
       expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
@@ -626,16 +596,16 @@ describe('discoverUrisFromHtml', () => {
         '\n',
       )
       const actualFeed = '<link rel="alternate" type="application/rss+xml" href="/feed.xml">'
-      const value = actualFeed + links
+      const value = `${actualFeed}${links}`
       const expected = ['/feed.xml']
 
       expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
     })
   })
 
-  // TODO: These edge cases should be handled during URL resolution phase.
-  // Currently, raw URIs are returned without validation. Invalid protocols
-  // and fragment-only URIs should be filtered when resolving to absolute URLs.
+  // The HTML method returns raw matched hrefs without protocol or fragment validation, so hash-only
+  // and non-http protocols pass through here and are filtered later during URL resolution. These
+  // tests pin that pass-through behavior.
   describe('unsupported edge cases', () => {
     it('should return hash-only href when matched by text', () => {
       const value = '<a href="#">RSS Feed</a>'

--- a/src/common/uris/index.test.ts
+++ b/src/common/uris/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import type { DiscoverFetchFn } from '../types.js'
 import { omitEmpty } from '../utils.js'
 import { discoverUris } from './index.js'
 
@@ -269,5 +270,54 @@ describe('discoverUris', () => {
     }
 
     expect(value).toEqual(expected)
+  })
+
+  it('should forward content, headers, and fetchFn to platform handler resolve', async () => {
+    let received: {
+      content: string | undefined
+      headers: Headers | undefined
+      fetchFn: DiscoverFetchFn | undefined
+    } = { content: undefined, headers: undefined, fetchFn: undefined }
+    const content = '<html>platform page</html>'
+    const headers = new Headers({ 'content-type': 'text/html' })
+    const fetchFn: DiscoverFetchFn = (url) => {
+      return Promise.resolve({
+        url,
+        body: '',
+        headers: new Headers(),
+        status: 200,
+        statusText: 'OK',
+      })
+    }
+
+    await discoverUris(
+      {
+        platform: {
+          content,
+          headers,
+          options: {
+            baseUrl: 'https://example.com',
+            handlers: [
+              {
+                match: () => true,
+                resolve: (_url, resolveContent, resolveHeaders, resolveFetchFn) => {
+                  received = {
+                    content: resolveContent,
+                    headers: resolveHeaders,
+                    fetchFn: resolveFetchFn,
+                  }
+
+                  return []
+                },
+              },
+            ],
+          },
+        },
+      },
+      fetchFn,
+    )
+    const expected = { content, headers, fetchFn }
+
+    expect(received).toEqual(expected)
   })
 })

--- a/src/common/uris/platform/index.test.ts
+++ b/src/common/uris/platform/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import type { DiscoverFetchFn } from '../../types.js'
 import { discoverUrisFromPlatform } from './index.js'
 import type { PlatformHandler } from './types.js'
 
@@ -8,10 +9,10 @@ describe('discoverUrisFromPlatform', () => {
       match: () => true,
       resolve: () => [{ uri: 'https://example.com/feed.xml' }],
     }
-    const value = { baseUrl: 'https://example.com', handlers: [handler] }
+    const options = { baseUrl: 'https://example.com', handlers: [handler] }
     const expected = [{ uri: 'https://example.com/feed.xml' }]
 
-    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual(expected)
+    expect(await discoverUrisFromPlatform(undefined, undefined, options)).toEqual(expected)
   })
 
   it('should return empty array when no handler matches', async () => {
@@ -19,15 +20,15 @@ describe('discoverUrisFromPlatform', () => {
       match: () => false,
       resolve: () => [{ uri: 'https://example.com/feed.xml' }],
     }
-    const value = { baseUrl: 'https://example.com', handlers: [handler] }
+    const options = { baseUrl: 'https://example.com', handlers: [handler] }
 
-    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual([])
+    expect(await discoverUrisFromPlatform(undefined, undefined, options)).toEqual([])
   })
 
   it('should return empty array when handlers array is empty', async () => {
-    const value = { baseUrl: 'https://example.com', handlers: [] }
+    const options = { baseUrl: 'https://example.com', handlers: [] }
 
-    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual([])
+    expect(await discoverUrisFromPlatform(undefined, undefined, options)).toEqual([])
   })
 
   it('should continue to next handler if first handler throws', async () => {
@@ -41,13 +42,13 @@ describe('discoverUrisFromPlatform', () => {
       match: () => true,
       resolve: () => [{ uri: 'https://example.com/feed.xml' }],
     }
-    const value = {
+    const options = {
       baseUrl: 'https://example.com',
       handlers: [throwingHandler, workingHandler],
     }
     const expected = [{ uri: 'https://example.com/feed.xml' }]
 
-    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual(expected)
+    expect(await discoverUrisFromPlatform(undefined, undefined, options)).toEqual(expected)
   })
 
   it('should continue to next handler if resolve throws', async () => {
@@ -61,13 +62,13 @@ describe('discoverUrisFromPlatform', () => {
       match: () => true,
       resolve: () => [{ uri: 'https://example.com/feed.xml' }],
     }
-    const value = {
+    const options = {
       baseUrl: 'https://example.com',
       handlers: [throwingHandler, workingHandler],
     }
     const expected = [{ uri: 'https://example.com/feed.xml' }]
 
-    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual(expected)
+    expect(await discoverUrisFromPlatform(undefined, undefined, options)).toEqual(expected)
   })
 
   it('should pass html content to handler resolve method', async () => {
@@ -81,34 +82,81 @@ describe('discoverUrisFromPlatform', () => {
       },
     }
     const html = '<html><body>Test</body></html>'
-    const value = { baseUrl: 'https://example.com', handlers: [handler] }
+    const options = { baseUrl: 'https://example.com', handlers: [handler] }
 
-    await discoverUrisFromPlatform(html, undefined, value)
+    await discoverUrisFromPlatform(html, undefined, options)
 
     expect(receivedHtml).toBe(html)
   })
 
   it('should pass baseUrl to handler match and resolve methods', async () => {
-    let matchedUrl = ''
-    let resolvedUrl = ''
+    const receivedUrls: Array<string> = []
     const handler: PlatformHandler = {
       match: (url) => {
-        matchedUrl = url
+        receivedUrls.push(`match:${url}`)
 
         return true
       },
       resolve: (url) => {
-        resolvedUrl = url
+        receivedUrls.push(`resolve:${url}`)
 
         return []
       },
     }
-    const value = { baseUrl: 'https://example.com/page', handlers: [handler] }
+    const options = { baseUrl: 'https://example.com/page', handlers: [handler] }
 
-    await discoverUrisFromPlatform(undefined, undefined, value)
+    await discoverUrisFromPlatform(undefined, undefined, options)
+    const expected = ['match:https://example.com/page', 'resolve:https://example.com/page']
 
-    expect(matchedUrl).toBe('https://example.com/page')
-    expect(resolvedUrl).toBe('https://example.com/page')
+    expect(receivedUrls).toEqual(expected)
+  })
+
+  it('should pass headers to handler match and resolve methods', async () => {
+    const receivedHeaders: Array<Headers | undefined> = []
+    const handler: PlatformHandler = {
+      match: (_url, _content, headers) => {
+        receivedHeaders.push(headers)
+
+        return true
+      },
+      resolve: (_url, _content, headers) => {
+        receivedHeaders.push(headers)
+
+        return []
+      },
+    }
+    const headers = new Headers({ 'content-type': 'text/html' })
+    const options = { baseUrl: 'https://example.com', handlers: [handler] }
+
+    await discoverUrisFromPlatform(undefined, headers, options)
+
+    expect(receivedHeaders).toEqual([headers, headers])
+  })
+
+  it('should pass fetchFn to handler resolve method', async () => {
+    let receivedFetchFn: DiscoverFetchFn | undefined
+    const handler: PlatformHandler = {
+      match: () => true,
+      resolve: (_url, _content, _headers, fetchFn) => {
+        receivedFetchFn = fetchFn
+
+        return []
+      },
+    }
+    const fetchFn: DiscoverFetchFn = (url) => {
+      return Promise.resolve({
+        url,
+        body: '',
+        headers: new Headers(),
+        status: 200,
+        statusText: 'OK',
+      })
+    }
+    const options = { baseUrl: 'https://example.com', handlers: [handler] }
+
+    await discoverUrisFromPlatform(undefined, undefined, options, fetchFn)
+
+    expect(receivedFetchFn).toBe(fetchFn)
   })
 
   it('should use first matching handler when multiple handlers match', async () => {
@@ -120,13 +168,13 @@ describe('discoverUrisFromPlatform', () => {
       match: () => true,
       resolve: () => [{ uri: 'https://example.com/second.xml' }],
     }
-    const value = {
+    const options = {
       baseUrl: 'https://example.com',
       handlers: [firstHandler, secondHandler],
     }
     const expected = [{ uri: 'https://example.com/first.xml' }]
 
-    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual(expected)
+    expect(await discoverUrisFromPlatform(undefined, undefined, options)).toEqual(expected)
   })
 
   it('should not call resolve on non-matching handlers', async () => {
@@ -143,34 +191,32 @@ describe('discoverUrisFromPlatform', () => {
         return [{ uri: 'https://example.com/second.xml' }]
       },
     }
-    const value = {
+    const options = {
       baseUrl: 'https://example.com',
       handlers: [firstHandler, secondHandler],
     }
 
-    await discoverUrisFromPlatform(undefined, undefined, value)
+    await discoverUrisFromPlatform(undefined, undefined, options)
 
     expect(secondResolvedCalled).toBe(false)
   })
 
-  it('should continue to next handler if async resolve throws', async () => {
+  it('should continue to next handler if async resolve rejects', async () => {
     const throwingHandler: PlatformHandler = {
       match: () => true,
-      resolve: () => {
-        throw new Error('Async resolve error')
-      },
+      resolve: () => Promise.reject(new Error('Async resolve error')),
     }
     const workingHandler: PlatformHandler = {
       match: () => true,
       resolve: () => [{ uri: 'https://example.com/feed.xml' }],
     }
-    const value = {
+    const options = {
       baseUrl: 'https://example.com',
       handlers: [throwingHandler, workingHandler],
     }
     const expected = [{ uri: 'https://example.com/feed.xml' }]
 
-    expect(await discoverUrisFromPlatform(undefined, undefined, value)).toEqual(expected)
+    expect(await discoverUrisFromPlatform(undefined, undefined, options)).toEqual(expected)
   })
 
   it('should check handlers in provided order', async () => {
@@ -191,12 +237,12 @@ describe('discoverUrisFromPlatform', () => {
       },
       resolve: () => [],
     }
-    const value = {
+    const options = {
       baseUrl: 'https://example.com',
       handlers: [firstHandler, secondHandler],
     }
 
-    await discoverUrisFromPlatform(undefined, undefined, value)
+    await discoverUrisFromPlatform(undefined, undefined, options)
 
     expect(callOrder).toEqual(['first', 'second'])
   })

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -916,12 +916,10 @@ describe('processConcurrently', () => {
     }
 
     await processConcurrently(items, processFn, { concurrency: 2 })
+    const processedSorted = processed.sort((a, b) => a - b)
+    const expected = [1, 2, 3, 4, 5]
 
-    expect(
-      processed.sort((a, b) => {
-        return a - b
-      }),
-    ).toEqual([1, 2, 3, 4, 5])
+    expect(processedSorted).toEqual(expected)
   })
 
   it('should respect concurrency limit', async () => {
@@ -972,12 +970,10 @@ describe('processConcurrently', () => {
     }
 
     await processConcurrently(items, processFn, { concurrency: 2 })
+    const processedSorted = processed.sort((a, b) => a - b)
+    const expected = [1, 2, 4, 5]
 
-    expect(
-      processed.sort((a, b) => {
-        return a - b
-      }),
-    ).toEqual([1, 2, 4, 5])
+    expect(processedSorted).toEqual(expected)
   })
 
   it('should handle empty array', async () => {
@@ -1038,34 +1034,34 @@ describe('processConcurrently', () => {
     }
 
     await processConcurrently(items, processFn, { concurrency: 10 })
+    const processedSorted = processed.sort((a, b) => a - b)
+    const expected = [1, 2, 3]
 
-    expect(
-      processed.sort((a, b) => {
-        return a - b
-      }),
-    ).toEqual([1, 2, 3])
+    expect(processedSorted).toEqual(expected)
   })
 
   it('should process items in parallel when concurrency allows', async () => {
     const items = [1, 2, 3]
-    const startTimes: Array<number> = []
+    let startedCount = 0
+    let releaseBarrier = () => {}
+    const barrier = new Promise<void>((resolve) => {
+      releaseBarrier = resolve
+    })
+    // Each item blocks on a barrier that opens only once all three have started, so the
+    // run completes only when all items execute in parallel.
     const processFn = async () => {
-      startTimes.push(Date.now())
-      await new Promise((resolve) => {
-        return setTimeout(resolve, 50)
-      })
+      startedCount++
+
+      if (startedCount === items.length) {
+        releaseBarrier()
+      }
+
+      await barrier
     }
 
     await processConcurrently(items, processFn, { concurrency: 3 })
-    const timeDifferences = startTimes.slice(1).map((time, index) => {
-      return time - startTimes[index]
-    })
 
-    expect(
-      timeDifferences.every((diff) => {
-        return diff < 30
-      }),
-    ).toBe(true)
+    expect(startedCount).toBe(3)
   })
 
   it('should maintain side effects order independence', async () => {
@@ -1079,16 +1075,11 @@ describe('processConcurrently', () => {
     }
 
     await processConcurrently(items, processFn, { concurrency: 3 })
+    const resultsSorted = results.sort((a, b) => a - b)
     const expected = [2, 4, 6, 8, 10]
 
-    expect(
-      results.sort((a, b) => {
-        return a - b
-      }),
-    ).toEqual(expected)
+    expect(resultsSorted).toEqual(expected)
   })
-
-  // TODO: Should handle concurrency=0 — causes infinite loop, items never process.
 
   it('should not call shouldStop after completion', async () => {
     const items = [1, 2, 3]
@@ -1121,6 +1112,11 @@ describe('processConcurrently', () => {
     await processConcurrently(items, processFn, { concurrency: 0 })
 
     expect(processed).toEqual([])
+  })
+
+  it.todo('should not process items when concurrency is negative', () => {
+    // Call processConcurrently with { concurrency: -1 } and a few items.
+    // Expected: returns immediately without processing any item, same as concurrency 0.
   })
 })
 
@@ -1203,5 +1199,16 @@ describe('hasMetaContent', () => {
 
   it('should return false for empty HTML', () => {
     expect(hasMetaContent('', 'generator', 'Mastodon')).toBe(false)
+  })
+
+  it.todo('should escape regex metacharacters in name and value', () => {
+    // hasMetaContent builds a RegExp from the raw name and value, escaping metacharacters first.
+    // Expected: a value like "C++ Blog" or a name like "og:site_name(beta)" matches literally
+    // instead of breaking the pattern.
+  })
+
+  it.todo('should match single-quoted attribute values', () => {
+    // Expected: "<meta name='generator' content='Mastodon v4.2.0'>" with single-quoted attributes
+    // returns true for ('generator', 'Mastodon').
   })
 })

--- a/src/favicons/extractors.test.ts
+++ b/src/favicons/extractors.test.ts
@@ -167,6 +167,12 @@ describe('defaultExtractFn', () => {
 
       expect(await defaultExtractFn(value)).toEqual(expected)
     })
+
+    it.todo('should not detect svg when <svg appears beyond the 200-char head slice', () => {
+      // An <?xml document whose <svg tag only appears after 200+ characters of prolog and comments
+      // is not detected as an image because the check only inspects the first 200 characters; the
+      // desired boundary is undecided.
+    })
   })
 
   describe('status code', () => {
@@ -229,6 +235,31 @@ describe('defaultExtractFn', () => {
     it('should return isValid: false for undefined status without other signals', async () => {
       const value = { url: 'https://example.com/icon.png', content: '' }
       const expected = { url: 'https://example.com/icon.png', isValid: false }
+
+      expect(await defaultExtractFn(value)).toEqual(expected)
+    })
+  })
+
+  describe('signal precedence', () => {
+    it('should return isValid: true for image content-type even with 404 status', async () => {
+      const value = {
+        url: 'https://example.com/icon.png',
+        content: '',
+        headers: new Headers({ 'content-type': 'image/png' }),
+        status: 404,
+      }
+      const expected = { url: 'https://example.com/icon.png', isValid: true }
+
+      expect(await defaultExtractFn(value)).toEqual(expected)
+    })
+
+    it('should return isValid: true for html content with 200 status', async () => {
+      const value = {
+        url: 'https://example.com/favicon.ico',
+        content: '<html><head></head><body></body></html>',
+        status: 200,
+      }
+      const expected = { url: 'https://example.com/favicon.ico', isValid: true }
 
       expect(await defaultExtractFn(value)).toEqual(expected)
     })

--- a/src/favicons/index.test.ts
+++ b/src/favicons/index.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'bun:test'
-import type { DiscoverFetchFn, DiscoverResult } from '../common/types.js'
+import type {
+  DiscoverExtractFn,
+  DiscoverFetchFn,
+  DiscoverResolveSiteUrlFn,
+  DiscoverResolveUrlFn,
+  DiscoverResult,
+} from '../common/types.js'
 import { discoverFavicons } from './index.js'
 import type { FaviconResult } from './types.js'
 
@@ -20,7 +26,7 @@ describe('discoverFavicons', () => {
       'https://example.com': html,
       'https://example.com/favicon.ico': 'binary',
     })
-    const value = await discoverFavicons('https://example.com', {
+    const result = await discoverFavicons('https://example.com', {
       methods: ['html'],
       fetchFn: mockFetch,
     })
@@ -28,11 +34,11 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/favicon.ico', isValid: true, method: 'html' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should discover favicons from headers', async () => {
-    const fetchFn: DiscoverFetchFn = async (url: string) => ({
+    const mockFetch: DiscoverFetchFn = async (url: string) => ({
       url,
       body: '',
       headers: new Headers({
@@ -41,15 +47,15 @@ describe('discoverFavicons', () => {
       status: 200,
       statusText: 'OK',
     })
-    const value = await discoverFavicons('https://example.com', {
+    const result = await discoverFavicons('https://example.com', {
       methods: ['headers'],
-      fetchFn,
+      fetchFn: mockFetch,
     })
     const expected: Array<DiscoverResult<FaviconResult>> = [
       { url: 'https://example.com/favicon.png', isValid: true, method: 'headers' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should discover favicons from guess paths', async () => {
@@ -58,7 +64,7 @@ describe('discoverFavicons', () => {
       'https://example.com/favicon.ico': 'binary',
       'https://example.com/favicon.png': 'binary',
     })
-    const value = await discoverFavicons('https://example.com', {
+    const result = await discoverFavicons('https://example.com', {
       methods: ['guess'],
       fetchFn: mockFetch,
     })
@@ -67,7 +73,7 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/favicon.png', isValid: true, method: 'guess' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should use all default methods', async () => {
@@ -77,13 +83,13 @@ describe('discoverFavicons', () => {
       'https://example.com/apple-touch-icon.png': 'binary',
       'https://example.com/favicon.ico': 'binary',
     })
-    const value = await discoverFavicons('https://example.com', { fetchFn: mockFetch })
+    const result = await discoverFavicons('https://example.com', { fetchFn: mockFetch })
     const expected: Array<DiscoverResult<FaviconResult>> = [
       { url: 'https://example.com/apple-touch-icon.png', isValid: true, method: 'html' },
       { url: 'https://example.com/favicon.ico', isValid: true, method: 'guess' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should deduplicate URLs across methods', async () => {
@@ -92,7 +98,7 @@ describe('discoverFavicons', () => {
       'https://example.com': html,
       'https://example.com/favicon.ico': 'binary',
     })
-    const value = await discoverFavicons('https://example.com', {
+    const result = await discoverFavicons('https://example.com', {
       methods: ['html', 'guess'],
       fetchFn: mockFetch,
     })
@@ -100,7 +106,7 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/favicon.ico', isValid: true, method: 'html' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should filter out invalid URLs', async () => {
@@ -108,7 +114,7 @@ describe('discoverFavicons', () => {
       'https://example.com': '',
       'https://example.com/favicon.ico': 'binary',
     })
-    const value = await discoverFavicons('https://example.com', {
+    const result = await discoverFavicons('https://example.com', {
       methods: { guess: { uris: ['/favicon.ico', '/nonexistent.png'] } },
       fetchFn: mockFetch,
     })
@@ -116,7 +122,7 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/favicon.ico', isValid: true, method: 'guess' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should return invalid results when includeInvalid is true', async () => {
@@ -124,7 +130,7 @@ describe('discoverFavicons', () => {
       'https://example.com': '',
       'https://example.com/favicon.ico': 'binary',
     })
-    const value = await discoverFavicons('https://example.com', {
+    const result = await discoverFavicons('https://example.com', {
       methods: { guess: { uris: ['/favicon.ico', '/missing.png'] } },
       fetchFn: mockFetch,
       includeInvalid: true,
@@ -134,7 +140,7 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/missing.png', isValid: false, method: 'guess' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should work with input object containing content', async () => {
@@ -142,7 +148,7 @@ describe('discoverFavicons', () => {
     const mockFetch = createMockFetch({
       'https://example.com/favicon.ico': 'binary',
     })
-    const value = await discoverFavicons(
+    const result = await discoverFavicons(
       { url: 'https://example.com', content: html },
       { methods: ['html'], fetchFn: mockFetch },
     )
@@ -150,19 +156,19 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/favicon.ico', isValid: true, method: 'html' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should return empty array when no favicons found', async () => {
     const mockFetch = createMockFetch({
       'https://example.com': '<html></html>',
     })
-    const value = await discoverFavicons('https://example.com', {
+    const result = await discoverFavicons('https://example.com', {
       methods: ['html'],
       fetchFn: mockFetch,
     })
 
-    expect(value).toEqual([])
+    expect(result).toEqual([])
   })
 
   it('should use custom guess paths', async () => {
@@ -170,7 +176,7 @@ describe('discoverFavicons', () => {
       'https://example.com': '',
       'https://example.com/custom-icon.png': 'binary',
     })
-    const value = await discoverFavicons('https://example.com', {
+    const result = await discoverFavicons('https://example.com', {
       methods: { guess: { uris: ['/custom-icon.png'] } },
       fetchFn: mockFetch,
     })
@@ -178,7 +184,7 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/custom-icon.png', isValid: true, method: 'guess' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should discover favicon from github platform handler', async () => {
@@ -186,7 +192,7 @@ describe('discoverFavicons', () => {
       'https://github.com/octocat': '<html></html>',
       'https://github.com/octocat.png': 'binary',
     })
-    const value = await discoverFavicons('https://github.com/octocat', {
+    const result = await discoverFavicons('https://github.com/octocat', {
       methods: ['platform'],
       fetchFn: mockFetch,
     })
@@ -194,7 +200,7 @@ describe('discoverFavicons', () => {
       { url: 'https://github.com/octocat.png', isValid: true, method: 'platform' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should discover favicon from mastodon platform handler', async () => {
@@ -207,7 +213,7 @@ describe('discoverFavicons', () => {
       }),
       [avatarUrl]: 'binary',
     })
-    const value = await discoverFavicons('https://mastodon.social/@user', {
+    const result = await discoverFavicons('https://mastodon.social/@user', {
       methods: ['platform'],
       fetchFn: mockFetch,
     })
@@ -215,7 +221,7 @@ describe('discoverFavicons', () => {
       { url: avatarUrl, isValid: true, method: 'platform' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should discover favicon from bluesky platform handler', async () => {
@@ -226,7 +232,7 @@ describe('discoverFavicons', () => {
         JSON.stringify({ avatar: avatarUrl }),
       [avatarUrl]: 'binary',
     })
-    const value = await discoverFavicons('https://bsky.app/profile/user.bsky.social', {
+    const result = await discoverFavicons('https://bsky.app/profile/user.bsky.social', {
       methods: ['platform'],
       fetchFn: mockFetch,
     })
@@ -234,21 +240,23 @@ describe('discoverFavicons', () => {
       { url: avatarUrl, isValid: true, method: 'platform' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should discover favicon from Atom feed content', async () => {
-    const atomContent = `<?xml version="1.0" encoding="utf-8"?>
+    const atomContent = `
+      <?xml version="1.0" encoding="utf-8"?>
       <feed xmlns="http://www.w3.org/2005/Atom">
         <title>Example</title>
         <icon>https://example.com/icon.png</icon>
         <id>urn:uuid:1</id>
         <updated>2024-01-01T00:00:00Z</updated>
-      </feed>`
+      </feed>
+    `
     const mockFetch = createMockFetch({
       'https://example.com/icon.png': 'binary',
     })
-    const value = await discoverFavicons(
+    const result = await discoverFavicons(
       { url: 'https://example.com/feed.xml', content: atomContent },
       { methods: ['feed'], fetchFn: mockFetch },
     )
@@ -256,7 +264,7 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/icon.png', isValid: true, method: 'feed' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should discover favicon from JSON Feed content', async () => {
@@ -271,7 +279,7 @@ describe('discoverFavicons', () => {
       'https://example.com/favicon.ico': 'binary',
       'https://example.com/icon.png': 'binary',
     })
-    const value = await discoverFavicons(
+    const result = await discoverFavicons(
       { url: 'https://example.com/feed.json', content: jsonContent },
       { methods: ['feed'], fetchFn: mockFetch },
     )
@@ -280,73 +288,75 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/icon.png', isValid: true, method: 'feed' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should return empty array from feed method for RSS content', async () => {
-    const rssContent = `<?xml version="1.0"?>
+    const rssContent = `
+      <?xml version="1.0"?>
       <rss version="2.0">
         <channel>
           <title>Example</title>
           <link>https://example.com</link>
         </channel>
-      </rss>`
+      </rss>
+    `
     const mockFetch = createMockFetch({})
-    const value = await discoverFavicons(
+    const result = await discoverFavicons(
       { url: 'https://example.com/feed.xml', content: rssContent },
       { methods: ['feed'], fetchFn: mockFetch },
     )
 
-    expect(value).toEqual([])
+    expect(result).toEqual([])
   })
 
   it('should return empty array for invalid URLs', async () => {
     const mockFetch = createMockFetch({})
-    const value = await discoverFavicons('not-a-valid-url', {
+    const result = await discoverFavicons('not-a-valid-url', {
       methods: ['html'],
       fetchFn: mockFetch,
     })
 
-    expect(value).toEqual([])
+    expect(result).toEqual([])
   })
 
   it('should recognize direct favicon URL via image content-type', async () => {
-    const fetchFn: DiscoverFetchFn = async (url: string) => ({
+    const mockFetch: DiscoverFetchFn = async (url: string) => ({
       url,
       body: 'binary',
       headers: new Headers({ 'content-type': 'image/png' }),
       status: 200,
       statusText: 'OK',
     })
-    const value = await discoverFavicons('https://example.com/icon.png', { fetchFn })
+    const result = await discoverFavicons('https://example.com/icon.png', { fetchFn: mockFetch })
     const expected: Array<DiscoverResult<FaviconResult>> = [
       { url: 'https://example.com/icon.png', isValid: true },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should recognize direct SVG favicon via content', async () => {
     const svgContent = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>'
-    const fetchFn: DiscoverFetchFn = async (url: string) => ({
+    const mockFetch: DiscoverFetchFn = async (url: string) => ({
       url,
       body: svgContent,
       headers: new Headers(),
       status: 200,
       statusText: 'OK',
     })
-    const value = await discoverFavicons('https://example.com/icon.svg', { fetchFn })
+    const result = await discoverFavicons('https://example.com/icon.svg', { fetchFn: mockFetch })
     const expected: Array<DiscoverResult<FaviconResult>> = [
       { url: 'https://example.com/icon.svg', isValid: true },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should recognize SVG favicon from object input without headers', async () => {
     const svgContent = '<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"></svg>'
     const mockFetch = createMockFetch({})
-    const value = await discoverFavicons(
+    const result = await discoverFavicons(
       { url: 'https://example.com/icon.svg', content: svgContent },
       { fetchFn: mockFetch },
     )
@@ -354,36 +364,38 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/icon.svg', isValid: true },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should not recognize HTML page with embedded SVG as direct favicon', async () => {
     const html =
       '<html><body><svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg></body></html>'
     const mockFetch = createMockFetch({})
-    const value = await discoverFavicons(
+    const result = await discoverFavicons(
       { url: 'https://example.com', content: html },
       { methods: ['guess'], fetchFn: mockFetch },
     )
 
-    expect(value).toEqual([])
+    expect(result).toEqual([])
   })
 
   it('should discover favicons from site HTML when given RSS feed URL', async () => {
-    const rssContent = `<?xml version="1.0"?>
+    const rssContent = `
+      <?xml version="1.0"?>
       <rss version="2.0">
         <channel>
           <title>Example</title>
           <link>https://example.com</link>
         </channel>
-      </rss>`
+      </rss>
+    `
     const siteHtml = '<link rel="icon" href="/favicon.ico">'
     const mockFetch = createMockFetch({
       'https://example.com/feed.xml': rssContent,
       'https://example.com/': siteHtml,
       'https://example.com/favicon.ico': 'binary',
     })
-    const value = await discoverFavicons('https://example.com/feed.xml', {
+    const result = await discoverFavicons('https://example.com/feed.xml', {
       methods: ['html'],
       fetchFn: mockFetch,
     })
@@ -391,22 +403,24 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/favicon.ico', isValid: true, method: 'html' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should discover favicons from site HTML when given Atom feed URL', async () => {
-    const atomContent = `<?xml version="1.0"?>
+    const atomContent = `
+      <?xml version="1.0"?>
       <feed xmlns="http://www.w3.org/2005/Atom">
         <title>Example</title>
         <link rel="alternate" href="https://example.com"/>
-      </feed>`
+      </feed>
+    `
     const siteHtml = '<link rel="icon" href="/icon.png">'
     const mockFetch = createMockFetch({
       'https://example.com/feed.xml': atomContent,
       'https://example.com/': siteHtml,
       'https://example.com/icon.png': 'binary',
     })
-    const value = await discoverFavicons('https://example.com/feed.xml', {
+    const result = await discoverFavicons('https://example.com/feed.xml', {
       methods: ['html'],
       fetchFn: mockFetch,
     })
@@ -414,22 +428,24 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/icon.png', isValid: true, method: 'html' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should discover favicons from site HTML when Atom feed has fragment-only alternate link', async () => {
-    const atomContent = `<?xml version="1.0"?>
+    const atomContent = `
+      <?xml version="1.0"?>
       <feed xmlns="http://www.w3.org/2005/Atom">
         <title>Example</title>
         <link rel="alternate" href="#respond"/>
-      </feed>`
+      </feed>
+    `
     const siteHtml = '<link rel="icon" href="/favicon.ico">'
     const mockFetch = createMockFetch({
       'https://example.com/feed.xml': atomContent,
       'https://example.com': siteHtml,
       'https://example.com/favicon.ico': 'binary',
     })
-    const value = await discoverFavicons('https://example.com/feed.xml', {
+    const result = await discoverFavicons('https://example.com/feed.xml', {
       methods: ['html'],
       fetchFn: mockFetch,
     })
@@ -437,7 +453,7 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/favicon.ico', isValid: true, method: 'html' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should discover favicons from site HTML when given JSON Feed URL', async () => {
@@ -453,7 +469,7 @@ describe('discoverFavicons', () => {
       'https://example.com/': siteHtml,
       'https://example.com/favicon.svg': 'binary',
     })
-    const value = await discoverFavicons('https://example.com/feed.json', {
+    const result = await discoverFavicons('https://example.com/feed.json', {
       methods: ['html'],
       fetchFn: mockFetch,
     })
@@ -461,21 +477,23 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/favicon.svg', isValid: true, method: 'html' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should fall back to origin when feed has no site URL', async () => {
-    const atomContent = `<?xml version="1.0"?>
+    const atomContent = `
+      <?xml version="1.0"?>
       <feed xmlns="http://www.w3.org/2005/Atom">
         <title>Example</title>
-      </feed>`
+      </feed>
+    `
     const siteHtml = '<link rel="icon" href="/favicon.ico">'
     const mockFetch = createMockFetch({
       'https://example.com/feed.xml': atomContent,
       'https://example.com': siteHtml,
       'https://example.com/favicon.ico': 'binary',
     })
-    const value = await discoverFavicons('https://example.com/feed.xml', {
+    const result = await discoverFavicons('https://example.com/feed.xml', {
       methods: ['html'],
       fetchFn: mockFetch,
     })
@@ -483,16 +501,18 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/favicon.ico', isValid: true, method: 'html' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should return results from both feed and html methods when given feed URL', async () => {
-    const atomContent = `<?xml version="1.0"?>
+    const atomContent = `
+      <?xml version="1.0"?>
       <feed xmlns="http://www.w3.org/2005/Atom">
         <title>Example</title>
         <icon>https://example.com/feed-icon.png</icon>
         <link rel="alternate" href="https://example.com"/>
-      </feed>`
+      </feed>
+    `
     const siteHtml = '<link rel="icon" href="/site-icon.png">'
     const mockFetch = createMockFetch({
       'https://example.com/feed.xml': atomContent,
@@ -500,7 +520,7 @@ describe('discoverFavicons', () => {
       'https://example.com/feed-icon.png': 'binary',
       'https://example.com/site-icon.png': 'binary',
     })
-    const value = await discoverFavicons('https://example.com/feed.xml', {
+    const result = await discoverFavicons('https://example.com/feed.xml', {
       methods: ['feed', 'html'],
       fetchFn: mockFetch,
     })
@@ -509,7 +529,7 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/site-icon.png', isValid: true, method: 'html' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should not trigger site resolution for non-feed input', async () => {
@@ -518,7 +538,7 @@ describe('discoverFavicons', () => {
       'https://example.com': html,
       'https://example.com/favicon.ico': 'binary',
     })
-    const value = await discoverFavicons('https://example.com', {
+    const result = await discoverFavicons('https://example.com', {
       methods: ['html'],
       fetchFn: mockFetch,
     })
@@ -526,17 +546,19 @@ describe('discoverFavicons', () => {
       { url: 'https://example.com/favicon.ico', isValid: true, method: 'html' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should proceed gracefully when site URL fetch fails', async () => {
-    const rssContent = `<?xml version="1.0"?>
+    const rssContent = `
+      <?xml version="1.0"?>
       <rss version="2.0">
         <channel>
           <link>https://dead-site.com</link>
         </channel>
-      </rss>`
-    const fetchFn: DiscoverFetchFn = (url: string) => {
+      </rss>
+    `
+    const mockFetch: DiscoverFetchFn = (url: string) => {
       if (url === 'https://dead-site.com') {
         return Promise.reject(new Error('Connection refused'))
       }
@@ -549,17 +571,17 @@ describe('discoverFavicons', () => {
         statusText: 'OK',
       })
     }
-    const value = await discoverFavicons('https://example.com/feed.xml', {
+    const result = await discoverFavicons('https://example.com/feed.xml', {
       methods: ['html'],
-      fetchFn,
+      fetchFn: mockFetch,
     })
 
-    expect(value).toEqual([])
+    expect(result).toEqual([])
   })
 
   it('should fall back to guess method when initial URL fetch throws', async () => {
     const pngContent = '\x89PNG\r\n\x1a\n'
-    const fetchFn: DiscoverFetchFn = (url: string) => {
+    const mockFetch: DiscoverFetchFn = (url: string) => {
       if (url === 'https://example.com/') {
         throw new Error('Connection refused')
       }
@@ -572,14 +594,88 @@ describe('discoverFavicons', () => {
         statusText: url === 'https://example.com/favicon.ico' ? 'OK' : 'Not Found',
       })
     }
-    const value = await discoverFavicons('https://example.com/', {
+    const result = await discoverFavicons('https://example.com/', {
       methods: ['guess'],
-      fetchFn,
+      fetchFn: mockFetch,
     })
     const expected: Array<DiscoverResult<FaviconResult>> = [
       { url: 'https://example.com/favicon.ico', isValid: true, method: 'guess' },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
+  })
+
+  it('should use custom extractFn to validate results', async () => {
+    const mockFetch = createMockFetch({
+      'https://example.com': '',
+      'https://example.com/favicon.ico': 'binary',
+    })
+    const extractFn: DiscoverExtractFn<FaviconResult> = (input) => ({
+      url: input.url,
+      isValid: input.url.endsWith('.png'),
+    })
+    const result = await discoverFavicons('https://example.com', {
+      methods: { guess: { uris: ['/favicon.ico', '/favicon.png'] } },
+      fetchFn: mockFetch,
+      extractFn,
+    })
+    const expected: Array<DiscoverResult<FaviconResult>> = [
+      { url: 'https://example.com/favicon.png', isValid: true, method: 'guess' },
+    ]
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should use custom resolveUrlFn to rewrite discovered URLs', async () => {
+    const html = '<link rel="icon" href="/favicon.ico">'
+    const mockFetch = createMockFetch({
+      'https://example.com': html,
+      'https://cdn.example.com/favicon.ico': 'binary',
+    })
+    const resolveUrlFn: DiscoverResolveUrlFn = () => 'https://cdn.example.com/favicon.ico'
+    const result = await discoverFavicons('https://example.com', {
+      methods: ['html'],
+      fetchFn: mockFetch,
+      resolveUrlFn,
+    })
+    const expected: Array<DiscoverResult<FaviconResult>> = [
+      { url: 'https://cdn.example.com/favicon.ico', isValid: true, method: 'html' },
+    ]
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should use custom resolveSiteUrlFn to discover from resolved site', async () => {
+    const siteHtml = '<link rel="icon" href="https://example.com/favicon.ico">'
+    const mockFetch = createMockFetch({
+      'https://blog.example.com/page': '<html><body>Post</body></html>',
+      'https://example.com': siteHtml,
+      'https://example.com/favicon.ico': 'binary',
+    })
+    const resolveSiteUrlFn: DiscoverResolveSiteUrlFn = () => 'https://example.com'
+    const result = await discoverFavicons('https://blog.example.com/page', {
+      methods: ['html'],
+      fetchFn: mockFetch,
+      resolveSiteUrlFn,
+    })
+    const expected: Array<DiscoverResult<FaviconResult>> = [
+      { url: 'https://example.com/favicon.ico', isValid: true, method: 'html' },
+    ]
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should return empty array for empty methods array', async () => {
+    const html = '<link rel="icon" href="/favicon.ico">'
+    const mockFetch = createMockFetch({
+      'https://example.com': html,
+      'https://example.com/favicon.ico': 'binary',
+    })
+    const result = await discoverFavicons('https://example.com', {
+      methods: [],
+      fetchFn: mockFetch,
+    })
+
+    expect(result).toEqual([])
   })
 })

--- a/src/favicons/platform/handlers/bluesky.test.ts
+++ b/src/favicons/platform/handlers/bluesky.test.ts
@@ -87,7 +87,7 @@ describe('blueskyHandler', () => {
             avatar: 'https://cdn.bsky.app/img/avatar/plain/did:plc:abc123/avatar.jpg',
           }),
       })
-      const value = await blueskyHandler.resolve(
+      const result = await blueskyHandler.resolve(
         'https://bsky.app/profile/user.bsky.social',
         undefined,
         undefined,
@@ -97,7 +97,7 @@ describe('blueskyHandler', () => {
         { uri: 'https://cdn.bsky.app/img/avatar/plain/did:plc:abc123/avatar.jpg' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should resolve avatar for custom domain handle', async () => {
@@ -107,7 +107,7 @@ describe('blueskyHandler', () => {
             avatar: 'https://cdn.bsky.app/img/avatar/plain/did:plc:xyz/avatar.jpg',
           }),
       })
-      const value = await blueskyHandler.resolve(
+      const result = await blueskyHandler.resolve(
         'https://bsky.app/profile/example.com',
         undefined,
         undefined,
@@ -117,13 +117,13 @@ describe('blueskyHandler', () => {
         { uri: 'https://cdn.bsky.app/img/avatar/plain/did:plc:xyz/avatar.jpg' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should return empty array when fetchFn is not provided', async () => {
-      const value = await blueskyHandler.resolve('https://bsky.app/profile/user.bsky.social')
+      const result = await blueskyHandler.resolve('https://bsky.app/profile/user.bsky.social')
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when avatar is empty string', async () => {
@@ -131,14 +131,14 @@ describe('blueskyHandler', () => {
         'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=user.bsky.social':
           JSON.stringify({ avatar: '' }),
       })
-      const value = await blueskyHandler.resolve(
+      const result = await blueskyHandler.resolve(
         'https://bsky.app/profile/user.bsky.social',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when avatar is not a string', async () => {
@@ -146,14 +146,14 @@ describe('blueskyHandler', () => {
         'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=user.bsky.social':
           JSON.stringify({ avatar: 123 }),
       })
-      const value = await blueskyHandler.resolve(
+      const result = await blueskyHandler.resolve(
         'https://bsky.app/profile/user.bsky.social',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when API returns no avatar', async () => {
@@ -161,14 +161,14 @@ describe('blueskyHandler', () => {
         'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=user.bsky.social':
           JSON.stringify({}),
       })
-      const value = await blueskyHandler.resolve(
+      const result = await blueskyHandler.resolve(
         'https://bsky.app/profile/user.bsky.social',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when API returns invalid JSON', async () => {
@@ -176,35 +176,47 @@ describe('blueskyHandler', () => {
         'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=user.bsky.social':
           'not json',
       })
-      const value = await blueskyHandler.resolve(
+      const result = await blueskyHandler.resolve(
         'https://bsky.app/profile/user.bsky.social',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when fetch throws', async () => {
       const mockFetch: DiscoverFetchFn = () => {
         throw new Error('Network error')
       }
-      const value = await blueskyHandler.resolve(
+      const result = await blueskyHandler.resolve(
         'https://bsky.app/profile/user.bsky.social',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array for invalid URL', async () => {
       const mockFetch = createMockFetch({})
-      const value = await blueskyHandler.resolve('not-a-url', undefined, undefined, mockFetch)
+      const result = await blueskyHandler.resolve('not-a-url', undefined, undefined, mockFetch)
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
+    })
+
+    it('should return empty array for non-profile path', async () => {
+      const mockFetch = createMockFetch({})
+      const result = await blueskyHandler.resolve(
+        'https://bsky.app/about',
+        undefined,
+        undefined,
+        mockFetch,
+      )
+
+      expect(result).toEqual([])
     })
 
     it('should resolve avatar from www.bsky.app variant', async () => {
@@ -214,7 +226,7 @@ describe('blueskyHandler', () => {
             avatar: 'https://cdn.bsky.app/img/avatar/plain/did:plc:abc/avatar.jpg',
           }),
       })
-      const value = await blueskyHandler.resolve(
+      const result = await blueskyHandler.resolve(
         'https://www.bsky.app/profile/user.bsky.social',
         undefined,
         undefined,
@@ -224,7 +236,7 @@ describe('blueskyHandler', () => {
         { uri: 'https://cdn.bsky.app/img/avatar/plain/did:plc:abc/avatar.jpg' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
   })
 })

--- a/src/favicons/platform/handlers/codeberg.test.ts
+++ b/src/favicons/platform/handlers/codeberg.test.ts
@@ -31,37 +31,34 @@ describe('codebergHandler', () => {
 
   describe('resolve', () => {
     it('should resolve user avatar from user URL', () => {
-      const value = codebergHandler.resolve('https://codeberg.org/forgejo')
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://codeberg.org/user/avatar/forgejo/512' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(codebergHandler.resolve('https://codeberg.org/forgejo')).toEqual(expected)
     })
 
     it('should resolve user avatar from repo URL', () => {
-      const value = codebergHandler.resolve('https://codeberg.org/forgejo/forgejo')
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://codeberg.org/user/avatar/forgejo/512' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(codebergHandler.resolve('https://codeberg.org/forgejo/forgejo')).toEqual(expected)
     })
 
     it('should resolve user avatar from deep path', () => {
-      const value = codebergHandler.resolve('https://codeberg.org/forgejo/forgejo/src/branch/main')
+      const value = 'https://codeberg.org/forgejo/forgejo/src/branch/main'
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://codeberg.org/user/avatar/forgejo/512' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(codebergHandler.resolve(value)).toEqual(expected)
     })
 
     it('should resolve user avatar using gitea.com origin', () => {
-      const value = codebergHandler.resolve('https://gitea.com/gitea')
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://gitea.com/user/avatar/gitea/512' }]
 
-      expect(value).toEqual(expected)
+      expect(codebergHandler.resolve('https://gitea.com/gitea')).toEqual(expected)
     })
 
     it('should return empty array for root URL', () => {
@@ -80,30 +77,32 @@ describe('codebergHandler', () => {
     })
 
     it('should resolve www.codeberg.org URL', () => {
-      const value = codebergHandler.resolve('https://www.codeberg.org/forgejo')
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://www.codeberg.org/user/avatar/forgejo/512' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(codebergHandler.resolve('https://www.codeberg.org/forgejo')).toEqual(expected)
     })
 
     it('should resolve www.gitea.com URL', () => {
-      const value = codebergHandler.resolve('https://www.gitea.com/gitea')
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://www.gitea.com/user/avatar/gitea/512' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(codebergHandler.resolve('https://www.gitea.com/gitea')).toEqual(expected)
     })
 
     it('should strip feed extension from user URL', () => {
-      const value = codebergHandler.resolve('https://codeberg.org/forgejo.rss')
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://codeberg.org/user/avatar/forgejo/512' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(codebergHandler.resolve('https://codeberg.org/forgejo.rss')).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/favicons/platform/handlers/deviantart.test.ts
+++ b/src/favicons/platform/handlers/deviantart.test.ts
@@ -22,6 +22,10 @@ describe('deviantartHandler', () => {
       expect(deviantartHandler.match('https://www.deviantart.com/artistname/favourites')).toBe(true)
     })
 
+    it('should match single-char username URLs even though resolve returns no avatars', () => {
+      expect(deviantartHandler.match('https://www.deviantart.com/x')).toBe(true)
+    })
+
     it('should not match tag pages', () => {
       expect(deviantartHandler.match('https://www.deviantart.com/tag/photography')).toBe(false)
     })
@@ -48,36 +52,34 @@ describe('deviantartHandler', () => {
 
   describe('resolve', () => {
     it('should resolve user avatar with 3 URI alternatives', () => {
-      const value = deviantartHandler.resolve('https://www.deviantart.com/artistname')
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.jpg' },
         { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.gif' },
         { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(deviantartHandler.resolve('https://www.deviantart.com/artistname')).toEqual(expected)
     })
 
     it('should resolve user avatar from gallery URL', () => {
-      const value = deviantartHandler.resolve('https://www.deviantart.com/artistname/gallery/all')
+      const value = 'https://www.deviantart.com/artistname/gallery/all'
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.jpg' },
         { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.gif' },
         { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(deviantartHandler.resolve(value)).toEqual(expected)
     })
 
     it('should normalize username to lowercase', () => {
-      const value = deviantartHandler.resolve('https://www.deviantart.com/ArtistName')
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.jpg' },
         { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.gif' },
         { uri: 'https://a.deviantart.net/avatars-big/a/r/artistname.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(deviantartHandler.resolve('https://www.deviantart.com/ArtistName')).toEqual(expected)
     })
 
     it('should return empty array for tag pages', () => {
@@ -95,6 +97,11 @@ describe('deviantartHandler', () => {
 
     it('should return empty array for single-char username', () => {
       expect(deviantartHandler.resolve('https://www.deviantart.com/x')).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/favicons/platform/handlers/devto.test.ts
+++ b/src/favicons/platform/handlers/devto.test.ts
@@ -54,7 +54,7 @@ describe('devtoHandler', () => {
           profile_image: 'https://res.cloudinary.com/practicaldev/image/fetch/alice.jpg',
         }),
       })
-      const value = await devtoHandler.resolve(
+      const result = await devtoHandler.resolve(
         'https://dev.to/alice',
         undefined,
         undefined,
@@ -64,88 +64,126 @@ describe('devtoHandler', () => {
         { uri: 'https://res.cloudinary.com/practicaldev/image/fetch/alice.jpg' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should return empty array when profile_image is absent', async () => {
       const mockFetch = createMockFetch({
         'https://dev.to/api/users/by_username?url=alice': JSON.stringify({}),
       })
-      const value = await devtoHandler.resolve(
+      const result = await devtoHandler.resolve(
         'https://dev.to/alice',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when profile_image is empty string', async () => {
       const mockFetch = createMockFetch({
         'https://dev.to/api/users/by_username?url=alice': JSON.stringify({ profile_image: '' }),
       })
-      const value = await devtoHandler.resolve(
+      const result = await devtoHandler.resolve(
         'https://dev.to/alice',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array for tag pages', async () => {
       const mockFetch = createMockFetch({})
-      const value = await devtoHandler.resolve(
+      const result = await devtoHandler.resolve(
         'https://dev.to/t/javascript',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when API returns invalid JSON', async () => {
       const mockFetch = createMockFetch({
         'https://dev.to/api/users/by_username?url=alice': 'not-json',
       })
-      const value = await devtoHandler.resolve(
+      const result = await devtoHandler.resolve(
         'https://dev.to/alice',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when fetchFn is not provided', async () => {
-      const value = await devtoHandler.resolve('https://dev.to/alice')
+      const result = await devtoHandler.resolve('https://dev.to/alice')
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when fetch throws', async () => {
       const mockFetch: DiscoverFetchFn = () => {
         throw new Error('Network error')
       }
-      const value = await devtoHandler.resolve(
+      const result = await devtoHandler.resolve(
         'https://dev.to/alice',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array for invalid URL', async () => {
       const mockFetch = createMockFetch({})
-      const value = await devtoHandler.resolve('not-a-url', undefined, undefined, mockFetch)
+      const result = await devtoHandler.resolve('not-a-url', undefined, undefined, mockFetch)
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
+    })
+
+    it('should return profile image from www.dev.to URL', async () => {
+      const mockFetch = createMockFetch({
+        'https://dev.to/api/users/by_username?url=alice': JSON.stringify({
+          profile_image: 'https://res.cloudinary.com/practicaldev/image/fetch/alice.jpg',
+        }),
+      })
+      const result = await devtoHandler.resolve(
+        'https://www.dev.to/alice',
+        undefined,
+        undefined,
+        mockFetch,
+      )
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://res.cloudinary.com/practicaldev/image/fetch/alice.jpg' },
+      ]
+
+      expect(result).toEqual(expected)
+    })
+
+    it('should resolve excluded paths as usernames since only match guards them', async () => {
+      const mockFetch = createMockFetch({
+        'https://dev.to/api/users/by_username?url=search': JSON.stringify({
+          profile_image: 'https://res.cloudinary.com/practicaldev/image/fetch/search.jpg',
+        }),
+      })
+      const result = await devtoHandler.resolve(
+        'https://dev.to/search',
+        undefined,
+        undefined,
+        mockFetch,
+      )
+      const expected: Array<DiscoverUriEntry> = [
+        { uri: 'https://res.cloudinary.com/practicaldev/image/fetch/search.jpg' },
+      ]
+
+      expect(result).toEqual(expected)
     })
   })
 })

--- a/src/favicons/platform/handlers/github.test.ts
+++ b/src/favicons/platform/handlers/github.test.ts
@@ -23,30 +23,26 @@ describe('githubHandler', () => {
 
   describe('resolve', () => {
     it('should resolve user avatar from user URL', () => {
-      const value = githubHandler.resolve('https://github.com/octocat')
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/octocat.png' }]
 
-      expect(value).toEqual(expected)
+      expect(githubHandler.resolve('https://github.com/octocat')).toEqual(expected)
     })
 
     it('should resolve user avatar from repo URL', () => {
-      const value = githubHandler.resolve('https://github.com/octocat/Hello-World')
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/octocat.png' }]
 
-      expect(value).toEqual(expected)
+      expect(githubHandler.resolve('https://github.com/octocat/Hello-World')).toEqual(expected)
     })
 
     it('should resolve user avatar from deep repo path', () => {
-      const value = githubHandler.resolve('https://github.com/octocat/Hello-World/tree/main/src')
+      const value = 'https://github.com/octocat/Hello-World/tree/main/src'
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/octocat.png' }]
 
-      expect(value).toEqual(expected)
+      expect(githubHandler.resolve(value)).toEqual(expected)
     })
 
     it('should return empty array for root URL', () => {
-      const value = githubHandler.resolve('https://github.com')
-
-      expect(value).toEqual([])
+      expect(githubHandler.resolve('https://github.com')).toEqual([])
     })
 
     it('should return empty array for excluded paths', () => {
@@ -62,24 +58,26 @@ describe('githubHandler', () => {
     })
 
     it('should resolve www.github.com URL', () => {
-      const value = githubHandler.resolve('https://www.github.com/octocat')
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/octocat.png' }]
 
-      expect(value).toEqual(expected)
+      expect(githubHandler.resolve('https://www.github.com/octocat')).toEqual(expected)
     })
 
     it('should resolve username with dashes', () => {
-      const value = githubHandler.resolve('https://github.com/my-org')
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/my-org.png' }]
 
-      expect(value).toEqual(expected)
+      expect(githubHandler.resolve('https://github.com/my-org')).toEqual(expected)
     })
 
     it('should strip feed extension from user URL', () => {
-      const value = githubHandler.resolve('https://github.com/octocat.atom')
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/octocat.png' }]
 
-      expect(value).toEqual(expected)
+      expect(githubHandler.resolve('https://github.com/octocat.atom')).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/favicons/platform/handlers/githubGist.test.ts
+++ b/src/favicons/platform/handlers/githubGist.test.ts
@@ -8,6 +8,10 @@ describe('githubGistHandler', () => {
       expect(githubGistHandler.match('https://gist.github.com/octocat')).toBe(true)
     })
 
+    it('should not match www.gist.github.com URLs', () => {
+      expect(githubGistHandler.match('https://www.gist.github.com/octocat')).toBe(false)
+    })
+
     it('should not match github.com URLs', () => {
       expect(githubGistHandler.match('https://github.com/octocat')).toBe(false)
     })
@@ -23,30 +27,26 @@ describe('githubGistHandler', () => {
 
   describe('resolve', () => {
     it('should resolve user avatar from user URL', () => {
-      const value = githubGistHandler.resolve('https://gist.github.com/octocat')
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/octocat.png' }]
 
-      expect(value).toEqual(expected)
+      expect(githubGistHandler.resolve('https://gist.github.com/octocat')).toEqual(expected)
     })
 
     it('should resolve user avatar from gist URL', () => {
-      const value = githubGistHandler.resolve('https://gist.github.com/octocat/abc123def456')
+      const value = 'https://gist.github.com/octocat/abc123def456'
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/octocat.png' }]
 
-      expect(value).toEqual(expected)
+      expect(githubGistHandler.resolve(value)).toEqual(expected)
     })
 
     it('should resolve user avatar from starred URL', () => {
-      const value = githubGistHandler.resolve('https://gist.github.com/octocat/starred')
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/octocat.png' }]
 
-      expect(value).toEqual(expected)
+      expect(githubGistHandler.resolve('https://gist.github.com/octocat/starred')).toEqual(expected)
     })
 
     it('should return empty array for root URL', () => {
-      const value = githubGistHandler.resolve('https://gist.github.com')
-
-      expect(value).toEqual([])
+      expect(githubGistHandler.resolve('https://gist.github.com')).toEqual([])
     })
 
     it('should return empty array for excluded paths', () => {
@@ -63,10 +63,14 @@ describe('githubGistHandler', () => {
     })
 
     it('should strip feed extension from user URL', () => {
-      const value = githubGistHandler.resolve('https://gist.github.com/octocat.atom')
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://github.com/octocat.png' }]
 
-      expect(value).toEqual(expected)
+      expect(githubGistHandler.resolve('https://gist.github.com/octocat.atom')).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/favicons/platform/handlers/gitlab.test.ts
+++ b/src/favicons/platform/handlers/gitlab.test.ts
@@ -67,7 +67,7 @@ describe('gitlabHandler', () => {
           { avatar_url: 'https://gitlab.com/uploads/user/avatar/1/alice.png' },
         ]),
       })
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com/alice',
         undefined,
         undefined,
@@ -77,7 +77,7 @@ describe('gitlabHandler', () => {
         { uri: 'https://gitlab.com/uploads/user/avatar/1/alice.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should return avatar from first result when API returns multiple users', async () => {
@@ -87,7 +87,7 @@ describe('gitlabHandler', () => {
           { avatar_url: 'https://gitlab.com/uploads/user/avatar/2/other.png' },
         ]),
       })
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com/alice',
         undefined,
         undefined,
@@ -97,7 +97,7 @@ describe('gitlabHandler', () => {
         { uri: 'https://gitlab.com/uploads/user/avatar/1/alice.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should use origin from self-hosted instance', async () => {
@@ -106,7 +106,7 @@ describe('gitlabHandler', () => {
           { avatar_url: 'https://gitlab.mycompany.com/uploads/user/avatar/1/alice.png' },
         ]),
       })
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.mycompany.com/alice',
         undefined,
         undefined,
@@ -116,7 +116,7 @@ describe('gitlabHandler', () => {
         { uri: 'https://gitlab.mycompany.com/uploads/user/avatar/1/alice.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should extract username from repo URL path', async () => {
@@ -125,7 +125,7 @@ describe('gitlabHandler', () => {
           { avatar_url: 'https://gitlab.com/uploads/group/avatar/1/gitlab-org.png' },
         ]),
       })
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com/gitlab-org/gitlab',
         undefined,
         undefined,
@@ -135,7 +135,7 @@ describe('gitlabHandler', () => {
         { uri: 'https://gitlab.com/uploads/group/avatar/1/gitlab-org.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should strip feed extension from user URL', async () => {
@@ -144,7 +144,7 @@ describe('gitlabHandler', () => {
           { avatar_url: 'https://gitlab.com/uploads/user/avatar/1/alice.png' },
         ]),
       })
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com/alice.atom',
         undefined,
         undefined,
@@ -154,7 +154,7 @@ describe('gitlabHandler', () => {
         { uri: 'https://gitlab.com/uploads/user/avatar/1/alice.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should preserve dots in usernames', async () => {
@@ -163,7 +163,7 @@ describe('gitlabHandler', () => {
           { avatar_url: 'https://gitlab.com/uploads/user/avatar/1/john.doe.png' },
         ]),
       })
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com/john.doe',
         undefined,
         undefined,
@@ -173,7 +173,7 @@ describe('gitlabHandler', () => {
         { uri: 'https://gitlab.com/uploads/user/avatar/1/john.doe.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should strip feed extension from dotted username', async () => {
@@ -182,7 +182,7 @@ describe('gitlabHandler', () => {
           { avatar_url: 'https://gitlab.com/uploads/user/avatar/1/john.doe.png' },
         ]),
       })
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com/john.doe.atom',
         undefined,
         undefined,
@@ -192,7 +192,7 @@ describe('gitlabHandler', () => {
         { uri: 'https://gitlab.com/uploads/user/avatar/1/john.doe.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should fall back to groups API when users API returns empty', async () => {
@@ -202,7 +202,7 @@ describe('gitlabHandler', () => {
           avatar_url: 'https://gitlab.com/uploads/-/system/group/avatar/9970/project_avatar.png',
         }),
       })
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com/gitlab-org',
         undefined,
         undefined,
@@ -212,7 +212,7 @@ describe('gitlabHandler', () => {
         { uri: 'https://gitlab.com/uploads/-/system/group/avatar/9970/project_avatar.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should return empty array when both users and groups API return empty', async () => {
@@ -220,107 +220,107 @@ describe('gitlabHandler', () => {
         'https://gitlab.com/api/v4/users?username=nonexistent': JSON.stringify([]),
         'https://gitlab.com/api/v4/groups/nonexistent': JSON.stringify({ avatar_url: '' }),
       })
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com/nonexistent',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array for root URL', async () => {
       const mockFetch = createMockFetch({})
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array for excluded paths', async () => {
       const mockFetch = createMockFetch({})
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com/explore',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when API returns empty array', async () => {
       const mockFetch = createMockFetch({
         'https://gitlab.com/api/v4/users?username=nonexistent': JSON.stringify([]),
       })
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com/nonexistent',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when avatar_url is empty', async () => {
       const mockFetch = createMockFetch({
         'https://gitlab.com/api/v4/users?username=alice': JSON.stringify([{ avatar_url: '' }]),
       })
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com/alice',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when API returns invalid JSON', async () => {
       const mockFetch = createMockFetch({
         'https://gitlab.com/api/v4/users?username=alice': 'not-json',
       })
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com/alice',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when fetchFn is not provided', async () => {
-      const value = await gitlabHandler.resolve('https://gitlab.com/alice')
+      const result = await gitlabHandler.resolve('https://gitlab.com/alice')
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when fetch throws', async () => {
       const mockFetch: DiscoverFetchFn = () => {
         throw new Error('Network error')
       }
-      const value = await gitlabHandler.resolve(
+      const result = await gitlabHandler.resolve(
         'https://gitlab.com/alice',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array for invalid URL', async () => {
       const mockFetch = createMockFetch({})
-      const value = await gitlabHandler.resolve('not-a-url', undefined, undefined, mockFetch)
+      const result = await gitlabHandler.resolve('not-a-url', undefined, undefined, mockFetch)
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
   })
 })

--- a/src/favicons/platform/handlers/lobsters.test.ts
+++ b/src/favicons/platform/handlers/lobsters.test.ts
@@ -9,6 +9,10 @@ describe('lobstersHandler', () => {
       expect(lobstersHandler.match('https://lobste.rs/~pushcx')).toBe(true)
     })
 
+    it('should not match www variant user URLs', () => {
+      expect(lobstersHandler.match('https://www.lobste.rs/~jcs')).toBe(false)
+    })
+
     it('should not match homepage', () => {
       expect(lobstersHandler.match('https://lobste.rs')).toBe(false)
       expect(lobstersHandler.match('https://lobste.rs/')).toBe(false)
@@ -41,19 +45,22 @@ describe('lobstersHandler', () => {
 
   describe('resolve', () => {
     it('should resolve user avatar from user URL', () => {
-      const value = lobstersHandler.resolve('https://lobste.rs/~jcs')
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://lobste.rs/avatars/jcs-100.png' }]
 
-      expect(value).toEqual(expected)
+      expect(lobstersHandler.resolve('https://lobste.rs/~jcs')).toEqual(expected)
     })
 
     it('should resolve user avatar from user URL with trailing slash', () => {
-      const value = lobstersHandler.resolve('https://lobste.rs/~pushcx/')
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://lobste.rs/avatars/pushcx-100.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(lobstersHandler.resolve('https://lobste.rs/~pushcx/')).toEqual(expected)
+    })
+
+    it('should return empty array for root URL', () => {
+      expect(lobstersHandler.resolve('https://lobste.rs')).toEqual([])
+      expect(lobstersHandler.resolve('https://lobste.rs/')).toEqual([])
     })
 
     it('should return empty array for non-user path', () => {
@@ -62,6 +69,11 @@ describe('lobstersHandler', () => {
 
     it('should return empty array for username with @ char', () => {
       expect(lobstersHandler.resolve('https://lobste.rs/~@invalid')).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/favicons/platform/handlers/mastodon.test.ts
+++ b/src/favicons/platform/handlers/mastodon.test.ts
@@ -160,7 +160,7 @@ describe('mastodonHandler', () => {
           avatar: 'https://files.mastodon.social/accounts/avatars/000/123/original/avatar.png',
         }),
       })
-      const value = await mastodonHandler.resolve(
+      const result = await mastodonHandler.resolve(
         'https://mastodon.social/@user',
         undefined,
         undefined,
@@ -170,7 +170,7 @@ describe('mastodonHandler', () => {
         { uri: 'https://files.mastodon.social/accounts/avatars/000/123/original/avatar.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should resolve avatar from different instance', async () => {
@@ -179,7 +179,7 @@ describe('mastodonHandler', () => {
           avatar: 'https://media.hachyderm.io/avatars/dev.png',
         }),
       })
-      const value = await mastodonHandler.resolve(
+      const result = await mastodonHandler.resolve(
         'https://hachyderm.io/@dev',
         undefined,
         undefined,
@@ -189,90 +189,90 @@ describe('mastodonHandler', () => {
         { uri: 'https://media.hachyderm.io/avatars/dev.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should return empty array when fetchFn is not provided', async () => {
-      const value = await mastodonHandler.resolve('https://mastodon.social/@user')
+      const result = await mastodonHandler.resolve('https://mastodon.social/@user')
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when avatar is empty string', async () => {
       const mockFetch = createMockFetch({
         'https://mastodon.social/api/v1/accounts/lookup?acct=user': JSON.stringify({ avatar: '' }),
       })
-      const value = await mastodonHandler.resolve(
+      const result = await mastodonHandler.resolve(
         'https://mastodon.social/@user',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when avatar is not a string', async () => {
       const mockFetch = createMockFetch({
         'https://mastodon.social/api/v1/accounts/lookup?acct=user': JSON.stringify({ avatar: 123 }),
       })
-      const value = await mastodonHandler.resolve(
+      const result = await mastodonHandler.resolve(
         'https://mastodon.social/@user',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when API returns no avatar', async () => {
       const mockFetch = createMockFetch({
         'https://mastodon.social/api/v1/accounts/lookup?acct=user': JSON.stringify({}),
       })
-      const value = await mastodonHandler.resolve(
+      const result = await mastodonHandler.resolve(
         'https://mastodon.social/@user',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when API returns invalid JSON', async () => {
       const mockFetch = createMockFetch({
         'https://mastodon.social/api/v1/accounts/lookup?acct=user': 'not json',
       })
-      const value = await mastodonHandler.resolve(
+      const result = await mastodonHandler.resolve(
         'https://mastodon.social/@user',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when fetch throws', async () => {
       const mockFetch: DiscoverFetchFn = () => {
         throw new Error('Network error')
       }
-      const value = await mastodonHandler.resolve(
+      const result = await mastodonHandler.resolve(
         'https://mastodon.social/@user',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array for invalid URL', async () => {
       const mockFetch = createMockFetch({})
-      const value = await mastodonHandler.resolve('not-a-url', undefined, undefined, mockFetch)
+      const result = await mastodonHandler.resolve('not-a-url', undefined, undefined, mockFetch)
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     // Port is stripped from API URL because handler uses hostname (not host).
@@ -282,7 +282,7 @@ describe('mastodonHandler', () => {
           avatar: 'https://mastodon.local:3000/avatars/user.png',
         }),
       })
-      const value = await mastodonHandler.resolve(
+      const result = await mastodonHandler.resolve(
         'https://mastodon.local:3000/@user',
         undefined,
         undefined,
@@ -292,7 +292,7 @@ describe('mastodonHandler', () => {
         { uri: 'https://mastodon.local:3000/avatars/user.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should resolve avatar from /@user@domain format', async () => {
@@ -301,7 +301,7 @@ describe('mastodonHandler', () => {
           avatar: 'https://remote.social/avatars/user.png',
         }),
       })
-      const value = await mastodonHandler.resolve(
+      const result = await mastodonHandler.resolve(
         'https://mastodon.social/@user@remote.social',
         undefined,
         undefined,
@@ -309,19 +309,19 @@ describe('mastodonHandler', () => {
       )
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://remote.social/avatars/user.png' }]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should return empty array for non-profile path', async () => {
       const mockFetch = createMockFetch({})
-      const value = await mastodonHandler.resolve(
+      const result = await mastodonHandler.resolve(
         'https://mastodon.social/about',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should strip feed extension from profile URL', async () => {
@@ -330,7 +330,7 @@ describe('mastodonHandler', () => {
           avatar: 'https://mastodon.social/avatars/user.png',
         }),
       })
-      const value = await mastodonHandler.resolve(
+      const result = await mastodonHandler.resolve(
         'https://mastodon.social/@user.rss',
         undefined,
         undefined,
@@ -340,7 +340,7 @@ describe('mastodonHandler', () => {
         { uri: 'https://mastodon.social/avatars/user.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
   })
 })

--- a/src/favicons/platform/handlers/reddit.test.ts
+++ b/src/favicons/platform/handlers/reddit.test.ts
@@ -155,7 +155,7 @@ describe('redditHandler', () => {
           data: { community_icon: 'https://styles.redditmedia.com/icon.png?v=1' },
         }),
       })
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/r/javascript',
         undefined,
         undefined,
@@ -163,7 +163,7 @@ describe('redditHandler', () => {
       )
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://styles.redditmedia.com/icon.png' }]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should resolve subreddit icon from icon_img when community_icon is empty', async () => {
@@ -172,7 +172,7 @@ describe('redditHandler', () => {
           data: { community_icon: '', icon_img: 'https://b.thumbs.redditmedia.com/icon.png' },
         }),
       })
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/r/programming',
         undefined,
         undefined,
@@ -182,7 +182,7 @@ describe('redditHandler', () => {
         { uri: 'https://b.thumbs.redditmedia.com/icon.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should resolve user icon from icon_img', async () => {
@@ -191,7 +191,7 @@ describe('redditHandler', () => {
           data: { icon_img: 'https://styles.redditmedia.com/user-icon.png' },
         }),
       })
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/u/spez',
         undefined,
         undefined,
@@ -201,7 +201,7 @@ describe('redditHandler', () => {
         { uri: 'https://styles.redditmedia.com/user-icon.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should resolve user icon from snoovatar_img when icon_img is empty', async () => {
@@ -210,7 +210,7 @@ describe('redditHandler', () => {
           data: { icon_img: '', snoovatar_img: 'https://i.redd.it/snoovatar/snoo.png' },
         }),
       })
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/user/spez',
         undefined,
         undefined,
@@ -218,7 +218,7 @@ describe('redditHandler', () => {
       )
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://i.redd.it/snoovatar/snoo.png' }]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should strip feed extension from subreddit URL', async () => {
@@ -227,7 +227,7 @@ describe('redditHandler', () => {
           data: { community_icon: 'https://styles.redditmedia.com/icon.png' },
         }),
       })
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/r/javascript.rss',
         undefined,
         undefined,
@@ -235,7 +235,7 @@ describe('redditHandler', () => {
       )
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://styles.redditmedia.com/icon.png' }]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should strip feed extension from user URL', async () => {
@@ -244,7 +244,7 @@ describe('redditHandler', () => {
           data: { icon_img: 'https://styles.redditmedia.com/user-icon.png' },
         }),
       })
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/u/spez.rss',
         undefined,
         undefined,
@@ -254,25 +254,25 @@ describe('redditHandler', () => {
         { uri: 'https://styles.redditmedia.com/user-icon.png' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should return empty array when fetchFn is not provided', async () => {
-      const value = await redditHandler.resolve('https://reddit.com/r/javascript')
+      const result = await redditHandler.resolve('https://reddit.com/r/javascript')
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array for non-subreddit and non-user path', async () => {
       const mockFetch = createMockFetch({})
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/about',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when subreddit icon fields are empty', async () => {
@@ -281,28 +281,28 @@ describe('redditHandler', () => {
           data: { community_icon: '', icon_img: '' },
         }),
       })
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/r/javascript',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when subreddit data fields are missing', async () => {
       const mockFetch = createMockFetch({
         'https://www.reddit.com/r/javascript/about.json': JSON.stringify({ data: {} }),
       })
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/r/javascript',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when user icon fields are empty', async () => {
@@ -311,63 +311,63 @@ describe('redditHandler', () => {
           data: { icon_img: '', snoovatar_img: '' },
         }),
       })
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/u/spez',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when user data fields are missing', async () => {
       const mockFetch = createMockFetch({
         'https://www.reddit.com/user/spez/about.json': JSON.stringify({ data: {} }),
       })
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/u/spez',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when API returns invalid JSON', async () => {
       const mockFetch = createMockFetch({
         'https://www.reddit.com/r/javascript/about.json': 'not json',
       })
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/r/javascript',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when fetch throws', async () => {
       const mockFetch: DiscoverFetchFn = () => {
         throw new Error('Network error')
       }
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/r/javascript',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array for invalid URL', async () => {
       const mockFetch = createMockFetch({})
-      const value = await redditHandler.resolve('not-a-url', undefined, undefined, mockFetch)
+      const result = await redditHandler.resolve('not-a-url', undefined, undefined, mockFetch)
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when community_icon is non-string type', async () => {
@@ -377,14 +377,14 @@ describe('redditHandler', () => {
           data: { community_icon: 42, icon_img: 'https://b.thumbs.redditmedia.com/fallback.png' },
         }),
       })
-      const value = await redditHandler.resolve(
+      const result = await redditHandler.resolve(
         'https://reddit.com/r/javascript',
         undefined,
         undefined,
         mockFetch,
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
   })
 })

--- a/src/favicons/platform/handlers/sourceforge.test.ts
+++ b/src/favicons/platform/handlers/sourceforge.test.ts
@@ -37,37 +37,51 @@ describe('sourceforgeHandler', () => {
 
   describe('resolve', () => {
     it('should resolve project icon from project URL', () => {
-      const value = sourceforgeHandler.resolve('https://sourceforge.net/projects/mingw')
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://a.fsdn.com/allura/p/mingw/icon' }]
 
-      expect(value).toEqual(expected)
+      expect(sourceforgeHandler.resolve('https://sourceforge.net/projects/mingw')).toEqual(expected)
     })
 
     it('should resolve project icon from project subpath', () => {
-      const value = sourceforgeHandler.resolve('https://sourceforge.net/projects/mingw/files')
+      const value = 'https://sourceforge.net/projects/mingw/files'
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://a.fsdn.com/allura/p/mingw/icon' }]
 
-      expect(value).toEqual(expected)
+      expect(sourceforgeHandler.resolve(value)).toEqual(expected)
     })
 
     it('should return empty array for non-project path', () => {
       expect(sourceforgeHandler.resolve('https://sourceforge.net/about')).toEqual([])
     })
 
+    it('should return empty array for root URL', () => {
+      expect(sourceforgeHandler.resolve('https://sourceforge.net')).toEqual([])
+      expect(sourceforgeHandler.resolve('https://sourceforge.net/')).toEqual([])
+    })
+
+    it('should return empty array for projects path without project name', () => {
+      expect(sourceforgeHandler.resolve('https://sourceforge.net/projects')).toEqual([])
+      expect(sourceforgeHandler.resolve('https://sourceforge.net/projects/')).toEqual([])
+    })
+
     it('should resolve project icon from www variant', () => {
-      const value = sourceforgeHandler.resolve('https://www.sourceforge.net/projects/mingw')
+      const value = 'https://www.sourceforge.net/projects/mingw'
       const expected: Array<DiscoverUriEntry> = [{ uri: 'https://a.fsdn.com/allura/p/mingw/icon' }]
 
-      expect(value).toEqual(expected)
+      expect(sourceforgeHandler.resolve(value)).toEqual(expected)
     })
 
     it('should resolve project icon for project with hyphens', () => {
-      const value = sourceforgeHandler.resolve('https://sourceforge.net/projects/my-cool-project')
+      const value = 'https://sourceforge.net/projects/my-cool-project'
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://a.fsdn.com/allura/p/my-cool-project/icon' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(sourceforgeHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/favicons/platform/handlers/tumblr.test.ts
+++ b/src/favicons/platform/handlers/tumblr.test.ts
@@ -27,36 +27,42 @@ describe('tumblrHandler', () => {
 
   describe('resolve', () => {
     it('should resolve blog avatar from subdomain URL', () => {
-      const value = tumblrHandler.resolve('https://staff.tumblr.com')
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://api.tumblr.com/v2/blog/staff/avatar/512' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(tumblrHandler.resolve('https://staff.tumblr.com')).toEqual(expected)
     })
 
     it('should resolve blog avatar from subdomain URL with path', () => {
-      const value = tumblrHandler.resolve('https://engineering.tumblr.com/post/123')
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://api.tumblr.com/v2/blog/engineering/avatar/512' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(tumblrHandler.resolve('https://engineering.tumblr.com/post/123')).toEqual(expected)
     })
 
     it('should resolve blog avatar from subdomain URL with tagged path', () => {
-      const value = tumblrHandler.resolve('https://staff.tumblr.com/tagged/updates')
       const expected: Array<DiscoverUriEntry> = [
         { uri: 'https://api.tumblr.com/v2/blog/staff/avatar/512' },
       ]
 
-      expect(value).toEqual(expected)
+      expect(tumblrHandler.resolve('https://staff.tumblr.com/tagged/updates')).toEqual(expected)
     })
 
     it('should return empty array for www subdomain', () => {
-      const value = tumblrHandler.resolve('https://www.tumblr.com/')
+      expect(tumblrHandler.resolve('https://www.tumblr.com/')).toEqual([])
+    })
 
-      expect(value).toEqual([])
+    it.todo('should return empty array for bare tumblr.com URL', () => {
+      // resolve('https://tumblr.com') currently returns the avatar URL for a blog named "tumblr"
+      // because the hostname label is treated as the blog name and only match guards the bare
+      // domain; the desired contract is undecided.
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/favicons/utils.test.ts
+++ b/src/favicons/utils.test.ts
@@ -11,16 +11,22 @@ describe('parseBodyJson', () => {
   })
 
   it('should throw on invalid JSON string', () => {
-    expect(() => parseBodyJson('not-json')).toThrow()
+    const throwing = () => parseBodyJson('not-json')
+
+    expect(throwing).toThrow()
   })
 
   it('should throw when body is a ReadableStream', () => {
-    const stream = new ReadableStream()
-    expect(() => parseBodyJson(stream)).toThrow()
+    const value = new ReadableStream()
+    const throwing = () => parseBodyJson(value)
+
+    expect(throwing).toThrow()
   })
 
   it('should throw on empty string', () => {
-    expect(() => parseBodyJson('')).toThrow()
+    const throwing = () => parseBodyJson('')
+
+    expect(throwing).toThrow()
   })
 })
 
@@ -42,13 +48,7 @@ describe('isNonEmptyString', () => {
     expect(isNonEmptyString({})).toBe(false)
   })
 
-  it('should act as a type guard narrowing to string', () => {
-    const value: unknown = 'https://example.com/avatar.png'
-
-    if (isNonEmptyString(value)) {
-      expect(value.startsWith('https')).toBe(true)
-    } else {
-      expect(true).toBe(false)
-    }
+  it('should return true for whitespace-only strings', () => {
+    expect(isNonEmptyString(' ')).toBe(true)
   })
 })

--- a/src/feeds/extractors.test.ts
+++ b/src/feeds/extractors.test.ts
@@ -162,7 +162,8 @@ describe('defaultExtractFn', () => {
           <link>https://example.com</link>
           <description>Test feed</description>
         </channel>
-      </RSS>`
+      </RSS>
+    `
     const result = await defaultExtractFn({
       content: rss,
       headers: new Headers(),

--- a/src/feeds/index.test.ts
+++ b/src/feeds/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'bun:test'
-import type { DiscoverFetchFn, DiscoverResult } from '../common/types.js'
+import type {
+  DiscoverExtractFn,
+  DiscoverFetchFn,
+  DiscoverResolveUrlFn,
+  DiscoverResult,
+} from '../common/types.js'
 import type { PlatformHandler } from '../common/uris/platform/types.js'
 import { defaultPlatformOptions, urisBalanced, urisComprehensive, urisMinimal } from './defaults.js'
 import { discoverFeeds } from './index.js'
@@ -29,7 +34,7 @@ describe('discoverFeeds', () => {
     const mockFetch = createMockFetch({
       'https://example.com/feed': rss,
     })
-    const value = await discoverFeeds('https://example.com', { fetchFn: mockFetch })
+    const result = await discoverFeeds('https://example.com', { fetchFn: mockFetch })
     const expected: Array<DiscoverResult<FeedResult>> = [
       {
         url: 'https://example.com/feed',
@@ -42,7 +47,7 @@ describe('discoverFeeds', () => {
       },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should find valid feeds using guess method with default URIs', async () => {
@@ -66,7 +71,7 @@ describe('discoverFeeds', () => {
       'https://example.com/feed': rss,
       'https://example.com/atom': atom,
     })
-    const value = await discoverFeeds(
+    const result = await discoverFeeds(
       { url: 'https://example.com' },
       {
         methods: { guess: { uris: ['/feed', '/atom', '/rss'] } },
@@ -94,7 +99,7 @@ describe('discoverFeeds', () => {
       },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should detect feed format from content', async () => {
@@ -110,7 +115,7 @@ describe('discoverFeeds', () => {
         </rss>
       `,
     })
-    const value = await discoverFeeds(
+    const result = await discoverFeeds(
       { url: 'https://example.com' },
       {
         methods: { guess: { uris: ['/feed'] } },
@@ -129,7 +134,7 @@ describe('discoverFeeds', () => {
       },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should work with minimal feed URIs array', async () => {
@@ -146,7 +151,7 @@ describe('discoverFeeds', () => {
       'https://example.com/feed': rss,
       'https://example.com/rss': rss,
     })
-    const value = await discoverFeeds(
+    const result = await discoverFeeds(
       { url: 'https://example.com' },
       {
         methods: { guess: { uris: urisMinimal } },
@@ -174,7 +179,7 @@ describe('discoverFeeds', () => {
       },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should work with balanced feed URIs array', async () => {
@@ -187,7 +192,7 @@ describe('discoverFeeds', () => {
         items: [],
       }),
     })
-    const value = await discoverFeeds(
+    const result = await discoverFeeds(
       { url: 'https://example.com' },
       {
         methods: { guess: { uris: urisBalanced } },
@@ -206,7 +211,7 @@ describe('discoverFeeds', () => {
       },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should work with comprehensive feed URIs array', async () => {
@@ -223,7 +228,7 @@ describe('discoverFeeds', () => {
       'https://example.com/?feed=rss': rss,
       'https://example.com/feeds/posts/default': rss,
     })
-    const value = await discoverFeeds(
+    const result = await discoverFeeds(
       { url: 'https://example.com' },
       {
         methods: { guess: { uris: urisComprehensive } },
@@ -251,7 +256,7 @@ describe('discoverFeeds', () => {
       },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should test additional base URLs alongside main baseUrl', async () => {
@@ -269,7 +274,7 @@ describe('discoverFeeds', () => {
       'https://www.example.com/feed': rss,
       'https://blog.example.com/feed': rss,
     })
-    const value = await discoverFeeds(
+    const result = await discoverFeeds(
       { url: 'https://example.com' },
       {
         methods: {
@@ -311,14 +316,14 @@ describe('discoverFeeds', () => {
       },
     ]
 
-    expect(value).toEqual(expected)
+    expect(result).toEqual(expected)
   })
 
   it('should return empty array when methods is empty array', async () => {
     const mockFetch = createMockFetch({
       'https://example.com/feed': '<rss><channel><title>Test</title></channel></rss>',
     })
-    const value = await discoverFeeds(
+    const result = await discoverFeeds(
       { url: 'https://example.com' },
       {
         methods: [],
@@ -326,7 +331,114 @@ describe('discoverFeeds', () => {
       },
     )
 
-    expect(value).toEqual([])
+    expect(result).toEqual([])
+  })
+
+  it('should fall back to guess method when initial URL fetch throws', async () => {
+    const rssContent = `
+      <?xml version="1.0"?>
+      <rss version="2.0">
+        <channel><title>Test</title></channel>
+      </rss>
+    `
+    const fetchFn: DiscoverFetchFn = (url: string) => {
+      if (url === 'https://example.com/') {
+        throw new Error('Connection refused')
+      }
+
+      return Promise.resolve({
+        url,
+        body: url === 'https://example.com/feed.xml' ? rssContent : '',
+        headers: new Headers(),
+        status: url === 'https://example.com/feed.xml' ? 200 : 404,
+        statusText: url === 'https://example.com/feed.xml' ? 'OK' : 'Not Found',
+      })
+    }
+    const result = await discoverFeeds('https://example.com/', {
+      methods: ['guess'],
+      fetchFn,
+    })
+    const expected: Array<DiscoverResult<FeedResult>> = [
+      {
+        url: 'https://example.com/feed.xml',
+        isValid: true,
+        method: 'guess',
+        format: 'rss',
+        title: 'Test',
+        description: undefined,
+        siteUrl: undefined,
+      },
+    ]
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should use custom extractFn when provided', async () => {
+    const mockFetch = createMockFetch({
+      'https://example.com/feed': '<data>opaque payload</data>',
+    })
+    const extractFn: DiscoverExtractFn<FeedResult> = ({ url }) => ({
+      url,
+      isValid: true,
+      format: 'rss',
+      title: 'Custom Extract',
+    })
+    const result = await discoverFeeds('https://example.com', {
+      methods: { guess: { uris: ['/feed'] } },
+      fetchFn: mockFetch,
+      extractFn,
+    })
+    const expected: Array<DiscoverResult<FeedResult>> = [
+      {
+        url: 'https://example.com/feed',
+        isValid: true,
+        method: 'guess',
+        format: 'rss',
+        title: 'Custom Extract',
+      },
+    ]
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should use custom resolveUrlFn when provided', async () => {
+    const rss = `
+      <rss version="2.0">
+        <channel>
+          <title>Test RSS</title>
+          <link>https://example.com</link>
+          <description>Test feed</description>
+        </channel>
+      </rss>
+    `
+    const mockFetch = createMockFetch({
+      'https://feeds.example.com/feed': rss,
+    })
+    const resolveUrlFn: DiscoverResolveUrlFn = (url, baseUrl) => {
+      const resolved = new URL(url, baseUrl)
+
+      resolved.hostname = 'feeds.example.com'
+
+      return resolved.href
+    }
+    const result = await discoverFeeds('https://example.com', {
+      methods: { guess: { uris: ['/feed'] } },
+      fetchFn: mockFetch,
+      resolveUrlFn,
+    })
+    const expected: Array<DiscoverResult<FeedResult>> = [
+      {
+        url: 'https://feeds.example.com/feed',
+        isValid: true,
+        method: 'guess',
+        format: 'rss',
+        title: 'Test RSS',
+        description: 'Test feed',
+        siteUrl: 'https://example.com/',
+      },
+    ]
+
+    expect(result).toEqual(expected)
   })
 
   describe('platform method', () => {
@@ -343,7 +455,7 @@ describe('discoverFeeds', () => {
       const mockFetch = createMockFetch({
         'https://www.reddit.com/r/programming/.rss': rss,
       })
-      const value = await discoverFeeds('https://reddit.com/r/programming', {
+      const result = await discoverFeeds('https://reddit.com/r/programming', {
         methods: ['platform'],
         fetchFn: mockFetch,
       })
@@ -360,7 +472,7 @@ describe('discoverFeeds', () => {
         },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should discover feeds when platform method specified as true in object form', async () => {
@@ -375,7 +487,7 @@ describe('discoverFeeds', () => {
         'https://github.com/owner/repo/releases.atom': atom,
         'https://github.com/owner/repo/commits.atom': atom,
       })
-      const value = await discoverFeeds('https://github.com/owner/repo', {
+      const result = await discoverFeeds('https://github.com/owner/repo', {
         methods: { platform: true },
         fetchFn: mockFetch,
       })
@@ -402,7 +514,7 @@ describe('discoverFeeds', () => {
         },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should use custom handlers when provided in object form', async () => {
@@ -422,7 +534,7 @@ describe('discoverFeeds', () => {
       const mockFetch = createMockFetch({
         'https://custom.com/my-feed.xml': rss,
       })
-      const value = await discoverFeeds('https://custom.com/page', {
+      const result = await discoverFeeds('https://custom.com/page', {
         methods: { platform: { handlers: [customHandler] } },
         fetchFn: mockFetch,
       })
@@ -438,7 +550,7 @@ describe('discoverFeeds', () => {
         },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should combine platform URIs with other method URIs', async () => {
@@ -455,7 +567,7 @@ describe('discoverFeeds', () => {
         'https://www.reddit.com/r/programming/.rss': rss,
         'https://reddit.com/feed': rss,
       })
-      const value = await discoverFeeds(
+      const result = await discoverFeeds(
         { url: 'https://reddit.com/r/programming' },
         {
           methods: { platform: true, guess: { uris: ['/feed'] } },
@@ -484,12 +596,12 @@ describe('discoverFeeds', () => {
         },
       ]
 
-      expect(value).toEqual(expected)
+      expect(result).toEqual(expected)
     })
 
     it('should return empty array when platform method not specified', async () => {
       const mockFetch = createMockFetch({})
-      const value = await discoverFeeds(
+      const result = await discoverFeeds(
         { url: 'https://reddit.com/r/programming' },
         {
           methods: { guess: { uris: [] } },
@@ -497,12 +609,12 @@ describe('discoverFeeds', () => {
         },
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array for invalid URLs', async () => {
       const mockFetch = createMockFetch({})
-      const value = await discoverFeeds(
+      const result = await discoverFeeds(
         { url: 'not-a-valid-url' },
         {
           methods: ['platform'],
@@ -510,7 +622,7 @@ describe('discoverFeeds', () => {
         },
       )
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should return empty array when platform discovery throws error', async () => {
@@ -521,12 +633,12 @@ describe('discoverFeeds', () => {
         },
       }
       const mockFetch = createMockFetch({})
-      const value = await discoverFeeds('https://example.com', {
+      const result = await discoverFeeds('https://example.com', {
         methods: { platform: { handlers: [errorHandler] } },
         fetchFn: mockFetch,
       })
 
-      expect(value).toEqual([])
+      expect(result).toEqual([])
     })
 
     it('should pass content to platform handlers', async () => {
@@ -552,67 +664,115 @@ describe('discoverFeeds', () => {
       expect(receivedContent).toBe(htmlContent)
     })
   })
+
+  describe('html method', () => {
+    it('should discover feeds from link rel=alternate elements', async () => {
+      const html = `
+        <html>
+          <head>
+            <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
+          </head>
+          <body>Example blog</body>
+        </html>
+      `
+      const rss = `
+        <rss version="2.0">
+          <channel>
+            <title>Test RSS</title>
+            <link>https://example.com</link>
+            <description>Test feed</description>
+          </channel>
+        </rss>
+      `
+      const mockFetch = createMockFetch({
+        'https://example.com': html,
+        'https://example.com/feed.xml': rss,
+      })
+      const result = await discoverFeeds('https://example.com', {
+        methods: ['html'],
+        fetchFn: mockFetch,
+      })
+      const expected: Array<DiscoverResult<FeedResult>> = [
+        {
+          url: 'https://example.com/feed.xml',
+          isValid: true,
+          method: 'html',
+          format: 'rss',
+          title: 'Test RSS',
+          description: 'Test feed',
+          siteUrl: 'https://example.com/',
+        },
+      ]
+
+      expect(result).toEqual(expected)
+    })
+  })
+
+  describe('headers method', () => {
+    it('should discover feeds from Link response header', async () => {
+      const rss = `
+        <rss version="2.0">
+          <channel>
+            <title>Test RSS</title>
+            <link>https://example.com</link>
+            <description>Test feed</description>
+          </channel>
+        </rss>
+      `
+      const fetchFn: DiscoverFetchFn = async (url: string) => ({
+        url,
+        body: url === 'https://example.com/feed.xml' ? rss : '',
+        headers:
+          url === 'https://example.com'
+            ? new Headers({
+                link: '<https://example.com/feed.xml>; rel="alternate"; type="application/rss+xml"',
+              })
+            : new Headers(),
+        status: 200,
+        statusText: 'OK',
+      })
+      const result = await discoverFeeds('https://example.com', {
+        methods: ['headers'],
+        fetchFn,
+      })
+      const expected: Array<DiscoverResult<FeedResult>> = [
+        {
+          url: 'https://example.com/feed.xml',
+          isValid: true,
+          method: 'headers',
+          format: 'rss',
+          title: 'Test RSS',
+          description: 'Test feed',
+          siteUrl: 'https://example.com/',
+        },
+      ]
+
+      expect(result).toEqual(expected)
+    })
+  })
 })
 
 describe('defaultPlatformOptions', () => {
   it('should contain handler that matches GitHub URLs', () => {
-    const value = defaultPlatformOptions.handlers.some((handler) =>
-      handler.match('https://github.com/owner/repo'),
-    )
+    const value = 'https://github.com/owner/repo'
+    const hasGithubHandler = defaultPlatformOptions.handlers.some((handler) => handler.match(value))
 
-    expect(value).toBe(true)
+    expect(hasGithubHandler).toBe(true)
   })
 
   it('should contain handler that matches Reddit URLs', () => {
-    const value = defaultPlatformOptions.handlers.some((handler) =>
-      handler.match('https://reddit.com/r/programming'),
-    )
+    const value = 'https://reddit.com/r/programming'
+    const hasRedditHandler = defaultPlatformOptions.handlers.some((handler) => handler.match(value))
 
-    expect(value).toBe(true)
+    expect(hasRedditHandler).toBe(true)
   })
 
   it('should contain handler that matches YouTube URLs', () => {
-    const value = defaultPlatformOptions.handlers.some((handler) =>
-      handler.match('https://youtube.com/@channel'),
+    const value = 'https://youtube.com/@channel'
+    const hasYoutubeHandler = defaultPlatformOptions.handlers.some((handler) =>
+      handler.match(value),
     )
 
-    expect(value).toBe(true)
-  })
-
-  it('should fall back to guess method when initial URL fetch throws', async () => {
-    const rssContent = `<?xml version="1.0"?>
-      <rss version="2.0">
-        <channel><title>Test</title></channel>
-      </rss>`
-    const fetchFn: DiscoverFetchFn = (url: string) => {
-      if (url === 'https://example.com/') {
-        throw new Error('Connection refused')
-      }
-
-      return Promise.resolve({
-        url,
-        body: url === 'https://example.com/feed.xml' ? rssContent : '',
-        headers: new Headers(),
-        status: url === 'https://example.com/feed.xml' ? 200 : 404,
-        statusText: url === 'https://example.com/feed.xml' ? 'OK' : 'Not Found',
-      })
-    }
-    const value = await discoverFeeds('https://example.com/', {
-      methods: ['guess'],
-      fetchFn,
-    })
-    const expected: Array<DiscoverResult<FeedResult>> = [
-      {
-        url: 'https://example.com/feed.xml',
-        isValid: true,
-        method: 'guess',
-        format: 'rss',
-        title: 'Test',
-        description: undefined,
-        siteUrl: undefined,
-      },
-    ]
-
-    expect(value).toEqual(expected)
+    expect(hasYoutubeHandler).toBe(true)
   })
 })

--- a/src/feeds/platform/handlers/acast.test.ts
+++ b/src/feeds/platform/handlers/acast.test.ts
@@ -3,16 +3,16 @@ import { acastHandler } from './acast.js'
 
 describe('acastHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://shows.acast.com/my-dad-wrote-a-porno', true],
-      ['https://shows.acast.com', true],
-      ['https://play.acast.com/s/my-dad-wrote-a-porno', true],
-      ['https://embed.acast.com/my-dad-wrote-a-porno', true],
-      ['https://acast.com/show', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://shows.acast.com/my-dad-wrote-a-porno'],
+      [true, 'https://shows.acast.com'],
+      [true, 'https://play.acast.com/s/my-dad-wrote-a-porno'],
+      [true, 'https://embed.acast.com/my-dad-wrote-a-porno'],
+      [false, 'https://acast.com/show'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(acastHandler.match(url)).toBe(expected)
     })
 
@@ -80,6 +80,23 @@ describe('acastHandler', () => {
       ]
 
       expect(acastHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return empty array for play.acast.com/s without slug', () => {
+      const value = 'https://play.acast.com/s'
+
+      expect(acastHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return empty array for excluded path on embed.acast.com', () => {
+      const value = 'https://embed.acast.com/discover'
+
+      expect(acastHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/ameblo.test.ts
+++ b/src/feeds/platform/handlers/ameblo.test.ts
@@ -3,14 +3,14 @@ import { amebloHandler } from './ameblo.js'
 
 describe('amebloHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://ameblo.jp/shibuya', true],
-      ['https://www.ameblo.jp/user', true],
-      ['https://ameblo.jp', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://ameblo.jp/shibuya'],
+      [true, 'https://www.ameblo.jp/user'],
+      [true, 'https://ameblo.jp'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(amebloHandler.match(url)).toBe(expected)
     })
 
@@ -70,6 +70,11 @@ describe('amebloHandler', () => {
       const value = 'https://ameblo.jp/hashtag'
 
       expect(amebloHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/applePodcasts.test.ts
+++ b/src/feeds/platform/handlers/applePodcasts.test.ts
@@ -3,35 +3,39 @@ import { applePodcastsHandler } from './applePodcasts.js'
 
 describe('applePodcastsHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://podcasts.apple.com/us/podcast/the-daily/id1200361736', true],
-      ['https://podcasts.apple.com/gb/podcast/some-podcast/id123456789', true],
-      ['https://podcasts.apple.com/de/podcast/podcast-name/id987654321', true],
-      ['https://podcasts.apple.com/us/podcast/id1200361736', true],
-      ['https://podcasts.apple.com/podcast/the-daily/id1200361736', true],
-      ['https://podcasts.apple.com/podcast/id1200361736', true],
-      ['https://podcasts.apple.com/us/artist/the-new-york-times/id121664449', false],
-      ['https://podcasts.apple.com/us/charts', false],
-      ['https://podcasts.apple.com/', false],
-      ['https://music.apple.com/us/album/something/id123', false],
-      ['https://example.com/us/podcast/name/id123', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://podcasts.apple.com/us/podcast/the-daily/id1200361736'],
+      [true, 'https://podcasts.apple.com/gb/podcast/some-podcast/id123456789'],
+      [true, 'https://podcasts.apple.com/de/podcast/podcast-name/id987654321'],
+      [true, 'https://podcasts.apple.com/us/podcast/id1200361736'],
+      [true, 'https://podcasts.apple.com/podcast/the-daily/id1200361736'],
+      [true, 'https://podcasts.apple.com/podcast/id1200361736'],
+      [false, 'https://podcasts.apple.com/us/artist/the-new-york-times/id121664449'],
+      [false, 'https://podcasts.apple.com/us/charts'],
+      [false, 'https://podcasts.apple.com/'],
+      [false, 'https://music.apple.com/us/album/something/id123'],
+      [false, 'https://example.com/us/podcast/name/id123'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(applePodcastsHandler.match(url)).toBe(expected)
+    })
+
+    it('should return false for invalid URL', () => {
+      expect(applePodcastsHandler.match('not-a-url')).toBe(false)
     })
   })
 
   describe('resolve', () => {
     const contentWithFeedUrl = `
-			{"feedUrl":"https://feeds.simplecast.com/Sl5CSM3S","name":"The Daily"}
+			{"feedUrl":"https://feeds.example.com/the-daily","name":"The Daily"}
 		`
 
     it('should return feed URL when found in content', () => {
       const value = 'https://podcasts.apple.com/us/podcast/the-daily/id1200361736'
       const expected = [
         {
-          uri: 'https://feeds.simplecast.com/Sl5CSM3S',
+          uri: 'https://feeds.example.com/the-daily',
           hint: { key: 'apple-podcasts:podcast', label: 'Podcast' },
         },
       ]
@@ -63,6 +67,10 @@ describe('applePodcastsHandler', () => {
       ]
 
       expect(applePodcastsHandler.resolve(value, content)).toEqual(expected)
+    })
+
+    it('should return empty array for invalid URL', () => {
+      expect(applePodcastsHandler.resolve('not-a-url')).toEqual([])
     })
   })
 })

--- a/src/feeds/platform/handlers/arena.test.ts
+++ b/src/feeds/platform/handlers/arena.test.ts
@@ -3,14 +3,14 @@ import { arenaHandler } from './arena.js'
 
 describe('arenaHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://www.are.na/charles-broskoski', true],
-      ['https://are.na/meg-miller/good-sign-offs', true],
-      ['https://are.na', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://www.are.na/charles-broskoski'],
+      [true, 'https://are.na/meg-miller/good-sign-offs'],
+      [true, 'https://are.na'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(arenaHandler.match(url)).toBe(expected)
     })
 
@@ -90,6 +90,11 @@ describe('arenaHandler', () => {
       ]
 
       expect(arenaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/artstation.test.ts
+++ b/src/feeds/platform/handlers/artstation.test.ts
@@ -3,15 +3,15 @@ import { artstationHandler } from './artstation.js'
 
 describe('artstationHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://www.artstation.com/rossdraws', true],
-      ['https://artstation.com/user', true],
-      ['https://artstation.com', true],
-      ['https://rossdraws.artstation.com', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://www.artstation.com/rossdraws'],
+      [true, 'https://artstation.com/user'],
+      [true, 'https://artstation.com'],
+      [true, 'https://rossdraws.artstation.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(artstationHandler.match(url)).toBe(expected)
     })
 
@@ -47,6 +47,18 @@ describe('artstationHandler', () => {
 
     it('should return feed URL for subdomain form', () => {
       const value = 'https://rossdraws.artstation.com'
+      const expected = [
+        {
+          uri: 'https://www.artstation.com/rossdraws.rss',
+          hint: { key: 'artstation:portfolio', label: 'Portfolio' },
+        },
+      ]
+
+      expect(artstationHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL for subdomain form regardless of subpath', () => {
+      const value = 'https://rossdraws.artstation.com/albums/all'
       const expected = [
         {
           uri: 'https://www.artstation.com/rossdraws.rss',
@@ -93,6 +105,11 @@ describe('artstationHandler', () => {
       const value = 'https://www.artstation.com/jobs'
 
       expect(artstationHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/audioboom.test.ts
+++ b/src/feeds/platform/handlers/audioboom.test.ts
@@ -3,14 +3,14 @@ import { audioboomHandler } from './audioboom.js'
 
 describe('audioboomHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://audioboom.com/channels/5071123', true],
-      ['https://www.audioboom.com/channels/5071123', true],
-      ['https://audioboom.com', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://audioboom.com/channels/5071123'],
+      [true, 'https://www.audioboom.com/channels/5071123'],
+      [true, 'https://audioboom.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(audioboomHandler.match(url)).toBe(expected)
     })
 
@@ -54,6 +54,11 @@ describe('audioboomHandler', () => {
       const value = 'https://audioboom.com/posts/12345'
 
       expect(audioboomHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/bearblog.test.ts
+++ b/src/feeds/platform/handlers/bearblog.test.ts
@@ -3,15 +3,15 @@ import { bearblogHandler } from './bearblog.js'
 
 describe('bearblogHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://herman.bearblog.dev', true],
-      ['https://blog.example.bearblog.dev', true],
-      ['https://bearblog.dev', true],
-      ['https://www.bearblog.dev', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://herman.bearblog.dev'],
+      [true, 'https://blog.example.bearblog.dev'],
+      [true, 'https://bearblog.dev'],
+      [true, 'https://www.bearblog.dev'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(bearblogHandler.match(url)).toBe(expected)
     })
 
@@ -91,6 +91,11 @@ describe('bearblogHandler', () => {
       ]
 
       expect(bearblogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/behance.test.ts
+++ b/src/feeds/platform/handlers/behance.test.ts
@@ -3,15 +3,15 @@ import { behanceHandler } from './behance.js'
 
 describe('behanceHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://www.behance.net/johndoe', true],
-      ['https://behance.net/johndoe', true],
-      ['https://www.behance.net/', true],
-      ['https://www.behance.net/search', true],
-      ['https://example.com/behance', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://www.behance.net/johndoe'],
+      [true, 'https://behance.net/johndoe'],
+      [true, 'https://www.behance.net/'],
+      [true, 'https://www.behance.net/search'],
+      [false, 'https://example.com/behance'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(behanceHandler.match(url)).toBe(expected)
     })
 
@@ -69,16 +69,14 @@ describe('behanceHandler', () => {
       expect(behanceHandler.resolve(value)).toEqual(expected)
     })
 
-    it('should return empty array for excluded paths', () => {
-      const values = [
-        'https://www.behance.net/search',
-        'https://www.behance.net/blog',
-        'https://www.behance.net/about',
-      ]
+    const excludedValues: Array<string> = [
+      'https://www.behance.net/search',
+      'https://www.behance.net/blog',
+      'https://www.behance.net/about',
+    ]
 
-      for (const value of values) {
-        expect(behanceHandler.resolve(value)).toEqual([])
-      }
+    it.each(excludedValues)('should return empty array for %s', (value) => {
+      expect(behanceHandler.resolve(value)).toEqual([])
     })
 
     it('should return featured projects + Featured-by-Adobe feed for homepage', () => {
@@ -117,6 +115,11 @@ describe('behanceHandler', () => {
       const value = 'https://www.behance.net/johndoe/projects'
 
       expect(behanceHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/blogspot.test.ts
+++ b/src/feeds/platform/handlers/blogspot.test.ts
@@ -1,22 +1,23 @@
 import { describe, expect, it } from 'bun:test'
+import type { DiscoverUriEntry } from '../../../common/types.js'
 import { blogspotHandler } from './blogspot.js'
 
 describe('blogspotHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://example.blogspot.com', true],
-      ['https://blog.example.blogspot.com', true],
-      ['https://example.blogspot.co.uk', true],
-      ['https://example.blogspot.de', true],
-      ['https://example.blogspot.fr', true],
-      ['https://example.blogspot.in', true],
-      ['https://example.blogspot.jp', true],
-      ['https://example.blogspot.com.br', true],
-      ['https://blogspot.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://example.blogspot.com'],
+      [true, 'https://blog.example.blogspot.com'],
+      [true, 'https://example.blogspot.co.uk'],
+      [true, 'https://example.blogspot.de'],
+      [true, 'https://example.blogspot.fr'],
+      [true, 'https://example.blogspot.in'],
+      [true, 'https://example.blogspot.jp'],
+      [true, 'https://example.blogspot.com.br'],
+      [false, 'https://blogspot.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(blogspotHandler.match(url)).toBe(expected)
     })
 
@@ -139,11 +140,67 @@ describe('blogspotHandler', () => {
     it('should not emit per-post feeds for non-post URLs even with content', () => {
       const value = 'https://blog.blogspot.com/'
       const content = '<link href="https://blog.blogspot.com/feeds/1234567890/comments/default" />'
-      const result = blogspotHandler.resolve(value, content) as Array<{ hint?: { key: string } }>
+      const expected: Array<DiscoverUriEntry> = [
+        {
+          uri: 'https://blog.blogspot.com/feeds/posts/default',
+          hint: { key: 'blogspot:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: 'https://blog.blogspot.com/feeds/posts/default?alt=rss',
+          hint: { key: 'blogspot:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://blog.blogspot.com/feeds/posts/summary',
+          hint: { key: 'blogspot:posts-summary-atom', label: 'Posts summary (Atom)' },
+        },
+        {
+          uri: 'https://blog.blogspot.com/feeds/posts/summary?alt=rss',
+          hint: { key: 'blogspot:posts-summary-rss', label: 'Posts summary (RSS)' },
+        },
+        {
+          uri: 'https://blog.blogspot.com/feeds/comments/default',
+          hint: { key: 'blogspot:comments-atom', label: 'Comments (Atom)' },
+        },
+        {
+          uri: 'https://blog.blogspot.com/feeds/comments/default?alt=rss',
+          hint: { key: 'blogspot:comments-rss', label: 'Comments (RSS)' },
+        },
+      ]
 
-      for (const entry of result) {
-        expect(entry.hint?.key?.startsWith('blogspot:post-comments')).toBe(false)
-      }
+      expect(blogspotHandler.resolve(value, content)).toEqual(expected)
+    })
+
+    it('should not emit per-post feeds for post URL when content has no comments feed link', () => {
+      const value = 'https://blog.blogspot.com/2024/01/some-post.html'
+      const content = '<html><head><title>Some post</title></head></html>'
+      const expected: Array<DiscoverUriEntry> = [
+        {
+          uri: 'https://blog.blogspot.com/feeds/posts/default',
+          hint: { key: 'blogspot:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: 'https://blog.blogspot.com/feeds/posts/default?alt=rss',
+          hint: { key: 'blogspot:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: 'https://blog.blogspot.com/feeds/posts/summary',
+          hint: { key: 'blogspot:posts-summary-atom', label: 'Posts summary (Atom)' },
+        },
+        {
+          uri: 'https://blog.blogspot.com/feeds/posts/summary?alt=rss',
+          hint: { key: 'blogspot:posts-summary-rss', label: 'Posts summary (RSS)' },
+        },
+        {
+          uri: 'https://blog.blogspot.com/feeds/comments/default',
+          hint: { key: 'blogspot:comments-atom', label: 'Comments (Atom)' },
+        },
+        {
+          uri: 'https://blog.blogspot.com/feeds/comments/default?alt=rss',
+          hint: { key: 'blogspot:comments-rss', label: 'Comments (RSS)' },
+        },
+      ]
+
+      expect(blogspotHandler.resolve(value, content)).toEqual(expected)
     })
 
     it('should include label feeds when on label page', () => {
@@ -184,6 +241,11 @@ describe('blogspotHandler', () => {
       ]
 
       expect(blogspotHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/bluesky.test.ts
+++ b/src/feeds/platform/handlers/bluesky.test.ts
@@ -3,13 +3,13 @@ import { blueskyHandler } from './bluesky.js'
 
 describe('blueskyHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://bsky.app/profile/user.bsky.social', true],
-      ['https://www.bsky.app/profile/user.bsky.social', true],
-      ['https://twitter.com/user', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://bsky.app/profile/user.bsky.social'],
+      [true, 'https://www.bsky.app/profile/user.bsky.social'],
+      [false, 'https://twitter.com/user'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(blueskyHandler.match(url)).toBe(expected)
     })
 
@@ -79,7 +79,7 @@ describe('blueskyHandler', () => {
       expect(blueskyHandler.resolve(value)).toEqual(expected)
     })
 
-    it('should return empty array for /profile/user/followers subpath extraction', () => {
+    it('should resolve /profile/user/followers using first segment as handle', () => {
       const value = 'https://bsky.app/profile/user.bsky.social/followers'
       const expected = [
         {
@@ -101,6 +101,11 @@ describe('blueskyHandler', () => {
       ]
 
       expect(blueskyHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/bookwyrm.test.ts
+++ b/src/feeds/platform/handlers/bookwyrm.test.ts
@@ -18,6 +18,10 @@ describe('bookwyrmHandler', () => {
     it('should return false for non-BookWyrm generator', () => {
       expect(isBookwyrmHtml(otherHtml)).toBe(false)
     })
+
+    it('should return false for empty content', () => {
+      expect(isBookwyrmHtml('')).toBe(false)
+    })
   })
 
   describe('match', () => {
@@ -43,35 +47,52 @@ describe('bookwyrmHandler', () => {
   })
 
   describe('resolve', () => {
-    const baseFeeds = (user: string) => [
-      {
-        uri: `https://bookwyrm.social/user/${user}/rss`,
-        hint: { key: 'bookwyrm:activity', label: 'Activity' },
-      },
-      {
-        uri: `https://bookwyrm.social/user/${user}/rss-reviews`,
-        hint: { key: 'bookwyrm:reviews', label: 'Reviews' },
-      },
-      {
-        uri: `https://bookwyrm.social/user/${user}/rss-quotes`,
-        hint: { key: 'bookwyrm:quotes', label: 'Quotes' },
-      },
-      {
-        uri: `https://bookwyrm.social/user/${user}/rss-comments`,
-        hint: { key: 'bookwyrm:comments', label: 'Comments' },
-      },
-    ]
-
     it('should return activity, reviews, quotes, and comments feeds for profile', () => {
       const value = 'https://bookwyrm.social/user/mouse'
+      const expected = [
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss',
+          hint: { key: 'bookwyrm:activity', label: 'Activity' },
+        },
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss-reviews',
+          hint: { key: 'bookwyrm:reviews', label: 'Reviews' },
+        },
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss-quotes',
+          hint: { key: 'bookwyrm:quotes', label: 'Quotes' },
+        },
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss-comments',
+          hint: { key: 'bookwyrm:comments', label: 'Comments' },
+        },
+      ]
 
-      expect(bookwyrmHandler.resolve(value)).toEqual(baseFeeds('mouse'))
+      expect(bookwyrmHandler.resolve(value)).toEqual(expected)
     })
 
     it('should return all four feeds regardless of subpath', () => {
       const value = 'https://bookwyrm.social/user/mouse/books'
+      const expected = [
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss',
+          hint: { key: 'bookwyrm:activity', label: 'Activity' },
+        },
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss-reviews',
+          hint: { key: 'bookwyrm:reviews', label: 'Reviews' },
+        },
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss-quotes',
+          hint: { key: 'bookwyrm:quotes', label: 'Quotes' },
+        },
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss-comments',
+          hint: { key: 'bookwyrm:comments', label: 'Comments' },
+        },
+      ]
 
-      expect(bookwyrmHandler.resolve(value)).toEqual(baseFeeds('mouse'))
+      expect(bookwyrmHandler.resolve(value)).toEqual(expected)
     })
 
     it('should prepend shelf feed for /user/{user}/books/{shelf}', () => {
@@ -81,7 +102,22 @@ describe('bookwyrmHandler', () => {
           uri: 'https://bookwyrm.social/user/mouse/books/read/rss',
           hint: { key: 'bookwyrm:shelf', label: 'Shelf' },
         },
-        ...baseFeeds('mouse'),
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss',
+          hint: { key: 'bookwyrm:activity', label: 'Activity' },
+        },
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss-reviews',
+          hint: { key: 'bookwyrm:reviews', label: 'Reviews' },
+        },
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss-quotes',
+          hint: { key: 'bookwyrm:quotes', label: 'Quotes' },
+        },
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss-comments',
+          hint: { key: 'bookwyrm:comments', label: 'Comments' },
+        },
       ]
 
       expect(bookwyrmHandler.resolve(value)).toEqual(expected)
@@ -94,7 +130,22 @@ describe('bookwyrmHandler', () => {
           uri: 'https://bookwyrm.social/user/mouse/shelf/to-read/rss',
           hint: { key: 'bookwyrm:shelf', label: 'Shelf' },
         },
-        ...baseFeeds('mouse'),
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss',
+          hint: { key: 'bookwyrm:activity', label: 'Activity' },
+        },
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss-reviews',
+          hint: { key: 'bookwyrm:reviews', label: 'Reviews' },
+        },
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss-quotes',
+          hint: { key: 'bookwyrm:quotes', label: 'Quotes' },
+        },
+        {
+          uri: 'https://bookwyrm.social/user/mouse/rss-comments',
+          hint: { key: 'bookwyrm:comments', label: 'Comments' },
+        },
       ]
 
       expect(bookwyrmHandler.resolve(value)).toEqual(expected)

--- a/src/feeds/platform/handlers/buttondown.test.ts
+++ b/src/feeds/platform/handlers/buttondown.test.ts
@@ -3,16 +3,16 @@ import { buttondownHandler } from './buttondown.js'
 
 describe('buttondownHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://buttondown.com/cassidoo', true],
-      ['https://www.buttondown.com/user', true],
-      ['https://buttondown.com', true],
-      ['https://buttondown.email/cassidoo', true],
-      ['https://www.buttondown.email/cassidoo', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://buttondown.com/cassidoo'],
+      [true, 'https://www.buttondown.com/user'],
+      [true, 'https://buttondown.com'],
+      [true, 'https://buttondown.email/cassidoo'],
+      [true, 'https://www.buttondown.email/cassidoo'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(buttondownHandler.match(url)).toBe(expected)
     })
 
@@ -68,6 +68,11 @@ describe('buttondownHandler', () => {
       ]
 
       expect(buttondownHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/buzzsprout.test.ts
+++ b/src/feeds/platform/handlers/buzzsprout.test.ts
@@ -3,14 +3,14 @@ import { buzzsproutHandler } from './buzzsprout.js'
 
 describe('buzzsproutHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://www.buzzsprout.com/1765577', true],
-      ['https://buzzsprout.com/1765577', true],
-      ['https://buzzsprout.com', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://www.buzzsprout.com/1765577'],
+      [true, 'https://buzzsprout.com/1765577'],
+      [true, 'https://buzzsprout.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(buzzsproutHandler.match(url)).toBe(expected)
     })
 
@@ -54,6 +54,11 @@ describe('buzzsproutHandler', () => {
       const value = 'https://www.buzzsprout.com/about'
 
       expect(buzzsproutHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/codeberg.test.ts
+++ b/src/feeds/platform/handlers/codeberg.test.ts
@@ -3,18 +3,18 @@ import { codebergHandler } from './codeberg.js'
 
 describe('codebergHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://codeberg.org/forgejo', true],
-      ['https://codeberg.org/forgejo/forgejo', true],
-      ['https://www.codeberg.org/user', true],
-      ['https://gitea.com/gitea', true],
-      ['https://gitea.com/gitea/go-sdk', true],
-      ['https://www.gitea.com/user', true],
-      ['https://github.com/user/repo', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://codeberg.org/forgejo'],
+      [true, 'https://codeberg.org/forgejo/forgejo'],
+      [true, 'https://www.codeberg.org/user'],
+      [true, 'https://gitea.com/gitea'],
+      [true, 'https://gitea.com/gitea/go-sdk'],
+      [true, 'https://www.gitea.com/user'],
+      [false, 'https://github.com/user/repo'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(codebergHandler.match(url)).toBe(expected)
     })
 
@@ -215,30 +215,31 @@ describe('codebergHandler', () => {
       expect(codebergHandler.resolve(value)).toEqual([])
     })
 
-    it('should return empty array for excluded paths', () => {
-      const values = [
-        'https://codeberg.org/explore',
-        'https://codeberg.org/admin',
-        'https://codeberg.org/user',
-        'https://codeberg.org/assets',
-        'https://codeberg.org/-',
-      ]
+    const excludedValues: Array<string> = [
+      'https://codeberg.org/explore',
+      'https://codeberg.org/admin',
+      'https://codeberg.org/user',
+      'https://codeberg.org/assets',
+      'https://codeberg.org/-',
+    ]
 
-      for (const value of values) {
-        expect(codebergHandler.resolve(value)).toEqual([])
-      }
+    it.each(excludedValues)('should return empty array for %s', (value) => {
+      expect(codebergHandler.resolve(value)).toEqual([])
     })
 
-    it('should return empty array for excluded paths with repo segment', () => {
-      const values = [
-        'https://codeberg.org/explore/repos',
-        'https://codeberg.org/admin/users',
-        'https://codeberg.org/user/login',
-      ]
+    const excludedRepoValues: Array<string> = [
+      'https://codeberg.org/explore/repos',
+      'https://codeberg.org/admin/users',
+      'https://codeberg.org/user/login',
+    ]
 
-      for (const value of values) {
-        expect(codebergHandler.resolve(value)).toEqual([])
-      }
+    it.each(excludedRepoValues)('should return empty array for %s', (value) => {
+      expect(codebergHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/csdn.test.ts
+++ b/src/feeds/platform/handlers/csdn.test.ts
@@ -3,13 +3,13 @@ import { csdnHandler } from './csdn.js'
 
 describe('csdnHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://blog.csdn.net/csdnnews', true],
-      ['https://www.csdn.net/', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://blog.csdn.net/csdnnews'],
+      [false, 'https://www.csdn.net/'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(csdnHandler.match(url)).toBe(expected)
     })
 
@@ -47,6 +47,11 @@ describe('csdnHandler', () => {
       const value = 'https://blog.csdn.net/'
 
       expect(csdnHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/dailymotion.test.ts
+++ b/src/feeds/platform/handlers/dailymotion.test.ts
@@ -3,16 +3,16 @@ import { dailymotionHandler } from './dailymotion.js'
 
 describe('dailymotionHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://www.dailymotion.com/bfmtv', true],
-      ['https://dailymotion.com/nasa', true],
-      ['https://www.dailymotion.com/playlist/x7vjjm', true],
-      ['https://www.dailymotion.com/signin', true],
-      ['https://www.dailymotion.com/', true],
-      ['https://example.com/dailymotion', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://www.dailymotion.com/bfmtv'],
+      [true, 'https://dailymotion.com/nasa'],
+      [true, 'https://www.dailymotion.com/playlist/x7vjjm'],
+      [true, 'https://www.dailymotion.com/signin'],
+      [true, 'https://www.dailymotion.com/'],
+      [false, 'https://example.com/dailymotion'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(dailymotionHandler.match(url)).toBe(expected)
     })
 
@@ -70,19 +70,17 @@ describe('dailymotionHandler', () => {
       expect(dailymotionHandler.resolve(value)).toEqual(expected)
     })
 
-    it('should return empty array for excluded paths', () => {
-      const values = [
-        'https://www.dailymotion.com/signin',
-        'https://www.dailymotion.com/upload',
-        'https://www.dailymotion.com/settings',
-        'https://www.dailymotion.com/video',
-        'https://www.dailymotion.com/login',
-        'https://www.dailymotion.com/live',
-      ]
+    const excludedValues: Array<string> = [
+      'https://www.dailymotion.com/signin',
+      'https://www.dailymotion.com/upload',
+      'https://www.dailymotion.com/settings',
+      'https://www.dailymotion.com/video',
+      'https://www.dailymotion.com/login',
+      'https://www.dailymotion.com/live',
+    ]
 
-      for (const value of values) {
-        expect(dailymotionHandler.resolve(value)).toEqual([])
-      }
+    it.each(excludedValues)('should return empty array for %s', (value) => {
+      expect(dailymotionHandler.resolve(value)).toEqual([])
     })
 
     it('should return trending feed for homepage', () => {
@@ -119,6 +117,11 @@ describe('dailymotionHandler', () => {
       ]
 
       expect(dailymotionHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/deviantart.test.ts
+++ b/src/feeds/platform/handlers/deviantart.test.ts
@@ -3,13 +3,13 @@ import { deviantartHandler } from './deviantart.js'
 
 describe('deviantartHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://deviantart.com/yuumei', true],
-      ['https://www.deviantart.com/yuumei', true],
-      ['https://example.com/yuumei', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://deviantart.com/yuumei'],
+      [true, 'https://www.deviantart.com/yuumei'],
+      [false, 'https://example.com/yuumei'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(deviantartHandler.match(url)).toBe(expected)
     })
 
@@ -115,17 +115,15 @@ describe('deviantartHandler', () => {
       expect(deviantartHandler.resolve(value)).toEqual(expected)
     })
 
-    it('should return empty array for excluded paths', () => {
-      const excludedUrls = [
-        'https://deviantart.com/about',
-        'https://deviantart.com/join',
-        'https://deviantart.com/search',
-        'https://deviantart.com/shop',
-      ]
+    const excludedValues: Array<string> = [
+      'https://deviantart.com/about',
+      'https://deviantart.com/join',
+      'https://deviantart.com/search',
+      'https://deviantart.com/shop',
+    ]
 
-      for (const url of excludedUrls) {
-        expect(deviantartHandler.resolve(url)).toEqual([])
-      }
+    it.each(excludedValues)('should return empty array for %s', (value) => {
+      expect(deviantartHandler.resolve(value)).toEqual([])
     })
 
     it('should return curated daily-deviations feed', () => {
@@ -142,6 +140,30 @@ describe('deviantartHandler', () => {
 
     it('should return popular feed', () => {
       const value = 'https://deviantart.com/popular'
+      const expected = [
+        {
+          uri: 'https://backend.deviantart.com/rss.xml?type=deviation&q=boost%3Apopular',
+          hint: { key: 'deviantart:popular', label: 'Popular' },
+        },
+      ]
+
+      expect(deviantartHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return curated daily-deviations feed for trailing slash', () => {
+      const value = 'https://deviantart.com/daily-deviations/'
+      const expected = [
+        {
+          uri: 'https://backend.deviantart.com/rss.xml?q=special%3Add',
+          hint: { key: 'deviantart:daily-deviations', label: 'Daily Deviations' },
+        },
+      ]
+
+      expect(deviantartHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return popular feed for trailing slash', () => {
+      const value = 'https://deviantart.com/popular/'
       const expected = [
         {
           uri: 'https://backend.deviantart.com/rss.xml?type=deviation&q=boost%3Apopular',
@@ -180,6 +202,11 @@ describe('deviantartHandler', () => {
       ]
 
       expect(deviantartHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/devto.test.ts
+++ b/src/feeds/platform/handlers/devto.test.ts
@@ -3,13 +3,13 @@ import { devtoHandler } from './devto.js'
 
 describe('devtoHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://dev.to/thepracticaldev', true],
-      ['https://www.dev.to/thepracticaldev', true],
-      ['https://example.com/thepracticaldev', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://dev.to/thepracticaldev'],
+      [true, 'https://www.dev.to/thepracticaldev'],
+      [false, 'https://example.com/thepracticaldev'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(devtoHandler.match(url)).toBe(expected)
     })
 
@@ -61,17 +61,15 @@ describe('devtoHandler', () => {
       expect(devtoHandler.resolve(value)).toEqual(expected)
     })
 
-    it('should return empty array for excluded paths', () => {
-      const excludedUrls = [
-        'https://dev.to/about',
-        'https://dev.to/search',
-        'https://dev.to/top',
-        'https://dev.to/settings',
-      ]
+    const excludedValues: Array<string> = [
+      'https://dev.to/about',
+      'https://dev.to/search',
+      'https://dev.to/top',
+      'https://dev.to/settings',
+    ]
 
-      for (const url of excludedUrls) {
-        expect(devtoHandler.resolve(url)).toEqual([])
-      }
+    it.each(excludedValues)('should return empty array for %s', (value) => {
+      expect(devtoHandler.resolve(value)).toEqual([])
     })
 
     it('should handle usernames with underscores', () => {
@@ -126,6 +124,11 @@ describe('devtoHandler', () => {
       ]
 
       expect(devtoHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/discourse.test.ts
+++ b/src/feeds/platform/handlers/discourse.test.ts
@@ -19,6 +19,10 @@ describe('discourseHandler', () => {
     it('should return false for non-Discourse generator', () => {
       expect(isDiscourseHtml(otherHtml)).toBe(false)
     })
+
+    it('should return false for empty content', () => {
+      expect(isDiscourseHtml('')).toBe(false)
+    })
   })
 
   describe('match', () => {
@@ -135,18 +139,31 @@ describe('discourseHandler', () => {
       expect(discourseHandler.resolve(value)).toEqual(expected)
     })
 
-    it('should pass through period via /top/{period} path', () => {
-      for (const period of ['daily', 'weekly', 'monthly', 'quarterly', 'yearly', 'all']) {
-        const value = `https://users.rust-lang.org/top/${period}`
-        const expected = [
-          {
-            uri: `https://users.rust-lang.org/top.rss?period=${period}`,
-            hint: { key: 'discourse:top', label: 'Top' },
-          },
-        ]
+    const topPeriodValues: Array<[string, string]> = [
+      ['https://users.rust-lang.org/top/daily', 'https://users.rust-lang.org/top.rss?period=daily'],
+      [
+        'https://users.rust-lang.org/top/weekly',
+        'https://users.rust-lang.org/top.rss?period=weekly',
+      ],
+      [
+        'https://users.rust-lang.org/top/monthly',
+        'https://users.rust-lang.org/top.rss?period=monthly',
+      ],
+      [
+        'https://users.rust-lang.org/top/quarterly',
+        'https://users.rust-lang.org/top.rss?period=quarterly',
+      ],
+      [
+        'https://users.rust-lang.org/top/yearly',
+        'https://users.rust-lang.org/top.rss?period=yearly',
+      ],
+      ['https://users.rust-lang.org/top/all', 'https://users.rust-lang.org/top.rss?period=all'],
+    ]
 
-        expect(discourseHandler.resolve(value)).toEqual(expected)
-      }
+    it.each(topPeriodValues)('should pass through period for %s', (value, uri) => {
+      const expected = [{ uri, hint: { key: 'discourse:top', label: 'Top' } }]
+
+      expect(discourseHandler.resolve(value)).toEqual(expected)
     })
 
     it('should pass through period via ?period= query param', () => {
@@ -154,6 +171,18 @@ describe('discourseHandler', () => {
       const expected = [
         {
           uri: 'https://users.rust-lang.org/top.rss?period=weekly',
+          hint: { key: 'discourse:top', label: 'Top' },
+        },
+      ]
+
+      expect(discourseHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should prefer path period over ?period= query param', () => {
+      const value = 'https://users.rust-lang.org/top/daily?period=weekly'
+      const expected = [
+        {
+          uri: 'https://users.rust-lang.org/top.rss?period=daily',
           hint: { key: 'discourse:top', label: 'Top' },
         },
       ]

--- a/src/feeds/platform/handlers/douban.test.ts
+++ b/src/feeds/platform/handlers/douban.test.ts
@@ -3,16 +3,16 @@ import { doubanHandler } from './douban.js'
 
 describe('doubanHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://www.douban.com/', true],
-      ['https://douban.com/', true],
-      ['https://book.douban.com/', true],
-      ['https://movie.douban.com/', true],
-      ['https://music.douban.com/', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://www.douban.com/'],
+      [true, 'https://douban.com/'],
+      [true, 'https://book.douban.com/'],
+      [true, 'https://movie.douban.com/'],
+      [true, 'https://music.douban.com/'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(doubanHandler.match(url)).toBe(expected)
     })
 
@@ -114,6 +114,11 @@ describe('doubanHandler', () => {
       ]
 
       expect(doubanHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/dreamwidth.test.ts
+++ b/src/feeds/platform/handlers/dreamwidth.test.ts
@@ -3,17 +3,17 @@ import { dreamwidthHandler } from './dreamwidth.js'
 
 describe('dreamwidthHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://news.dreamwidth.org', true],
-      ['https://blog.example.dreamwidth.org', true],
-      ['https://www.dreamwidth.org/users/dw_news', true],
-      ['https://www.dreamwidth.org/~dw-news', true],
-      ['https://www.dreamwidth.org', false],
-      ['https://dreamwidth.org', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://news.dreamwidth.org'],
+      [true, 'https://blog.example.dreamwidth.org'],
+      [true, 'https://www.dreamwidth.org/users/dw_news'],
+      [true, 'https://www.dreamwidth.org/~dw-news'],
+      [false, 'https://www.dreamwidth.org'],
+      [false, 'https://dreamwidth.org'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(dreamwidthHandler.match(url)).toBe(expected)
     })
 
@@ -133,6 +133,11 @@ describe('dreamwidthHandler', () => {
       ]
 
       expect(dreamwidthHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/exblog.test.ts
+++ b/src/feeds/platform/handlers/exblog.test.ts
@@ -3,14 +3,14 @@ import { exblogHandler } from './exblog.js'
 
 describe('exblogHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://petitcc.exblog.jp', true],
-      ['https://blog.example.exblog.jp', true],
-      ['https://exblog.jp', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://petitcc.exblog.jp'],
+      [true, 'https://blog.example.exblog.jp'],
+      [false, 'https://exblog.jp'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(exblogHandler.match(url)).toBe(expected)
     })
 
@@ -74,6 +74,11 @@ describe('exblogHandler', () => {
       ]
 
       expect(exblogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/fireside.test.ts
+++ b/src/feeds/platform/handlers/fireside.test.ts
@@ -3,14 +3,14 @@ import { firesideHandler } from './fireside.js'
 
 describe('firesideHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://office.fireside.fm', true],
-      ['https://blog.example.fireside.fm', true],
-      ['https://fireside.fm', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://office.fireside.fm'],
+      [true, 'https://blog.example.fireside.fm'],
+      [false, 'https://fireside.fm'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(firesideHandler.match(url)).toBe(expected)
     })
 
@@ -50,6 +50,16 @@ describe('firesideHandler', () => {
       ]
 
       expect(firesideHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for www.fireside.fm', () => {
+      // resolve('https://www.fireside.fm') currently treats www as a podcast slug and emits
+      // https://feeds.fireside.fm/www/rss, which is likely a source bug.
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/friendica.test.ts
+++ b/src/feeds/platform/handlers/friendica.test.ts
@@ -19,6 +19,10 @@ describe('friendicaHandler', () => {
     it('should return false for non-Friendica generator', () => {
       expect(isFriendicaHtml(otherHtml)).toBe(false)
     })
+
+    it('should return false for empty content', () => {
+      expect(isFriendicaHtml('')).toBe(false)
+    })
   })
 
   describe('match', () => {

--- a/src/feeds/platform/handlers/ghost.test.ts
+++ b/src/feeds/platform/handlers/ghost.test.ts
@@ -3,14 +3,14 @@ import { ghostHandler } from './ghost.js'
 
 describe('ghostHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://demo.ghost.io', true],
-      ['https://blog.example.ghost.io', true],
-      ['https://ghost.io', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://demo.ghost.io'],
+      [true, 'https://blog.example.ghost.io'],
+      [false, 'https://ghost.io'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(ghostHandler.match(url)).toBe(expected)
     })
 
@@ -74,6 +74,11 @@ describe('ghostHandler', () => {
       ]
 
       expect(ghostHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/github.test.ts
+++ b/src/feeds/platform/handlers/github.test.ts
@@ -3,13 +3,13 @@ import { githubHandler } from './github.js'
 
 describe('githubHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://github.com/owner/repo', true],
-      ['https://www.github.com/owner/repo', true],
-      ['https://gitlab.com/owner/repo', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://github.com/owner/repo'],
+      [true, 'https://www.github.com/owner/repo'],
+      [false, 'https://gitlab.com/owner/repo'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(githubHandler.match(url)).toBe(expected)
     })
 
@@ -105,6 +105,26 @@ describe('githubHandler', () => {
         {
           uri: 'https://github.com/microsoft/vscode/commits/main.atom',
           hint: { key: 'github:branch-commits', label: 'Branch commits' },
+        },
+      ]
+
+      expect(githubHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should not include branch commits feed for tree path with subdirectory', () => {
+      const value = 'https://github.com/microsoft/vscode/tree/main/src'
+      const expected = [
+        {
+          uri: 'https://github.com/microsoft/vscode/releases.atom',
+          hint: { key: 'github:releases', label: 'Releases' },
+        },
+        {
+          uri: 'https://github.com/microsoft/vscode/commits.atom',
+          hint: { key: 'github:commits', label: 'Commits' },
+        },
+        {
+          uri: 'https://github.com/microsoft/vscode/tags.atom',
+          hint: { key: 'github:tags', label: 'Tags' },
         },
       ]
 
@@ -365,6 +385,11 @@ describe('githubHandler', () => {
       ]
 
       expect(githubHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/githubGist.test.ts
+++ b/src/feeds/platform/handlers/githubGist.test.ts
@@ -3,14 +3,14 @@ import { githubGistHandler } from './githubGist.js'
 
 describe('githubGistHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://gist.github.com/defunkt', true],
-      ['https://gist.github.com/defunkt/1234567890abcdef', true],
-      ['https://github.com/defunkt', false],
-      ['https://example.com/gist', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://gist.github.com/defunkt'],
+      [true, 'https://gist.github.com/defunkt/1234567890abcdef'],
+      [false, 'https://github.com/defunkt'],
+      [false, 'https://example.com/gist'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(githubGistHandler.match(url)).toBe(expected)
     })
 
@@ -128,16 +128,14 @@ describe('githubGistHandler', () => {
       expect(githubGistHandler.resolve(value)).toEqual(expected)
     })
 
-    it('should return empty array for excluded paths', () => {
-      const excludedUrls = [
-        'https://gist.github.com/search',
-        'https://gist.github.com/login',
-        'https://gist.github.com/join',
-      ]
+    const excludedValues: Array<string> = [
+      'https://gist.github.com/search',
+      'https://gist.github.com/login',
+      'https://gist.github.com/join',
+    ]
 
-      for (const url of excludedUrls) {
-        expect(githubGistHandler.resolve(url)).toEqual([])
-      }
+    it.each(excludedValues)('should return empty array for %s', (value) => {
+      expect(githubGistHandler.resolve(value)).toEqual([])
     })
 
     it('should return empty array for gist URL with excluded username', () => {
@@ -150,6 +148,11 @@ describe('githubGistHandler', () => {
       const value = 'https://gist.github.com/'
 
       expect(githubGistHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/gitlab.test.ts
+++ b/src/feeds/platform/handlers/gitlab.test.ts
@@ -55,6 +55,13 @@ describe('gitlabHandler', () => {
       )
     })
 
+    it('should match self-hosted instance with non-GitLab content but GitLab header', () => {
+      const value = 'https://gitlab.mycompany.com/user'
+      const content = '<html><head><title>Projects</title></head></html>'
+
+      expect(gitlabHandler.match(value, content, selfHostedHeaders)).toBe(true)
+    })
+
     it('should not match self-hosted root path even with GitLab signals', () => {
       expect(gitlabHandler.match('https://gitlab.mycompany.com', selfHostedHtml)).toBe(false)
     })
@@ -212,30 +219,38 @@ describe('gitlabHandler', () => {
       expect(gitlabHandler.resolve(value)).toEqual([])
     })
 
-    it('should return empty array for excluded paths', () => {
-      const values = [
-        'https://gitlab.com/explore',
-        'https://gitlab.com/dashboard',
-        'https://gitlab.com/users',
-        'https://gitlab.com/search',
-        'https://gitlab.com/help',
-      ]
+    const excludedValues: Array<string> = [
+      'https://gitlab.com/explore',
+      'https://gitlab.com/dashboard',
+      'https://gitlab.com/users',
+      'https://gitlab.com/search',
+      'https://gitlab.com/help',
+    ]
 
-      for (const value of values) {
-        expect(gitlabHandler.resolve(value)).toEqual([])
-      }
+    it.each(excludedValues)('should return empty array for %s', (value) => {
+      expect(gitlabHandler.resolve(value)).toEqual([])
     })
 
-    it('should return empty array for excluded paths with repo segment', () => {
-      const values = [
-        'https://gitlab.com/explore/projects',
-        'https://gitlab.com/dashboard/issues',
-        'https://gitlab.com/help/docs',
+    const excludedRepoValues: Array<string> = [
+      'https://gitlab.com/explore/projects',
+      'https://gitlab.com/dashboard/issues',
+      'https://gitlab.com/help/docs',
+    ]
+
+    it.each(excludedRepoValues)('should return empty array for %s', (value) => {
+      expect(gitlabHandler.resolve(value)).toEqual([])
+    })
+
+    it('should keep self-hosted origin in resolved feeds', () => {
+      const value = 'https://gitlab.mycompany.com/team'
+      const expected = [
+        {
+          uri: 'https://gitlab.mycompany.com/team.atom',
+          hint: { key: 'gitlab:activity', label: 'Activity' },
+        },
       ]
 
-      for (const value of values) {
-        expect(gitlabHandler.resolve(value)).toEqual([])
-      }
+      expect(gitlabHandler.resolve(value)).toEqual(expected)
     })
 
     it('should use first two path segments for deeply nested groups', () => {
@@ -265,6 +280,11 @@ describe('gitlabHandler', () => {
       ]
 
       expect(gitlabHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/goodreads.test.ts
+++ b/src/feeds/platform/handlers/goodreads.test.ts
@@ -3,15 +3,15 @@ import { goodreadsHandler } from './goodreads.js'
 
 describe('goodreadsHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://www.goodreads.com/user/show/1-otis', true],
-      ['https://goodreads.com/review/list/1', true],
-      ['https://www.goodreads.com', true],
-      ['https://github.com/user/repo', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://www.goodreads.com/user/show/1-otis'],
+      [true, 'https://goodreads.com/review/list/1'],
+      [true, 'https://www.goodreads.com'],
+      [false, 'https://github.com/user/repo'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(goodreadsHandler.match(url)).toBe(expected)
     })
 
@@ -106,10 +106,10 @@ describe('goodreadsHandler', () => {
     })
 
     it('should encode special characters in shelf name', () => {
-      const value = 'https://www.goodreads.com/review/list/1?shelf=to-read'
+      const value = 'https://www.goodreads.com/review/list/1?shelf=currently%20reading'
       const expected = [
         {
-          uri: 'https://www.goodreads.com/review/list_rss/1?shelf=to-read',
+          uri: 'https://www.goodreads.com/review/list_rss/1?shelf=currently%20reading',
           hint: { key: 'goodreads:shelf', label: 'Shelf' },
         },
         {
@@ -155,16 +155,19 @@ describe('goodreadsHandler', () => {
       expect(goodreadsHandler.resolve(value)).toEqual([])
     })
 
-    it('should return empty array for non-feedable paths', () => {
-      const values = [
-        'https://www.goodreads.com/genres/fiction',
-        'https://www.goodreads.com/list/show/1.Best_Books_Ever',
-        'https://www.goodreads.com/choiceawards',
-      ]
+    const nonFeedableValues: Array<string> = [
+      'https://www.goodreads.com/genres/fiction',
+      'https://www.goodreads.com/list/show/1.Best_Books_Ever',
+      'https://www.goodreads.com/choiceawards',
+    ]
 
-      for (const value of values) {
-        expect(goodreadsHandler.resolve(value)).toEqual([])
-      }
+    it.each(nonFeedableValues)('should return empty array for %s', (value) => {
+      expect(goodreadsHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/hackernews.test.ts
+++ b/src/feeds/platform/handlers/hackernews.test.ts
@@ -3,15 +3,15 @@ import { hackernewsHandler } from './hackernews.js'
 
 describe('hackernewsHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://news.ycombinator.com', true],
-      ['https://news.ycombinator.com/news', true],
-      ['https://news.ycombinator.com/item?id=12345', true],
-      ['https://ycombinator.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://news.ycombinator.com'],
+      [true, 'https://news.ycombinator.com/news'],
+      [true, 'https://news.ycombinator.com/item?id=12345'],
+      [false, 'https://ycombinator.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(hackernewsHandler.match(url)).toBe(expected)
     })
 
@@ -67,6 +67,11 @@ describe('hackernewsHandler', () => {
       ]
 
       expect(hackernewsHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/hashnode.test.ts
+++ b/src/feeds/platform/handlers/hashnode.test.ts
@@ -3,16 +3,16 @@ import { hashnodeHandler } from './hashnode.js'
 
 describe('hashnodeHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://example.hashnode.dev', true],
-      ['https://blog.example.hashnode.dev', true],
-      ['https://townhall.hashnode.com', true],
-      ['https://hashnode.dev', false],
-      ['https://hashnode.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://example.hashnode.dev'],
+      [true, 'https://blog.example.hashnode.dev'],
+      [true, 'https://townhall.hashnode.com'],
+      [false, 'https://hashnode.dev'],
+      [false, 'https://hashnode.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(hashnodeHandler.match(url)).toBe(expected)
     })
 
@@ -44,6 +44,11 @@ describe('hashnodeHandler', () => {
       ]
 
       expect(hashnodeHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/hatenablog.test.ts
+++ b/src/feeds/platform/handlers/hatenablog.test.ts
@@ -3,22 +3,22 @@ import { hatenablogHandler } from './hatenablog.js'
 
 describe('hatenablogHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://example.hatenablog.com', true],
-      ['https://example.hatenablog.jp', true],
-      ['https://example.hateblo.jp', true],
-      ['https://example.hatenadiary.com', true],
-      ['https://example.hatenadiary.jp', true],
-      ['https://example.hatenadiary.org', true],
-      ['https://blog.example.hatenablog.com', true],
-      ['https://hatenablog.com', false],
-      ['https://hatenablog.jp', false],
-      ['https://hateblo.jp', false],
-      ['https://hatenadiary.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://example.hatenablog.com'],
+      [true, 'https://example.hatenablog.jp'],
+      [true, 'https://example.hateblo.jp'],
+      [true, 'https://example.hatenadiary.com'],
+      [true, 'https://example.hatenadiary.jp'],
+      [true, 'https://example.hatenadiary.org'],
+      [true, 'https://blog.example.hatenablog.com'],
+      [false, 'https://hatenablog.com'],
+      [false, 'https://hatenablog.jp'],
+      [false, 'https://hateblo.jp'],
+      [false, 'https://hatenadiary.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(hatenablogHandler.match(url)).toBe(expected)
     })
 
@@ -122,6 +122,11 @@ describe('hatenablogHandler', () => {
       ]
 
       expect(hatenablogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/hearthis.test.ts
+++ b/src/feeds/platform/handlers/hearthis.test.ts
@@ -3,14 +3,14 @@ import { hearthisHandler } from './hearthis.js'
 
 describe('hearthisHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://hearthis.at/james-monty-montgomery', true],
-      ['https://www.hearthis.at/user', true],
-      ['https://hearthis.at', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://hearthis.at/james-monty-montgomery'],
+      [true, 'https://www.hearthis.at/user'],
+      [true, 'https://hearthis.at'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(hearthisHandler.match(url)).toBe(expected)
     })
 
@@ -54,6 +54,11 @@ describe('hearthisHandler', () => {
       const value = 'https://hearthis.at/login'
 
       expect(hearthisHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/heyWorld.test.ts
+++ b/src/feeds/platform/handlers/heyWorld.test.ts
@@ -3,14 +3,14 @@ import { heyWorldHandler } from './heyWorld.js'
 
 describe('heyWorldHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://world.hey.com/dhh', true],
-      ['https://world.hey.com', true],
-      ['https://hey.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://world.hey.com/dhh'],
+      [true, 'https://world.hey.com'],
+      [false, 'https://hey.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(heyWorldHandler.match(url)).toBe(expected)
     })
 
@@ -48,6 +48,11 @@ describe('heyWorldHandler', () => {
       const value = 'https://world.hey.com/'
 
       expect(heyWorldHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/insanejournal.test.ts
+++ b/src/feeds/platform/handlers/insanejournal.test.ts
@@ -3,23 +3,23 @@ import { insanejournalHandler } from './insanejournal.js'
 
 describe('insanejournalHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://random.insanejournal.com', true],
-      ['https://anything.insanejournal.com/post', true],
-      ['https://www.insanejournal.com/users/news', true],
-      ['https://www.insanejournal.com/~news', true],
-      ['https://www.insanejournal.com/asylum/squeaky', true],
-      ['https://www.insanejournal.com/community/squeaky', true],
-      ['https://asylums.insanejournal.com/squeaky', true],
-      ['https://feeds.insanejournal.com/dw_code_feed', true],
-      ['https://www.insanejournal.com', false],
-      ['https://asylums.insanejournal.com', false],
-      ['https://feeds.insanejournal.com', false],
-      ['https://insanejournal.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://random.insanejournal.com'],
+      [true, 'https://anything.insanejournal.com/post'],
+      [true, 'https://www.insanejournal.com/users/news'],
+      [true, 'https://www.insanejournal.com/~news'],
+      [true, 'https://www.insanejournal.com/asylum/squeaky'],
+      [true, 'https://www.insanejournal.com/community/squeaky'],
+      [true, 'https://asylums.insanejournal.com/squeaky'],
+      [true, 'https://feeds.insanejournal.com/dw_code_feed'],
+      [false, 'https://www.insanejournal.com'],
+      [false, 'https://asylums.insanejournal.com'],
+      [false, 'https://feeds.insanejournal.com'],
+      [false, 'https://insanejournal.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(insanejournalHandler.match(url)).toBe(expected)
     })
 
@@ -70,14 +70,14 @@ describe('insanejournalHandler', () => {
     })
 
     it('should add tag-filtered feeds for /tag/ paths on journal', () => {
-      const value = 'https://random.insanejournal.com/tag/foo'
+      const value = 'https://random.insanejournal.com/tag/photography'
       const expected = [
         {
-          uri: 'https://random.insanejournal.com/data/rss?tag=foo',
+          uri: 'https://random.insanejournal.com/data/rss?tag=photography',
           hint: { key: 'insanejournal:posts-tag-rss', label: 'Tag (RSS)' },
         },
         {
-          uri: 'https://random.insanejournal.com/data/atom?tag=foo',
+          uri: 'https://random.insanejournal.com/data/atom?tag=photography',
           hint: { key: 'insanejournal:posts-tag-atom', label: 'Tag (Atom)' },
         },
         {
@@ -187,6 +187,11 @@ describe('insanejournalHandler', () => {
       ]
 
       expect(insanejournalHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/itchio.test.ts
+++ b/src/feeds/platform/handlers/itchio.test.ts
@@ -3,16 +3,16 @@ import { itchioHandler } from './itchio.js'
 
 describe('itchioHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://itch.io/games', true],
-      ['https://www.itch.io/games', true],
-      ['https://leafo.itch.io', true],
-      ['https://leafo.itch.io/x-moon', true],
-      ['https://example.com', false],
-      ['https://notitch.io', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://itch.io/games'],
+      [true, 'https://www.itch.io/games'],
+      [true, 'https://leafo.itch.io'],
+      [true, 'https://leafo.itch.io/x-moon'],
+      [false, 'https://example.com'],
+      [false, 'https://notitch.io'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(itchioHandler.match(url)).toBe(expected)
     })
 
@@ -233,6 +233,11 @@ describe('itchioHandler', () => {
       ]
 
       expect(itchioHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/kickstarter.test.ts
+++ b/src/feeds/platform/handlers/kickstarter.test.ts
@@ -3,15 +3,15 @@ import { kickstarterHandler } from './kickstarter.js'
 
 describe('kickstarterHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://www.kickstarter.com/projects/creator/project', true],
-      ['https://kickstarter.com/projects/creator/project', true],
-      ['https://kickstarter.com/discover', true],
-      ['https://kickstarter.com', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://www.kickstarter.com/projects/creator/project'],
+      [true, 'https://kickstarter.com/projects/creator/project'],
+      [true, 'https://kickstarter.com/discover'],
+      [true, 'https://kickstarter.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(kickstarterHandler.match(url)).toBe(expected)
     })
 
@@ -69,6 +69,18 @@ describe('kickstarterHandler', () => {
       expect(kickstarterHandler.resolve(value)).toEqual(expected)
     })
 
+    it('should return global projects feed for other non-project paths', () => {
+      const value = 'https://www.kickstarter.com/help'
+      const expected = [
+        {
+          uri: 'https://www.kickstarter.com/projects/feed.atom',
+          hint: { key: 'kickstarter:projects', label: 'Projects' },
+        },
+      ]
+
+      expect(kickstarterHandler.resolve(value)).toEqual(expected)
+    })
+
     it('should handle URLs with query params', () => {
       const value = 'https://www.kickstarter.com/projects/creator/project?ref=discovery'
       const expected = [
@@ -91,6 +103,11 @@ describe('kickstarterHandler', () => {
       ]
 
       expect(kickstarterHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/lemmy.test.ts
+++ b/src/feeds/platform/handlers/lemmy.test.ts
@@ -164,6 +164,7 @@ describe('lemmyHandler', () => {
 
     it('should not match without Lemmy signals', () => {
       const plainHtml = '<html><head></head></html>'
+
       expect(lemmyHandler.match('https://lemmy.ml/c/programming', plainHtml)).toBe(false)
     })
 
@@ -237,28 +238,33 @@ describe('lemmyHandler', () => {
       expect(lemmyHandler.resolve(value)).toEqual(expected)
     })
 
-    it('should forward ?sort= on community, user, and home feeds', () => {
-      const communityExpected = [
+    it('should forward ?sort= on community feed', () => {
+      const value = 'https://lemmy.ml/c/programming?sort=TopWeek'
+      const expected = [
         {
           uri: 'https://lemmy.ml/feeds/c/programming.xml?sort=TopWeek',
           hint: { key: 'lemmy:community', label: 'Community' },
         },
       ]
 
-      expect(lemmyHandler.resolve('https://lemmy.ml/c/programming?sort=TopWeek')).toEqual(
-        communityExpected,
-      )
+      expect(lemmyHandler.resolve(value)).toEqual(expected)
+    })
 
-      const userExpected = [
+    it('should forward ?sort= on user feed', () => {
+      const value = 'https://lemmy.ml/u/alice?sort=New'
+      const expected = [
         {
           uri: 'https://lemmy.ml/feeds/u/alice.xml?sort=New',
           hint: { key: 'lemmy:user', label: 'User' },
         },
       ]
 
-      expect(lemmyHandler.resolve('https://lemmy.ml/u/alice?sort=New')).toEqual(userExpected)
+      expect(lemmyHandler.resolve(value)).toEqual(expected)
+    })
 
-      const homeExpected = [
+    it('should forward ?sort= on home feeds', () => {
+      const value = 'https://lemmy.ml/?sort=Active'
+      const expected = [
         {
           uri: 'https://lemmy.ml/feeds/all.xml?sort=Active',
           hint: { key: 'lemmy:all', label: 'All' },
@@ -269,7 +275,7 @@ describe('lemmyHandler', () => {
         },
       ]
 
-      expect(lemmyHandler.resolve('https://lemmy.ml/?sort=Active')).toEqual(homeExpected)
+      expect(lemmyHandler.resolve(value)).toEqual(expected)
     })
 
     it('should drop unknown ?sort= values', () => {
@@ -322,6 +328,34 @@ describe('lemmyHandler', () => {
         {
           uri: 'https://lemmy.ml/feeds/c/programming.xml',
           hint: { key: 'lemmy:community', label: 'Community' },
+        },
+      ]
+
+      expect(lemmyHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should pass through ?limit= without sort', () => {
+      const value = 'https://lemmy.ml/c/programming?limit=10'
+      const expected = [
+        {
+          uri: 'https://lemmy.ml/feeds/c/programming.xml?limit=10',
+          hint: { key: 'lemmy:community', label: 'Community' },
+        },
+      ]
+
+      expect(lemmyHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return site-wide feeds for /home path', () => {
+      const value = 'https://lemmy.ml/home'
+      const expected = [
+        {
+          uri: 'https://lemmy.ml/feeds/all.xml',
+          hint: { key: 'lemmy:all', label: 'All' },
+        },
+        {
+          uri: 'https://lemmy.ml/feeds/local.xml',
+          hint: { key: 'lemmy:local', label: 'Local' },
         },
       ]
 

--- a/src/feeds/platform/handlers/letterboxd.test.ts
+++ b/src/feeds/platform/handlers/letterboxd.test.ts
@@ -3,16 +3,16 @@ import { letterboxdHandler } from './letterboxd.js'
 
 describe('letterboxdHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://letterboxd.com/dave', true],
-      ['https://www.letterboxd.com/dave', true],
-      ['https://letterboxd.com/dave/films/', true],
-      ['https://letterboxd.com', true],
-      ['https://example.com/letterboxd', false],
-      ['https://twitter.com/letterboxd', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://letterboxd.com/dave'],
+      [true, 'https://www.letterboxd.com/dave'],
+      [true, 'https://letterboxd.com/dave/films/'],
+      [true, 'https://letterboxd.com'],
+      [false, 'https://example.com/letterboxd'],
+      [false, 'https://twitter.com/letterboxd'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(letterboxdHandler.match(url)).toBe(expected)
     })
 
@@ -98,6 +98,23 @@ describe('letterboxdHandler', () => {
       ]
 
       expect(letterboxdHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return Journal feed for journal article subpath', () => {
+      const value = 'https://letterboxd.com/journal/the-best-films-of-the-year'
+      const expected = [
+        {
+          uri: 'https://letterboxd.com/journal/rss/',
+          hint: { key: 'letterboxd:journal', label: 'Journal' },
+        },
+      ]
+
+      expect(letterboxdHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/libsyn.test.ts
+++ b/src/feeds/platform/handlers/libsyn.test.ts
@@ -3,14 +3,14 @@ import { libsynHandler } from './libsyn.js'
 
 describe('libsynHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://podcastingforcoaches.libsyn.com', true],
-      ['https://blog.example.libsyn.com', true],
-      ['https://libsyn.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://podcastingforcoaches.libsyn.com'],
+      [true, 'https://blog.example.libsyn.com'],
+      [false, 'https://libsyn.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(libsynHandler.match(url)).toBe(expected)
     })
 
@@ -72,6 +72,11 @@ describe('libsynHandler', () => {
       const value = 'https://feeds.libsyn.com/something-non-numeric'
 
       expect(libsynHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/listed.test.ts
+++ b/src/feeds/platform/handlers/listed.test.ts
@@ -3,14 +3,14 @@ import { listedHandler } from './listed.js'
 
 describe('listedHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://listed.to/@Listed', true],
-      ['https://www.listed.to/@user', true],
-      ['https://listed.to', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://listed.to/@Listed'],
+      [true, 'https://www.listed.to/@user'],
+      [true, 'https://listed.to'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(listedHandler.match(url)).toBe(expected)
     })
 
@@ -54,6 +54,11 @@ describe('listedHandler', () => {
       const value = 'https://listed.to/about'
 
       expect(listedHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/livejournal.test.ts
+++ b/src/feeds/platform/handlers/livejournal.test.ts
@@ -3,22 +3,22 @@ import { livejournalHandler } from './livejournal.js'
 
 describe('livejournalHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://ohnotheydidnt.livejournal.com', true],
-      ['https://blog.example.livejournal.com', true],
-      ['https://www.livejournal.com/users/news', true],
-      ['https://www.livejournal.com/~news', true],
-      ['https://users.livejournal.com/news', true],
-      ['https://community.livejournal.com/ohnotheydidnt', true],
-      ['https://www.livejournal.com', false],
-      ['https://users.livejournal.com', false],
-      ['https://community.livejournal.com', false],
-      ['https://syndicated.livejournal.com', false],
-      ['https://livejournal.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://ohnotheydidnt.livejournal.com'],
+      [true, 'https://blog.example.livejournal.com'],
+      [true, 'https://www.livejournal.com/users/news'],
+      [true, 'https://www.livejournal.com/~news'],
+      [true, 'https://users.livejournal.com/news'],
+      [true, 'https://community.livejournal.com/ohnotheydidnt'],
+      [false, 'https://www.livejournal.com'],
+      [false, 'https://users.livejournal.com'],
+      [false, 'https://community.livejournal.com'],
+      [false, 'https://syndicated.livejournal.com'],
+      [false, 'https://livejournal.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(livejournalHandler.match(url)).toBe(expected)
     })
 
@@ -162,6 +162,11 @@ describe('livejournalHandler', () => {
       ]
 
       expect(livejournalHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/lobsters.test.ts
+++ b/src/feeds/platform/handlers/lobsters.test.ts
@@ -3,16 +3,16 @@ import { lobstersHandler } from './lobsters.js'
 
 describe('lobstersHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://lobste.rs/', true],
-      ['https://lobste.rs/newest', true],
-      ['https://lobste.rs/t/programming', true],
-      ['https://lobste.rs/t/programming,security', true],
-      ['https://lobste.rs/domains/github.com', true],
-      ['https://example.com/lobsters', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://lobste.rs/'],
+      [true, 'https://lobste.rs/newest'],
+      [true, 'https://lobste.rs/t/programming'],
+      [true, 'https://lobste.rs/t/programming,security'],
+      [true, 'https://lobste.rs/domains/github.com'],
+      [false, 'https://example.com/lobsters'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(lobstersHandler.match(url)).toBe(expected)
     })
 
@@ -106,6 +106,28 @@ describe('lobstersHandler', () => {
       expect(lobstersHandler.resolve(value)).toEqual(expected)
     })
 
+    const topPeriodValues: Array<[string, string]> = [
+      ['https://lobste.rs/top/3d', 'https://lobste.rs/top/3d/rss'],
+      ['https://lobste.rs/top/1w', 'https://lobste.rs/top/1w/rss'],
+      ['https://lobste.rs/top/1m', 'https://lobste.rs/top/1m/rss'],
+      ['https://lobste.rs/top/1y', 'https://lobste.rs/top/1y/rss'],
+    ]
+
+    it.each(topPeriodValues)('should return top stories feed for %s', (value, uri) => {
+      const expected = [{ uri, hint: { key: 'lobsters:top', label: 'Top stories' } }]
+
+      expect(lobstersHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should fall back to main feed for invalid top period', () => {
+      const value = 'https://lobste.rs/top/2d'
+      const expected = [
+        { uri: 'https://lobste.rs/rss', hint: { key: 'lobsters:stories', label: 'Stories' } },
+      ]
+
+      expect(lobstersHandler.resolve(value)).toEqual(expected)
+    })
+
     it('should return comments feed for comments page', () => {
       const value = 'https://lobste.rs/comments'
       const expected = [
@@ -116,6 +138,11 @@ describe('lobstersHandler', () => {
       ]
 
       expect(lobstersHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/mastodon.test.ts
+++ b/src/feeds/platform/handlers/mastodon.test.ts
@@ -69,36 +69,29 @@ describe('mastodonHandler', () => {
     })
 
     it('should match profile path with Mastodon server header', () => {
-      const result = mastodonHandler.match('https://mastodon.social/@user', '', mastodonHeaders)
-
-      expect(result).toBe(true)
+      expect(mastodonHandler.match('https://mastodon.social/@user', '', mastodonHeaders)).toBe(true)
     })
 
     it('should match tag path with Mastodon HTML', () => {
-      const result = mastodonHandler.match('https://mastodon.social/tags/javascript', mastodonHtml)
+      const value = 'https://mastodon.social/tags/javascript'
 
-      expect(result).toBe(true)
+      expect(mastodonHandler.match(value, mastodonHtml)).toBe(true)
     })
 
     it('should match tag path with Mastodon server header', () => {
-      const result = mastodonHandler.match(
-        'https://mastodon.social/tags/javascript',
-        '',
-        mastodonHeaders,
-      )
+      const value = 'https://mastodon.social/tags/javascript'
 
-      expect(result).toBe(true)
+      expect(mastodonHandler.match(value, '', mastodonHeaders)).toBe(true)
     })
 
-    it('should not match without Mastodon signals', () => {
-      const result = mastodonHandler.match(
-        'https://mastodon.social/@user',
-        '',
-        new Headers({ server: 'nginx' }),
-      )
-
+    it('should not match without Mastodon HTML signals', () => {
       expect(mastodonHandler.match('https://mastodon.social/@user', '<html></html>')).toBe(false)
-      expect(result).toBe(false)
+    })
+
+    it('should not match without Mastodon header signals', () => {
+      const headers = new Headers({ server: 'nginx' })
+
+      expect(mastodonHandler.match('https://mastodon.social/@user', '', headers)).toBe(false)
     })
 
     it('should not match without content and headers', () => {

--- a/src/feeds/platform/handlers/mataroa.test.ts
+++ b/src/feeds/platform/handlers/mataroa.test.ts
@@ -3,14 +3,14 @@ import { mataroaHandler } from './mataroa.js'
 
 describe('mataroaHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://hey.mataroa.blog', true],
-      ['https://blog.example.mataroa.blog', true],
-      ['https://mataroa.blog', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://hey.mataroa.blog'],
+      [true, 'https://blog.example.mataroa.blog'],
+      [false, 'https://mataroa.blog'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(mataroaHandler.match(url)).toBe(expected)
     })
 
@@ -42,6 +42,11 @@ describe('mataroaHandler', () => {
       ]
 
       expect(mataroaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/medium.test.ts
+++ b/src/feeds/platform/handlers/medium.test.ts
@@ -3,15 +3,15 @@ import { mediumHandler } from './medium.js'
 
 describe('mediumHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://medium.com/@ev', true],
-      ['https://www.medium.com/@ev', true],
-      ['https://medium.com/towards-data-science', true],
-      ['https://blog.medium.com', true],
-      ['https://example.com/@ev', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://medium.com/@ev'],
+      [true, 'https://www.medium.com/@ev'],
+      [true, 'https://medium.com/towards-data-science'],
+      [true, 'https://blog.medium.com'],
+      [false, 'https://example.com/@ev'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(mediumHandler.match(url)).toBe(expected)
     })
 
@@ -96,6 +96,7 @@ describe('mediumHandler', () => {
         'https://medium.com/me',
         'https://medium.com/new-story',
         'https://medium.com/plans',
+        'https://medium.com/membership',
       ]
 
       for (const url of excludedUrls) {
@@ -108,6 +109,7 @@ describe('mediumHandler', () => {
         'https://medium.com/search/tagged/javascript',
         'https://medium.com/me/tagged/react',
         'https://medium.com/plans/tagged/python',
+        'https://medium.com/membership/tagged/writing',
       ]
 
       for (const url of excludedUrls) {
@@ -152,6 +154,11 @@ describe('mediumHandler', () => {
       ]
 
       expect(mediumHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/microblog.test.ts
+++ b/src/feeds/platform/handlers/microblog.test.ts
@@ -3,14 +3,14 @@ import { microblogHandler } from './microblog.js'
 
 describe('microblogHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://manton.micro.blog', true],
-      ['https://blog.example.micro.blog', true],
-      ['https://micro.blog', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://manton.micro.blog'],
+      [true, 'https://blog.example.micro.blog'],
+      [false, 'https://micro.blog'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(microblogHandler.match(url)).toBe(expected)
     })
 
@@ -182,6 +182,11 @@ describe('microblogHandler', () => {
       ]
 
       expect(microblogHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/myanimelist.test.ts
+++ b/src/feeds/platform/handlers/myanimelist.test.ts
@@ -1,35 +1,16 @@
 import { describe, expect, it } from 'bun:test'
 import { myanimelistHandler } from './myanimelist.js'
 
-const expectedFeeds = (user: string) => [
-  {
-    uri: `https://myanimelist.net/rss.php?type=rw&u=${user}`,
-    hint: { key: 'myanimelist:anime', label: 'Anime list' },
-  },
-  {
-    uri: `https://myanimelist.net/rss.php?type=rm&u=${user}`,
-    hint: { key: 'myanimelist:manga', label: 'Manga list' },
-  },
-  {
-    uri: `https://myanimelist.net/rss.php?type=rrw&u=${user}`,
-    hint: { key: 'myanimelist:recently-watched', label: 'Recently watched' },
-  },
-  {
-    uri: `https://myanimelist.net/rss.php?type=rrm&u=${user}`,
-    hint: { key: 'myanimelist:recently-read', label: 'Recently read' },
-  },
-]
-
 describe('myanimelistHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://myanimelist.net/profile/Xinil', true],
-      ['https://www.myanimelist.net/animelist/Xinil', true],
-      ['https://myanimelist.net', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://myanimelist.net/profile/Xinil'],
+      [true, 'https://www.myanimelist.net/animelist/Xinil'],
+      [true, 'https://myanimelist.net'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(myanimelistHandler.match(url)).toBe(expected)
     })
 
@@ -41,28 +22,96 @@ describe('myanimelistHandler', () => {
   describe('resolve', () => {
     it('should return all four feeds for /profile/{user}', () => {
       const value = 'https://myanimelist.net/profile/Xinil'
-      const expected = expectedFeeds('Xinil')
+      const expected = [
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rw&u=Xinil',
+          hint: { key: 'myanimelist:anime', label: 'Anime list' },
+        },
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rm&u=Xinil',
+          hint: { key: 'myanimelist:manga', label: 'Manga list' },
+        },
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rrw&u=Xinil',
+          hint: { key: 'myanimelist:recently-watched', label: 'Recently watched' },
+        },
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rrm&u=Xinil',
+          hint: { key: 'myanimelist:recently-read', label: 'Recently read' },
+        },
+      ]
 
       expect(myanimelistHandler.resolve(value)).toEqual(expected)
     })
 
     it('should return feeds for /animelist/{user}', () => {
       const value = 'https://myanimelist.net/animelist/Xinil'
-      const expected = expectedFeeds('Xinil')
+      const expected = [
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rw&u=Xinil',
+          hint: { key: 'myanimelist:anime', label: 'Anime list' },
+        },
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rm&u=Xinil',
+          hint: { key: 'myanimelist:manga', label: 'Manga list' },
+        },
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rrw&u=Xinil',
+          hint: { key: 'myanimelist:recently-watched', label: 'Recently watched' },
+        },
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rrm&u=Xinil',
+          hint: { key: 'myanimelist:recently-read', label: 'Recently read' },
+        },
+      ]
 
       expect(myanimelistHandler.resolve(value)).toEqual(expected)
     })
 
     it('should return feeds for /mangalist/{user}', () => {
       const value = 'https://myanimelist.net/mangalist/Xinil'
-      const expected = expectedFeeds('Xinil')
+      const expected = [
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rw&u=Xinil',
+          hint: { key: 'myanimelist:anime', label: 'Anime list' },
+        },
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rm&u=Xinil',
+          hint: { key: 'myanimelist:manga', label: 'Manga list' },
+        },
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rrw&u=Xinil',
+          hint: { key: 'myanimelist:recently-watched', label: 'Recently watched' },
+        },
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rrm&u=Xinil',
+          hint: { key: 'myanimelist:recently-read', label: 'Recently read' },
+        },
+      ]
 
       expect(myanimelistHandler.resolve(value)).toEqual(expected)
     })
 
     it('should return feeds for /history/{user}', () => {
       const value = 'https://myanimelist.net/history/Xinil'
-      const expected = expectedFeeds('Xinil')
+      const expected = [
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rw&u=Xinil',
+          hint: { key: 'myanimelist:anime', label: 'Anime list' },
+        },
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rm&u=Xinil',
+          hint: { key: 'myanimelist:manga', label: 'Manga list' },
+        },
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rrw&u=Xinil',
+          hint: { key: 'myanimelist:recently-watched', label: 'Recently watched' },
+        },
+        {
+          uri: 'https://myanimelist.net/rss.php?type=rrm&u=Xinil',
+          hint: { key: 'myanimelist:recently-read', label: 'Recently read' },
+        },
+      ]
 
       expect(myanimelistHandler.resolve(value)).toEqual(expected)
     })
@@ -121,6 +170,11 @@ describe('myanimelistHandler', () => {
 
     it('should return empty array for root', () => {
       expect(myanimelistHandler.resolve('https://myanimelist.net/')).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/naverBlog.test.ts
+++ b/src/feeds/platform/handlers/naverBlog.test.ts
@@ -3,15 +3,15 @@ import { naverBlogHandler } from './naverBlog.js'
 
 describe('naverBlogHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://blog.naver.com/prologue', true],
-      ['https://m.blog.naver.com/prologue', true],
-      ['https://blog.naver.com', true],
-      ['https://naver.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://blog.naver.com/prologue'],
+      [true, 'https://m.blog.naver.com/prologue'],
+      [true, 'https://blog.naver.com'],
+      [false, 'https://naver.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(naverBlogHandler.match(url)).toBe(expected)
     })
 
@@ -67,6 +67,11 @@ describe('naverBlogHandler', () => {
       const value = 'https://blog.naver.com/BlogList.naver'
 
       expect(naverBlogHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/nebula.test.ts
+++ b/src/feeds/platform/handlers/nebula.test.ts
@@ -3,14 +3,14 @@ import { nebulaHandler } from './nebula.js'
 
 describe('nebulaHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://nebula.tv/realengineering', true],
-      ['https://www.nebula.tv/realengineering', true],
-      ['https://nebula.tv', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://nebula.tv/realengineering'],
+      [true, 'https://www.nebula.tv/realengineering'],
+      [true, 'https://nebula.tv'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(nebulaHandler.match(url)).toBe(expected)
     })
 
@@ -112,6 +112,26 @@ describe('nebulaHandler', () => {
       expect(nebulaHandler.resolve(value)).toEqual(expected)
     })
 
+    it('should return global feeds for /explore/{tab}', () => {
+      const value = 'https://nebula.tv/explore/podcasts'
+      const expected = [
+        {
+          uri: 'https://rss.nebula.app/video.rss',
+          hint: { key: 'nebula:videos-all', label: 'All Videos' },
+        },
+        {
+          uri: 'https://rss.nebula.app/video.rss?plus=true',
+          hint: { key: 'nebula:videos-all-plus', label: 'All Videos (Plus)' },
+        },
+        {
+          uri: 'https://rss.nebula.app/video/channels.rss',
+          hint: { key: 'nebula:channels', label: 'Recently Added Channels' },
+        },
+      ]
+
+      expect(nebulaHandler.resolve(value)).toEqual(expected)
+    })
+
     it('should return category feeds when category query is set', () => {
       const value = 'https://nebula.tv/videos?category=technology'
       const expected = [
@@ -169,9 +189,28 @@ describe('nebulaHandler', () => {
     })
 
     it('should return empty array for excluded paths', () => {
-      const value = 'https://nebula.tv/login'
+      const values = [
+        'https://nebula.tv/login',
+        'https://nebula.tv/about',
+        'https://nebula.tv/classes',
+        'https://nebula.tv/library',
+        'https://nebula.tv/originals',
+        'https://nebula.tv/pricing',
+        'https://nebula.tv/privacy',
+        'https://nebula.tv/search',
+        'https://nebula.tv/settings',
+        'https://nebula.tv/signup',
+        'https://nebula.tv/terms',
+      ]
 
-      expect(nebulaHandler.resolve(value)).toEqual([])
+      for (const value of values) {
+        expect(nebulaHandler.resolve(value)).toEqual([])
+      }
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/note.test.ts
+++ b/src/feeds/platform/handlers/note.test.ts
@@ -3,14 +3,14 @@ import { noteHandler } from './note.js'
 
 describe('noteHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://note.com/tsukasa_yamato', true],
-      ['https://www.note.com/user', true],
-      ['https://note.com', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://note.com/tsukasa_yamato'],
+      [true, 'https://www.note.com/user'],
+      [true, 'https://note.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(noteHandler.match(url)).toBe(expected)
     })
 
@@ -81,9 +81,32 @@ describe('noteHandler', () => {
     })
 
     it('should return empty array for excluded paths', () => {
-      const value = 'https://note.com/login'
+      const values = [
+        'https://note.com/login',
+        'https://note.com/about',
+        'https://note.com/api',
+        'https://note.com/explore',
+        'https://note.com/hashtag',
+        'https://note.com/help',
+        'https://note.com/m',
+        'https://note.com/n',
+        'https://note.com/premium',
+        'https://note.com/privacy',
+        'https://note.com/ranking',
+        'https://note.com/search',
+        'https://note.com/settings',
+        'https://note.com/signup',
+        'https://note.com/terms',
+      ]
 
-      expect(noteHandler.resolve(value)).toEqual([])
+      for (const value of values) {
+        expect(noteHandler.resolve(value)).toEqual([])
+      }
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/observable.test.ts
+++ b/src/feeds/platform/handlers/observable.test.ts
@@ -3,14 +3,14 @@ import { observableHandler } from './observable.js'
 
 describe('observableHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://observablehq.com/@mbostock', true],
-      ['https://www.observablehq.com/@user', true],
-      ['https://observablehq.com', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://observablehq.com/@mbostock'],
+      [true, 'https://www.observablehq.com/@user'],
+      [true, 'https://observablehq.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(observableHandler.match(url)).toBe(expected)
     })
 
@@ -86,10 +86,39 @@ describe('observableHandler', () => {
       expect(observableHandler.resolve(value)).toEqual(expected)
     })
 
+    it('should return recent feed for /recent with trailing slash', () => {
+      const value = 'https://observablehq.com/recent/'
+      const expected = [
+        {
+          uri: 'https://api.observablehq.com/documents/public.rss',
+          hint: { key: 'observable:recent', label: 'Recent' },
+        },
+      ]
+
+      expect(observableHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return trending feed for /trending with trailing slash', () => {
+      const value = 'https://observablehq.com/trending/'
+      const expected = [
+        {
+          uri: 'https://api.observablehq.com/documents/trending.rss',
+          hint: { key: 'observable:trending', label: 'Trending' },
+        },
+      ]
+
+      expect(observableHandler.resolve(value)).toEqual(expected)
+    })
+
     it('should return empty array for paths without @ prefix', () => {
       const value = 'https://observablehq.com/about'
 
       expect(observableHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/odysee.test.ts
+++ b/src/feeds/platform/handlers/odysee.test.ts
@@ -3,14 +3,14 @@ import { odyseeHandler } from './odysee.js'
 
 describe('odyseeHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://odysee.com/@veritasium:f', true],
-      ['https://www.odysee.com/@lbry:3f', true],
-      ['https://odysee.com', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://odysee.com/@veritasium:f'],
+      [true, 'https://www.odysee.com/@lbry:3f'],
+      [true, 'https://odysee.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(odyseeHandler.match(url)).toBe(expected)
     })
 
@@ -44,6 +44,18 @@ describe('odyseeHandler', () => {
       expect(odyseeHandler.resolve(value)).toEqual(expected)
     })
 
+    it('should preserve uppercase characters in channel and claim ID', () => {
+      const value = 'https://odysee.com/@Veritasium:F'
+      const expected = [
+        {
+          uri: 'https://odysee.com/$/rss/@Veritasium:F',
+          hint: { key: 'odysee:videos', label: 'Videos' },
+        },
+      ]
+
+      expect(odyseeHandler.resolve(value)).toEqual(expected)
+    })
+
     it('should return empty array for channel without claim ID', () => {
       const value = 'https://odysee.com/@veritasium'
 
@@ -54,6 +66,11 @@ describe('odyseeHandler', () => {
       const value = 'https://odysee.com/'
 
       expect(odyseeHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/pagecord.test.ts
+++ b/src/feeds/platform/handlers/pagecord.test.ts
@@ -3,15 +3,15 @@ import { pagecordHandler } from './pagecord.js'
 
 describe('pagecordHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://unfiltered.pagecord.com', true],
-      ['https://blog.example.pagecord.com', true],
-      ['https://pagecord.com', false],
-      ['https://www.pagecord.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://unfiltered.pagecord.com'],
+      [true, 'https://blog.example.pagecord.com'],
+      [false, 'https://pagecord.com'],
+      [false, 'https://www.pagecord.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(pagecordHandler.match(url)).toBe(expected)
     })
 
@@ -43,6 +43,11 @@ describe('pagecordHandler', () => {
       ]
 
       expect(pagecordHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/paragraph.test.ts
+++ b/src/feeds/platform/handlers/paragraph.test.ts
@@ -3,14 +3,14 @@ import { paragraphHandler } from './paragraph.js'
 
 describe('paragraphHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://paragraph.com/@blog', true],
-      ['https://www.paragraph.com/@user', true],
-      ['https://paragraph.com/', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://paragraph.com/@blog'],
+      [true, 'https://www.paragraph.com/@user'],
+      [true, 'https://paragraph.com/'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(paragraphHandler.match(url)).toBe(expected)
     })
 
@@ -66,6 +66,11 @@ describe('paragraphHandler', () => {
       const value = 'https://paragraph.com/about'
 
       expect(paragraphHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/pika.test.ts
+++ b/src/feeds/platform/handlers/pika.test.ts
@@ -3,14 +3,14 @@ import { pikaHandler } from './pika.js'
 
 describe('pikaHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://pika.pika.page', true],
-      ['https://blog.example.pika.page', true],
-      ['https://pika.page', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://pika.pika.page'],
+      [true, 'https://blog.example.pika.page'],
+      [false, 'https://pika.page'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(pikaHandler.match(url)).toBe(expected)
     })
 
@@ -74,6 +74,11 @@ describe('pikaHandler', () => {
       ]
 
       expect(pikaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/pinterest.test.ts
+++ b/src/feeds/platform/handlers/pinterest.test.ts
@@ -3,15 +3,15 @@ import { pinterestHandler } from './pinterest.js'
 
 describe('pinterestHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://www.pinterest.com/nasa', true],
-      ['https://pinterest.com/nasa', true],
-      ['https://www.pinterest.com/nasa/mars', true],
-      ['https://pin.it/abc123', true],
-      ['https://example.com/pinterest', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://www.pinterest.com/nasa'],
+      [true, 'https://pinterest.com/nasa'],
+      [true, 'https://www.pinterest.com/nasa/mars'],
+      [true, 'https://pin.it/abc123'],
+      [false, 'https://example.com/pinterest'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(pinterestHandler.match(url)).toBe(expected)
     })
 
@@ -111,6 +111,18 @@ describe('pinterestHandler', () => {
         'https://www.pinterest.com/ideas',
         'https://www.pinterest.com/today',
         'https://www.pinterest.com/explore',
+        'https://www.pinterest.com/_',
+        'https://www.pinterest.com/about',
+        'https://www.pinterest.com/business',
+        'https://www.pinterest.com/convert',
+        'https://www.pinterest.com/login',
+        'https://www.pinterest.com/news_hub',
+        'https://www.pinterest.com/password',
+        'https://www.pinterest.com/privacy',
+        'https://www.pinterest.com/resource',
+        'https://www.pinterest.com/settings',
+        'https://www.pinterest.com/terms',
+        'https://www.pinterest.com/topics',
       ]
 
       for (const value of values) {
@@ -128,6 +140,16 @@ describe('pinterestHandler', () => {
       const value = 'https://www.pinterest.com/pin/123456789'
 
       expect(pinterestHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define resolve behavior for pin.it short links', () => {
+      // pin.it short codes are redirect tokens, not usernames, but resolve currently
+      // emits https://www.pinterest.com/{code}/feed.rss for them; likely needs a fix.
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/podbean.test.ts
+++ b/src/feeds/platform/handlers/podbean.test.ts
@@ -3,19 +3,19 @@ import { podbeanHandler } from './podbean.js'
 
 describe('podbeanHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://kickstartcommerce.podbean.com', true],
-      ['https://blog.example.podbean.com', true],
-      ['https://podbean.com', false],
-      ['https://example.com', false],
-      ['https://www.podbean.com', false],
-      ['https://support.podbean.com', false],
-      ['https://feed.podbean.com', false],
-      ['https://pbcdn1.podbean.com', false],
-      ['https://sponsorship.podbean.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://kickstartcommerce.podbean.com'],
+      [true, 'https://blog.example.podbean.com'],
+      [false, 'https://podbean.com'],
+      [false, 'https://example.com'],
+      [false, 'https://www.podbean.com'],
+      [false, 'https://support.podbean.com'],
+      [false, 'https://feed.podbean.com'],
+      [false, 'https://pbcdn1.podbean.com'],
+      [false, 'https://sponsorship.podbean.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(podbeanHandler.match(url)).toBe(expected)
     })
 
@@ -47,6 +47,11 @@ describe('podbeanHandler', () => {
       ]
 
       expect(podbeanHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/podigee.test.ts
+++ b/src/feeds/platform/handlers/podigee.test.ts
@@ -3,18 +3,18 @@ import { podigeeHandler } from './podigee.js'
 
 describe('podigeeHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://cui-bono.podigee.io', true],
-      ['https://anything.podigee.io/episodes', true],
-      ['https://podigee.io', false],
-      ['https://example.com', false],
-      ['https://www.podigee.io', false],
-      ['https://app.podigee.io', false],
-      ['https://help.podigee.io', false],
-      ['https://blog.podigee.io', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://cui-bono.podigee.io'],
+      [true, 'https://anything.podigee.io/episodes'],
+      [false, 'https://podigee.io'],
+      [false, 'https://example.com'],
+      [false, 'https://www.podigee.io'],
+      [false, 'https://app.podigee.io'],
+      [false, 'https://help.podigee.io'],
+      [false, 'https://blog.podigee.io'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(podigeeHandler.match(url)).toBe(expected)
     })
 
@@ -46,6 +46,11 @@ describe('podigeeHandler', () => {
       ]
 
       expect(podigeeHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/posthaven.test.ts
+++ b/src/feeds/platform/handlers/posthaven.test.ts
@@ -3,14 +3,14 @@ import { posthavenHandler } from './posthaven.js'
 
 describe('posthavenHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://blog.posthaven.com', true],
-      ['https://anything.posthaven.com/post', true],
-      ['https://posthaven.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://blog.posthaven.com'],
+      [true, 'https://anything.posthaven.com/post'],
+      [false, 'https://posthaven.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(posthavenHandler.match(url)).toBe(expected)
     })
 
@@ -58,6 +58,11 @@ describe('posthavenHandler', () => {
       ]
 
       expect(posthavenHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/producthunt.test.ts
+++ b/src/feeds/platform/handlers/producthunt.test.ts
@@ -3,15 +3,15 @@ import { producthuntHandler } from './producthunt.js'
 
 describe('producthuntHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://www.producthunt.com/', true],
-      ['https://producthunt.com/', true],
-      ['https://www.producthunt.com/topics/artificial-intelligence', true],
-      ['https://www.producthunt.com/categories/tech', true],
-      ['https://example.com/producthunt', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://www.producthunt.com/'],
+      [true, 'https://producthunt.com/'],
+      [true, 'https://www.producthunt.com/topics/artificial-intelligence'],
+      [true, 'https://www.producthunt.com/categories/tech'],
+      [false, 'https://example.com/producthunt'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(producthuntHandler.match(url)).toBe(expected)
     })
 
@@ -67,6 +67,11 @@ describe('producthuntHandler', () => {
       ]
 
       expect(producthuntHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/prose.test.ts
+++ b/src/feeds/platform/handlers/prose.test.ts
@@ -3,15 +3,15 @@ import { proseHandler } from './prose.js'
 
 describe('proseHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://hey.prose.sh', true],
-      ['https://blog.example.prose.sh', true],
-      ['https://prose.sh', true],
-      ['https://www.prose.sh', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://hey.prose.sh'],
+      [true, 'https://blog.example.prose.sh'],
+      [true, 'https://prose.sh'],
+      [true, 'https://www.prose.sh'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(proseHandler.match(url)).toBe(expected)
     })
 
@@ -67,6 +67,23 @@ describe('proseHandler', () => {
       ]
 
       expect(proseHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return discovery feed for www apex', () => {
+      const value = 'https://www.prose.sh/'
+      const expected = [
+        {
+          uri: 'https://prose.sh/rss',
+          hint: { key: 'prose:discovery', label: 'Discovery' },
+        },
+      ]
+
+      expect(proseHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/qiita.test.ts
+++ b/src/feeds/platform/handlers/qiita.test.ts
@@ -3,14 +3,14 @@ import { qiitaHandler } from './qiita.js'
 
 describe('qiitaHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://qiita.com/Qiita', true],
-      ['https://www.qiita.com/user', true],
-      ['https://qiita.com', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://qiita.com/Qiita'],
+      [true, 'https://www.qiita.com/user'],
+      [true, 'https://qiita.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(qiitaHandler.match(url)).toBe(expected)
     })
 
@@ -92,6 +92,25 @@ describe('qiitaHandler', () => {
       expect(qiitaHandler.resolve(value)).toEqual([])
     })
 
+    it('should return empty array for excluded paths', () => {
+      const values = [
+        'https://qiita.com/about',
+        'https://qiita.com/api',
+        'https://qiita.com/login',
+        'https://qiita.com/organizations',
+        'https://qiita.com/privacy',
+        'https://qiita.com/search',
+        'https://qiita.com/settings',
+        'https://qiita.com/signup',
+        'https://qiita.com/terms',
+        'https://qiita.com/trend',
+      ]
+
+      for (const value of values) {
+        expect(qiitaHandler.resolve(value)).toEqual([])
+      }
+    })
+
     it('should return Qiita Zine feed for /official-columns', () => {
       const value = 'https://qiita.com/official-columns'
       const expected = [
@@ -114,6 +133,11 @@ describe('qiitaHandler', () => {
       ]
 
       expect(qiitaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/reddit.test.ts
+++ b/src/feeds/platform/handlers/reddit.test.ts
@@ -4,15 +4,15 @@ import { redditHandler } from './reddit.js'
 
 describe('redditHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://reddit.com/r/programming', true],
-      ['https://www.reddit.com/r/programming', true],
-      ['https://old.reddit.com/r/programming', true],
-      ['https://new.reddit.com/r/programming', true],
-      ['https://example.com/r/test', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://reddit.com/r/programming'],
+      [true, 'https://www.reddit.com/r/programming'],
+      [true, 'https://old.reddit.com/r/programming'],
+      [true, 'https://new.reddit.com/r/programming'],
+      [false, 'https://example.com/r/test'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(redditHandler.match(url)).toBe(expected)
     })
 
@@ -38,113 +38,126 @@ describe('redditHandler', () => {
       expect(redditHandler.resolve(value)).toEqual(expected)
     })
 
-    it('should return sorted RSS feed URL and all-comments feed when viewing sorted subreddit', () => {
-      const cases: Array<[string, Array<DiscoverUriEntry>]> = [
+    const sortedValues: Array<[string, Array<DiscoverUriEntry>]> = [
+      [
+        'https://reddit.com/r/programming/hot',
         [
-          'https://reddit.com/r/programming/hot',
-          [
-            {
-              uri: 'https://www.reddit.com/r/programming/hot/.rss',
-              hint: { key: 'reddit:posts', label: 'Posts' },
-            },
-            {
-              uri: 'https://www.reddit.com/r/programming/comments/.rss',
-              hint: { key: 'reddit:comments', label: 'Comments' },
-            },
-          ],
+          {
+            uri: 'https://www.reddit.com/r/programming/hot/.rss',
+            hint: { key: 'reddit:posts', label: 'Posts' },
+          },
+          {
+            uri: 'https://www.reddit.com/r/programming/comments/.rss',
+            hint: { key: 'reddit:comments', label: 'Comments' },
+          },
         ],
+      ],
+      [
+        'https://reddit.com/r/programming/new',
         [
-          'https://reddit.com/r/programming/new',
-          [
-            {
-              uri: 'https://www.reddit.com/r/programming/new/.rss',
-              hint: { key: 'reddit:posts', label: 'Posts' },
-            },
-            {
-              uri: 'https://www.reddit.com/r/programming/comments/.rss',
-              hint: { key: 'reddit:comments', label: 'Comments' },
-            },
-          ],
+          {
+            uri: 'https://www.reddit.com/r/programming/new/.rss',
+            hint: { key: 'reddit:posts', label: 'Posts' },
+          },
+          {
+            uri: 'https://www.reddit.com/r/programming/comments/.rss',
+            hint: { key: 'reddit:comments', label: 'Comments' },
+          },
         ],
+      ],
+      [
+        'https://reddit.com/r/programming/rising',
         [
-          'https://reddit.com/r/programming/rising',
-          [
-            {
-              uri: 'https://www.reddit.com/r/programming/rising/.rss',
-              hint: { key: 'reddit:posts', label: 'Posts' },
-            },
-            {
-              uri: 'https://www.reddit.com/r/programming/comments/.rss',
-              hint: { key: 'reddit:comments', label: 'Comments' },
-            },
-          ],
+          {
+            uri: 'https://www.reddit.com/r/programming/rising/.rss',
+            hint: { key: 'reddit:posts', label: 'Posts' },
+          },
+          {
+            uri: 'https://www.reddit.com/r/programming/comments/.rss',
+            hint: { key: 'reddit:comments', label: 'Comments' },
+          },
         ],
+      ],
+      [
+        'https://reddit.com/r/programming/controversial',
         [
-          'https://reddit.com/r/programming/controversial',
-          [
-            {
-              uri: 'https://www.reddit.com/r/programming/controversial/.rss',
-              hint: { key: 'reddit:posts', label: 'Posts' },
-            },
-            {
-              uri: 'https://www.reddit.com/r/programming/comments/.rss',
-              hint: { key: 'reddit:comments', label: 'Comments' },
-            },
-          ],
+          {
+            uri: 'https://www.reddit.com/r/programming/controversial/.rss',
+            hint: { key: 'reddit:posts', label: 'Posts' },
+          },
+          {
+            uri: 'https://www.reddit.com/r/programming/comments/.rss',
+            hint: { key: 'reddit:comments', label: 'Comments' },
+          },
         ],
+      ],
+      [
+        'https://reddit.com/r/programming/top',
         [
-          'https://reddit.com/r/programming/top',
-          [
-            {
-              uri: 'https://www.reddit.com/r/programming/top/.rss',
-              hint: { key: 'reddit:posts', label: 'Posts' },
-            },
-            {
-              uri: 'https://www.reddit.com/r/programming/comments/.rss',
-              hint: { key: 'reddit:comments', label: 'Comments' },
-            },
-          ],
+          {
+            uri: 'https://www.reddit.com/r/programming/top/.rss',
+            hint: { key: 'reddit:posts', label: 'Posts' },
+          },
+          {
+            uri: 'https://www.reddit.com/r/programming/comments/.rss',
+            hint: { key: 'reddit:comments', label: 'Comments' },
+          },
         ],
-      ]
+      ],
+      [
+        'https://reddit.com/r/programming/best',
+        [
+          {
+            uri: 'https://www.reddit.com/r/programming/best/.rss',
+            hint: { key: 'reddit:posts', label: 'Posts' },
+          },
+          {
+            uri: 'https://www.reddit.com/r/programming/comments/.rss',
+            hint: { key: 'reddit:comments', label: 'Comments' },
+          },
+        ],
+      ],
+    ]
 
-      for (const [value, expected] of cases) {
-        expect(redditHandler.resolve(value)).toEqual(expected)
-      }
+    it.each(
+      sortedValues,
+    )('should return sorted RSS feed URL and all-comments feed for %s', (url, expected) => {
+      expect(redditHandler.resolve(url)).toEqual(expected)
     })
 
-    it('should forward ?t=timeframe on top and controversial sorts', () => {
-      const cases: Array<[string, Array<DiscoverUriEntry>]> = [
+    const timeframeValues: Array<[string, Array<DiscoverUriEntry>]> = [
+      [
+        'https://reddit.com/r/programming/top?t=week',
         [
-          'https://reddit.com/r/programming/top?t=week',
-          [
-            {
-              uri: 'https://www.reddit.com/r/programming/top/.rss?t=week',
-              hint: { key: 'reddit:posts', label: 'Posts' },
-            },
-            {
-              uri: 'https://www.reddit.com/r/programming/comments/.rss',
-              hint: { key: 'reddit:comments', label: 'Comments' },
-            },
-          ],
+          {
+            uri: 'https://www.reddit.com/r/programming/top/.rss?t=week',
+            hint: { key: 'reddit:posts', label: 'Posts' },
+          },
+          {
+            uri: 'https://www.reddit.com/r/programming/comments/.rss',
+            hint: { key: 'reddit:comments', label: 'Comments' },
+          },
         ],
+      ],
+      [
+        'https://reddit.com/r/programming/controversial?t=all',
         [
-          'https://reddit.com/r/programming/controversial?t=all',
-          [
-            {
-              uri: 'https://www.reddit.com/r/programming/controversial/.rss?t=all',
-              hint: { key: 'reddit:posts', label: 'Posts' },
-            },
-            {
-              uri: 'https://www.reddit.com/r/programming/comments/.rss',
-              hint: { key: 'reddit:comments', label: 'Comments' },
-            },
-          ],
+          {
+            uri: 'https://www.reddit.com/r/programming/controversial/.rss?t=all',
+            hint: { key: 'reddit:posts', label: 'Posts' },
+          },
+          {
+            uri: 'https://www.reddit.com/r/programming/comments/.rss',
+            hint: { key: 'reddit:comments', label: 'Comments' },
+          },
         ],
-      ]
+      ],
+    ]
 
-      for (const [value, expected] of cases) {
-        expect(redditHandler.resolve(value)).toEqual(expected)
-      }
+    it.each(
+      timeframeValues,
+    )('should forward ?t=timeframe on time-filtered sort for %s', (url, expected) => {
+      expect(redditHandler.resolve(url)).toEqual(expected)
     })
 
     it('should drop unknown ?t= values', () => {
@@ -212,6 +225,18 @@ describe('redditHandler', () => {
       const expected = [
         {
           uri: 'https://www.reddit.com/top/.rss?t=week',
+          hint: { key: 'reddit:posts', label: 'Posts' },
+        },
+      ]
+
+      expect(redditHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return sitewide sort feed for /best', () => {
+      const value = 'https://www.reddit.com/best'
+      const expected = [
+        {
+          uri: 'https://www.reddit.com/best/.rss',
           hint: { key: 'reddit:posts', label: 'Posts' },
         },
       ]
@@ -294,6 +319,30 @@ describe('redditHandler', () => {
       const expected = [
         {
           uri: 'https://www.reddit.com/subreddits/popular/.rss',
+          hint: { key: 'reddit:subreddits', label: 'Subreddits' },
+        },
+      ]
+
+      expect(redditHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return subreddit-list feed for /subreddits/new', () => {
+      const value = 'https://www.reddit.com/subreddits/new'
+      const expected = [
+        {
+          uri: 'https://www.reddit.com/subreddits/new/.rss',
+          hint: { key: 'reddit:subreddits', label: 'Subreddits' },
+        },
+      ]
+
+      expect(redditHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return subreddit-list feed for /reddits alias', () => {
+      const value = 'https://www.reddit.com/reddits'
+      const expected = [
+        {
+          uri: 'https://www.reddit.com/subreddits/.rss',
           hint: { key: 'reddit:subreddits', label: 'Subreddits' },
         },
       ]
@@ -464,6 +513,11 @@ describe('redditHandler', () => {
       ]
 
       expect(redditHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/rssCom.test.ts
+++ b/src/feeds/platform/handlers/rssCom.test.ts
@@ -3,14 +3,14 @@ import { rssComHandler } from './rssCom.js'
 
 describe('rssComHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://rss.com/podcasts/podcasting101', true],
-      ['https://www.rss.com/podcasts/some-show', true],
-      ['https://rss.com', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://rss.com/podcasts/podcasting101'],
+      [true, 'https://www.rss.com/podcasts/some-show'],
+      [true, 'https://rss.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(rssComHandler.match(url)).toBe(expected)
     })
 
@@ -78,6 +78,11 @@ describe('rssComHandler', () => {
       ]
 
       expect(rssComHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/seesaa.test.ts
+++ b/src/feeds/platform/handlers/seesaa.test.ts
@@ -3,14 +3,14 @@ import { seesaaHandler } from './seesaa.js'
 
 describe('seesaaHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://jetstream777.seesaa.net', true],
-      ['https://blog.example.seesaa.net', true],
-      ['https://seesaa.net', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://jetstream777.seesaa.net'],
+      [true, 'https://blog.example.seesaa.net'],
+      [false, 'https://seesaa.net'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(seesaaHandler.match(url)).toBe(expected)
     })
 
@@ -50,6 +50,11 @@ describe('seesaaHandler', () => {
       ]
 
       expect(seesaaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/soundcloud.test.ts
+++ b/src/feeds/platform/handlers/soundcloud.test.ts
@@ -3,22 +3,25 @@ import { soundcloudHandler } from './soundcloud.js'
 
 describe('soundcloudHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://soundcloud.com/diplo', true],
-      ['https://www.soundcloud.com/diplo', true],
-      ['https://m.soundcloud.com/diplo', true],
-      ['https://soundcloud.com/diplo/tracks', true],
-      ['https://soundcloud.com/discover', false],
-      ['https://soundcloud.com/stream', false],
-      ['https://soundcloud.com/search', false],
-      ['https://soundcloud.com/upload', false],
-      ['https://soundcloud.com/Discover', false],
-      ['https://soundcloud.com/STREAM', false],
-      ['https://soundcloud.com', false],
-      ['https://example.com/diplo', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://soundcloud.com/diplo'],
+      [true, 'https://www.soundcloud.com/diplo'],
+      [true, 'https://m.soundcloud.com/diplo'],
+      [true, 'https://soundcloud.com/diplo/tracks'],
+      [false, 'https://soundcloud.com/discover'],
+      [false, 'https://soundcloud.com/stream'],
+      [false, 'https://soundcloud.com/search'],
+      [false, 'https://soundcloud.com/upload'],
+      [false, 'https://soundcloud.com/you'],
+      [false, 'https://soundcloud.com/settings'],
+      [false, 'https://soundcloud.com/messages'],
+      [false, 'https://soundcloud.com/Discover'],
+      [false, 'https://soundcloud.com/STREAM'],
+      [false, 'https://soundcloud.com'],
+      [false, 'https://example.com/diplo'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(soundcloudHandler.match(url)).toBe(expected)
     })
 
@@ -56,6 +59,10 @@ describe('soundcloudHandler', () => {
       const content = '<html><body>No user ID here</body></html>'
 
       expect(soundcloudHandler.resolve(value, content)).toEqual([])
+    })
+
+    it('should return empty array for invalid URL without content', () => {
+      expect(soundcloudHandler.resolve('not-a-url')).toEqual([])
     })
   })
 })

--- a/src/feeds/platform/handlers/sourceforge.test.ts
+++ b/src/feeds/platform/handlers/sourceforge.test.ts
@@ -3,16 +3,16 @@ import { sourceforgeHandler } from './sourceforge.js'
 
 describe('sourceforgeHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://sourceforge.net/projects/filezilla', true],
-      ['https://www.sourceforge.net/projects/nmap', true],
-      ['https://sourceforge.net/p/nmap/activity', true],
-      ['https://sourceforge.net', true],
-      ['https://github.com/user/repo', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://sourceforge.net/projects/filezilla'],
+      [true, 'https://www.sourceforge.net/projects/nmap'],
+      [true, 'https://sourceforge.net/p/nmap/activity'],
+      [true, 'https://sourceforge.net'],
+      [false, 'https://github.com/user/repo'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(sourceforgeHandler.match(url)).toBe(expected)
     })
 
@@ -170,6 +170,11 @@ describe('sourceforgeHandler', () => {
       const value = 'https://sourceforge.net/p'
 
       expect(sourceforgeHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/spreaker.test.ts
+++ b/src/feeds/platform/handlers/spreaker.test.ts
@@ -3,14 +3,14 @@ import { spreakerHandler } from './spreaker.js'
 
 describe('spreakerHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://www.spreaker.com/podcast/spreaker-live-show--1433865', true],
-      ['https://spreaker.com/podcast/my-show--12345', true],
-      ['https://spreaker.com', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://www.spreaker.com/podcast/spreaker-live-show--1433865'],
+      [true, 'https://spreaker.com/podcast/my-show--12345'],
+      [true, 'https://spreaker.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(spreakerHandler.match(url)).toBe(expected)
     })
 
@@ -66,6 +66,23 @@ describe('spreakerHandler', () => {
       ]
 
       expect(spreakerHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return feed URL for /show/{id} with deeper path', () => {
+      const value = 'https://www.spreaker.com/show/1433865/episodes'
+      const expected = [
+        {
+          uri: 'https://www.spreaker.com/show/1433865/episodes/feed',
+          hint: { key: 'spreaker:podcast', label: 'Podcast' },
+        },
+      ]
+
+      expect(spreakerHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/stackExchange.test.ts
+++ b/src/feeds/platform/handlers/stackExchange.test.ts
@@ -1,26 +1,26 @@
 import { describe, expect, it } from 'bun:test'
+import type { DiscoverUriEntry } from '../../../common/types.js'
 import { stackExchangeHandler } from './stackExchange.js'
 
 describe('stackExchangeHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://stackoverflow.com/questions/tagged/javascript', true],
-      ['https://www.stackoverflow.com/questions/12345', true],
-      ['https://serverfault.com/users/123', true],
-      ['https://superuser.com/', true],
-      ['https://askubuntu.com/questions/tagged/apt', true],
-      ['https://stackapps.com/', true],
-      ['https://mathoverflow.net/questions/tagged/algebra', true],
-      ['https://www.stackoverflow.com/questions/12345', true],
-      ['https://meta.stackoverflow.com/', true],
-      ['https://es.stackoverflow.com/', true],
-      ['https://meta.mathoverflow.net/', true],
-      ['https://math.stackexchange.com/questions/tagged/calculus', true],
-      ['https://gaming.stackexchange.com/', true],
-      ['https://example.com/questions', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://stackoverflow.com/questions/tagged/javascript'],
+      [true, 'https://www.stackoverflow.com/questions/12345'],
+      [true, 'https://serverfault.com/users/123'],
+      [true, 'https://superuser.com/'],
+      [true, 'https://askubuntu.com/questions/tagged/apt'],
+      [true, 'https://stackapps.com/'],
+      [true, 'https://mathoverflow.net/questions/tagged/algebra'],
+      [true, 'https://meta.stackoverflow.com/'],
+      [true, 'https://es.stackoverflow.com/'],
+      [true, 'https://meta.mathoverflow.net/'],
+      [true, 'https://math.stackexchange.com/questions/tagged/calculus'],
+      [true, 'https://gaming.stackexchange.com/'],
+      [false, 'https://example.com/questions'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(stackExchangeHandler.match(url)).toBe(expected)
     })
 
@@ -162,18 +162,58 @@ describe('stackExchangeHandler', () => {
       expect(stackExchangeHandler.resolve(value)).toEqual(expected)
     })
 
-    it('should pass through ?sort= on tag feed when value is allowed', () => {
-      for (const sort of ['newest', 'active', 'votes', 'creation']) {
-        const value = `https://stackoverflow.com/questions/tagged/javascript?sort=${sort}`
-        const expected = [
+    const allowedSortValues: Array<[string, Array<DiscoverUriEntry>]> = [
+      [
+        'https://stackoverflow.com/questions/tagged/javascript?sort=newest',
+        [
           {
-            uri: `https://stackoverflow.com/feeds/tag/javascript?sort=${sort}`,
+            uri: 'https://stackoverflow.com/feeds/tag/javascript?sort=newest',
             hint: { key: 'stackexchange:tag', label: 'Tag' },
           },
-        ]
+        ],
+      ],
+      [
+        'https://stackoverflow.com/questions/tagged/javascript?sort=active',
+        [
+          {
+            uri: 'https://stackoverflow.com/feeds/tag/javascript?sort=active',
+            hint: { key: 'stackexchange:tag', label: 'Tag' },
+          },
+        ],
+      ],
+      [
+        'https://stackoverflow.com/questions/tagged/javascript?sort=votes',
+        [
+          {
+            uri: 'https://stackoverflow.com/feeds/tag/javascript?sort=votes',
+            hint: { key: 'stackexchange:tag', label: 'Tag' },
+          },
+        ],
+      ],
+      [
+        'https://stackoverflow.com/questions/tagged/javascript?sort=creation',
+        [
+          {
+            uri: 'https://stackoverflow.com/feeds/tag/javascript?sort=creation',
+            hint: { key: 'stackexchange:tag', label: 'Tag' },
+          },
+        ],
+      ],
+      [
+        'https://stackoverflow.com/questions/tagged/javascript?sort=month',
+        [
+          {
+            uri: 'https://stackoverflow.com/feeds/tag/javascript?sort=month',
+            hint: { key: 'stackexchange:tag', label: 'Tag' },
+          },
+        ],
+      ],
+    ]
 
-        expect(stackExchangeHandler.resolve(value)).toEqual(expected)
-      }
+    it.each(
+      allowedSortValues,
+    )('should pass through allowed ?sort= value for %s', (url, expected) => {
+      expect(stackExchangeHandler.resolve(url)).toEqual(expected)
     })
 
     it('should pass through ?tab= on tag feed (lowercased) when value is allowed', () => {
@@ -212,6 +252,18 @@ describe('stackExchangeHandler', () => {
       expect(stackExchangeHandler.resolve(value)).toEqual(expected)
     })
 
+    it('should drop disallowed ?tab= values silently', () => {
+      const value = 'https://stackoverflow.com/questions/tagged/javascript?tab=Frequent'
+      const expected = [
+        {
+          uri: 'https://stackoverflow.com/feeds/tag/javascript',
+          hint: { key: 'stackexchange:tag', label: 'Tag' },
+        },
+      ]
+
+      expect(stackExchangeHandler.resolve(value)).toEqual(expected)
+    })
+
     it('should drop unknown sort values silently', () => {
       const value = 'https://stackoverflow.com/questions/tagged/javascript?sort=garbage'
       const expected = [
@@ -226,6 +278,11 @@ describe('stackExchangeHandler', () => {
 
     it('should return empty array for unrecognized path', () => {
       expect(stackExchangeHandler.resolve('https://stackoverflow.com/company')).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/steam.test.ts
+++ b/src/feeds/platform/handlers/steam.test.ts
@@ -3,15 +3,15 @@ import { steamHandler } from './steam.js'
 
 describe('steamHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://store.steampowered.com/app/730/Counter_Strike_2/', true],
-      ['https://store.steampowered.com/news/app/730/', true],
-      ['https://steamcommunity.com/app/730', true],
-      ['https://steamcommunity.com/groups/Valve', true],
-      ['https://example.com/app/730', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://store.steampowered.com/app/730/Counter_Strike_2/'],
+      [true, 'https://store.steampowered.com/news/app/730/'],
+      [true, 'https://steamcommunity.com/app/730'],
+      [true, 'https://steamcommunity.com/groups/Valve'],
+      [false, 'https://example.com/app/730'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(steamHandler.match(url)).toBe(expected)
     })
 
@@ -131,6 +131,11 @@ describe('steamHandler', () => {
 
     it('should return empty array for unrecognized store path', () => {
       expect(steamHandler.resolve('https://store.steampowered.com/about/')).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/substack.test.ts
+++ b/src/feeds/platform/handlers/substack.test.ts
@@ -3,18 +3,18 @@ import { substackHandler } from './substack.js'
 
 describe('substackHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://example.substack.com', true],
-      ['https://blog.example.substack.com', true],
-      ['https://substack.com/@govtrackus', true],
-      ['https://substack.com/@theconsciouslee', true],
-      ['https://substack.com/@user-name', true],
-      ['https://substack.com/home', false],
-      ['https://substack.com', false],
-      ['https://medium.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://example.substack.com'],
+      [true, 'https://blog.example.substack.com'],
+      [true, 'https://substack.com/@govtrackus'],
+      [true, 'https://substack.com/@theconsciouslee'],
+      [true, 'https://substack.com/@user-name'],
+      [false, 'https://substack.com/home'],
+      [false, 'https://substack.com'],
+      [false, 'https://medium.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(substackHandler.match(url)).toBe(expected)
     })
 
@@ -70,6 +70,23 @@ describe('substackHandler', () => {
       ]
 
       expect(substackHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should fall back to origin feed for apex URL without profile path', () => {
+      const value = 'https://substack.com/home'
+      const expected = [
+        {
+          uri: 'https://substack.com/feed',
+          hint: { key: 'substack:newsletter', label: 'Newsletter' },
+        },
+      ]
+
+      expect(substackHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/tildes.test.ts
+++ b/src/feeds/platform/handlers/tildes.test.ts
@@ -3,14 +3,14 @@ import { tildesHandler } from './tildes.js'
 
 describe('tildesHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://tildes.net/~tech', true],
-      ['https://www.tildes.net/~science', true],
-      ['https://tildes.net', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://tildes.net/~tech'],
+      [true, 'https://www.tildes.net/~science'],
+      [true, 'https://tildes.net'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(tildesHandler.match(url)).toBe(expected)
     })
 
@@ -104,6 +104,11 @@ describe('tildesHandler', () => {
       ]
 
       expect(tildesHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/tistory.test.ts
+++ b/src/feeds/platform/handlers/tistory.test.ts
@@ -3,14 +3,14 @@ import { tistoryHandler } from './tistory.js'
 
 describe('tistoryHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://headstartup.tistory.com', true],
-      ['https://blog.example.tistory.com', true],
-      ['https://tistory.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://headstartup.tistory.com'],
+      [true, 'https://blog.example.tistory.com'],
+      [false, 'https://tistory.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(tistoryHandler.match(url)).toBe(expected)
     })
 
@@ -42,6 +42,11 @@ describe('tistoryHandler', () => {
       ]
 
       expect(tistoryHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/transistor.test.ts
+++ b/src/feeds/platform/handlers/transistor.test.ts
@@ -3,18 +3,18 @@ import { transistorHandler } from './transistor.js'
 
 describe('transistorHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://build-your-saas.transistor.fm', true],
-      ['https://blog.example.transistor.fm', true],
-      ['https://transistor.fm', false],
-      ['https://example.com', false],
-      ['https://www.transistor.fm', false],
-      ['https://feeds.transistor.fm', false],
-      ['https://share.transistor.fm', false],
-      ['https://support.transistor.fm', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://build-your-saas.transistor.fm'],
+      [true, 'https://blog.example.transistor.fm'],
+      [false, 'https://transistor.fm'],
+      [false, 'https://example.com'],
+      [false, 'https://www.transistor.fm'],
+      [false, 'https://feeds.transistor.fm'],
+      [false, 'https://share.transistor.fm'],
+      [false, 'https://support.transistor.fm'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(transistorHandler.match(url)).toBe(expected)
     })
 
@@ -46,6 +46,11 @@ describe('transistorHandler', () => {
       ]
 
       expect(transistorHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/tumblr.test.ts
+++ b/src/feeds/platform/handlers/tumblr.test.ts
@@ -3,14 +3,14 @@ import { tumblrHandler } from './tumblr.js'
 
 describe('tumblrHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://example.tumblr.com', true],
-      ['https://blog.example.tumblr.com', true],
-      ['https://tumblr.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://example.tumblr.com'],
+      [true, 'https://blog.example.tumblr.com'],
+      [false, 'https://tumblr.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(tumblrHandler.match(url)).toBe(expected)
     })
 
@@ -48,6 +48,16 @@ describe('tumblrHandler', () => {
       ]
 
       expect(tumblrHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should resolve blog name from www.tumblr.com/{blog} URLs', () => {
+      // resolve currently emits https://www.tumblr.com/rss for www.tumblr.com/{blog},
+      // dropping the blog name from the feed URL; likely needs a source fix.
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/v2ex.test.ts
+++ b/src/feeds/platform/handlers/v2ex.test.ts
@@ -3,13 +3,13 @@ import { v2exHandler } from './v2ex.js'
 
 describe('v2exHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://www.v2ex.com/', true],
-      ['https://v2ex.com/', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://www.v2ex.com/'],
+      [true, 'https://v2ex.com/'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(v2exHandler.match(url)).toBe(expected)
     })
 
@@ -83,6 +83,23 @@ describe('v2exHandler', () => {
       const value = 'https://www.v2ex.com/t/12345'
 
       expect(v2exHandler.resolve(value)).toEqual([])
+    })
+
+    it('should return tab feed for /t/{id} page with tab query', () => {
+      const value = 'https://www.v2ex.com/t/12345?tab=tech'
+      const expected = [
+        {
+          uri: 'https://www.v2ex.com/feed/tab/tech.xml',
+          hint: { key: 'v2ex:tab', label: 'Tab' },
+        },
+      ]
+
+      expect(v2exHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/velog.test.ts
+++ b/src/feeds/platform/handlers/velog.test.ts
@@ -3,14 +3,14 @@ import { velogHandler } from './velog.js'
 
 describe('velogHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://velog.io/@velopert', true],
-      ['https://www.velog.io/@user', true],
-      ['https://velog.io', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://velog.io/@velopert'],
+      [true, 'https://www.velog.io/@user'],
+      [true, 'https://velog.io'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(velogHandler.match(url)).toBe(expected)
     })
 
@@ -60,6 +60,11 @@ describe('velogHandler', () => {
       const value = 'https://velog.io/trending'
 
       expect(velogHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/vimeo.test.ts
+++ b/src/feeds/platform/handlers/vimeo.test.ts
@@ -3,15 +3,15 @@ import { vimeoHandler } from './vimeo.js'
 
 describe('vimeoHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://vimeo.com/casey', true],
-      ['https://vimeo.com/channels/staffpicks', true],
-      ['https://www.vimeo.com/user', true],
-      ['https://youtube.com/user', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://vimeo.com/casey'],
+      [true, 'https://vimeo.com/channels/staffpicks'],
+      [true, 'https://www.vimeo.com/user'],
+      [false, 'https://youtube.com/user'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(vimeoHandler.match(url)).toBe(expected)
     })
 
@@ -172,6 +172,32 @@ describe('vimeoHandler', () => {
         'https://vimeo.com/upload',
         'https://vimeo.com/settings',
         'https://vimeo.com/explore',
+        'https://vimeo.com/about',
+        'https://vimeo.com/album',
+        'https://vimeo.com/blog',
+        'https://vimeo.com/business',
+        'https://vimeo.com/careers',
+        'https://vimeo.com/categories',
+        'https://vimeo.com/channels',
+        'https://vimeo.com/create',
+        'https://vimeo.com/enterprise',
+        'https://vimeo.com/features',
+        'https://vimeo.com/for-hire',
+        'https://vimeo.com/groups',
+        'https://vimeo.com/help',
+        'https://vimeo.com/join',
+        'https://vimeo.com/log_in',
+        'https://vimeo.com/manage',
+        'https://vimeo.com/ondemand',
+        'https://vimeo.com/ott',
+        'https://vimeo.com/plus',
+        'https://vimeo.com/pricing',
+        'https://vimeo.com/pro',
+        'https://vimeo.com/showcase',
+        'https://vimeo.com/site_map',
+        'https://vimeo.com/solutions',
+        'https://vimeo.com/stock',
+        'https://vimeo.com/upgrade',
       ]
 
       for (const value of values) {
@@ -189,6 +215,11 @@ describe('vimeoHandler', () => {
       for (const value of values) {
         expect(vimeoHandler.resolve(value)).toEqual([])
       }
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/weblogLol.test.ts
+++ b/src/feeds/platform/handlers/weblogLol.test.ts
@@ -3,14 +3,14 @@ import { weblogLolHandler } from './weblogLol.js'
 
 describe('weblogLolHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://robb.weblog.lol', true],
-      ['https://blog.example.weblog.lol', true],
-      ['https://weblog.lol', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://robb.weblog.lol'],
+      [true, 'https://blog.example.weblog.lol'],
+      [false, 'https://weblog.lol'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(weblogLolHandler.match(url)).toBe(expected)
     })
 
@@ -58,6 +58,11 @@ describe('weblogLolHandler', () => {
       ]
 
       expect(weblogLolHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/weebly.test.ts
+++ b/src/feeds/platform/handlers/weebly.test.ts
@@ -3,14 +3,14 @@ import { weeblyHandler } from './weebly.js'
 
 describe('weeblyHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://example.weebly.com', true],
-      ['https://blog.example.weebly.com', true],
-      ['https://weebly.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://example.weebly.com'],
+      [true, 'https://blog.example.weebly.com'],
+      [false, 'https://weebly.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(weeblyHandler.match(url)).toBe(expected)
     })
 
@@ -58,6 +58,16 @@ describe('weeblyHandler', () => {
       ]
 
       expect(weeblyHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should not emit duplicate entries for /blog paths', () => {
+      // resolve('https://example.weebly.com/blog') currently returns the same
+      // /blog/feed entry twice (custom slug branch plus default); likely needs a source fix.
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/wordpress.test.ts
+++ b/src/feeds/platform/handlers/wordpress.test.ts
@@ -1,16 +1,17 @@
 import { describe, expect, it } from 'bun:test'
+import type { DiscoverUriEntry } from '../../../common/types.js'
 import { wordpressHandler } from './wordpress.js'
 
 describe('wordpressHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://example.wordpress.com', true],
-      ['https://blog.example.wordpress.com', true],
-      ['https://wordpress.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://example.wordpress.com'],
+      [true, 'https://blog.example.wordpress.com'],
+      [false, 'https://wordpress.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(wordpressHandler.match(url)).toBe(expected)
     })
 
@@ -715,11 +716,55 @@ describe('wordpressHandler', () => {
 
     it('should not emit post comments feed when URL path is a feed URL', () => {
       const value = 'https://blog.wordpress.com/feed/atom/'
-      const result = wordpressHandler.resolve(value) as Array<{ hint?: { key: string } }>
+      const expected: Array<DiscoverUriEntry> = [
+        {
+          uri: [
+            'https://blog.wordpress.com/feed/',
+            'https://blog.wordpress.com/?feed=rss',
+            'https://blog.wordpress.com/feed/rss2/',
+            'https://blog.wordpress.com/?feed=rss2',
+          ],
+          hint: { key: 'wordpress:posts-rss', label: 'Posts (RSS)' },
+        },
+        {
+          uri: ['https://blog.wordpress.com/feed/atom/', 'https://blog.wordpress.com/?feed=atom'],
+          hint: { key: 'wordpress:posts-atom', label: 'Posts (Atom)' },
+        },
+        {
+          uri: ['https://blog.wordpress.com/feed/rdf/', 'https://blog.wordpress.com/?feed=rdf'],
+          hint: { key: 'wordpress:posts-rdf', label: 'Posts (RDF)' },
+        },
+        {
+          uri: [
+            'https://blog.wordpress.com/comments/feed/',
+            'https://blog.wordpress.com/?feed=comments-rss',
+            'https://blog.wordpress.com/comments/feed/rss2/',
+            'https://blog.wordpress.com/?feed=comments-rss2',
+          ],
+          hint: { key: 'wordpress:comments-rss', label: 'Comments (RSS)' },
+        },
+        {
+          uri: [
+            'https://blog.wordpress.com/comments/feed/atom/',
+            'https://blog.wordpress.com/?feed=comments-atom',
+          ],
+          hint: { key: 'wordpress:comments-atom', label: 'Comments (Atom)' },
+        },
+        {
+          uri: [
+            'https://blog.wordpress.com/comments/feed/rdf/',
+            'https://blog.wordpress.com/?feed=comments-rdf',
+          ],
+          hint: { key: 'wordpress:comments-rdf', label: 'Comments (RDF)' },
+        },
+      ]
 
-      for (const entry of result) {
-        expect(entry.hint?.key?.startsWith('wordpress:post-comments')).toBe(false)
-      }
+      expect(wordpressHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/wpengine.test.ts
+++ b/src/feeds/platform/handlers/wpengine.test.ts
@@ -3,17 +3,17 @@ import { wpengineHandler } from './wpengine.js'
 
 describe('wpengineHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://example.wpenginepowered.com', true],
-      ['https://blog.example.wpenginepowered.com', true],
-      ['https://example.wpengine.com', true],
-      ['https://blog.example.wpengine.com', true],
-      ['https://wpenginepowered.com', false],
-      ['https://wpengine.com', false],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://example.wpenginepowered.com'],
+      [true, 'https://blog.example.wpenginepowered.com'],
+      [true, 'https://example.wpengine.com'],
+      [true, 'https://blog.example.wpengine.com'],
+      [false, 'https://wpenginepowered.com'],
+      [false, 'https://wpengine.com'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(wpengineHandler.match(url)).toBe(expected)
     })
 
@@ -662,6 +662,11 @@ describe('wpengineHandler', () => {
       ]
 
       expect(wpengineHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/writeas.test.ts
+++ b/src/feeds/platform/handlers/writeas.test.ts
@@ -3,14 +3,14 @@ import { writeasHandler } from './writeas.js'
 
 describe('writeasHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://write.as/matt', true],
-      ['https://www.write.as/user', true],
-      ['https://write.as', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://write.as/matt'],
+      [true, 'https://www.write.as/user'],
+      [true, 'https://write.as'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(writeasHandler.match(url)).toBe(expected)
     })
 
@@ -70,6 +70,11 @@ describe('writeasHandler', () => {
       const value = 'https://write.as/login'
 
       expect(writeasHandler.resolve(value)).toEqual([])
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/ximalaya.test.ts
+++ b/src/feeds/platform/handlers/ximalaya.test.ts
@@ -3,13 +3,13 @@ import { ximalayaHandler } from './ximalaya.js'
 
 describe('ximalayaHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://www.ximalaya.com/album/203355', true],
-      ['https://ximalaya.com/album/203355', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://www.ximalaya.com/album/203355'],
+      [true, 'https://ximalaya.com/album/203355'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(ximalayaHandler.match(url)).toBe(expected)
     })
 
@@ -71,6 +71,11 @@ describe('ximalayaHandler', () => {
       ]
 
       expect(ximalayaHandler.resolve(value)).toEqual(expected)
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/youtube.test.ts
+++ b/src/feeds/platform/handlers/youtube.test.ts
@@ -4,17 +4,17 @@ import { youtubeHandler } from './youtube.js'
 
 describe('youtubeHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://youtube.com/@channel', true],
-      ['https://www.youtube.com/@channel', true],
-      ['https://m.youtube.com/@channel', true],
-      ['https://music.youtube.com/channel/UC1234567890', true],
-      ['https://youtu.be/dQw4w9WgXcQ', true],
-      ['https://www.youtu.be/dQw4w9WgXcQ', true],
-      ['https://vimeo.com/channel', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://youtube.com/@channel'],
+      [true, 'https://www.youtube.com/@channel'],
+      [true, 'https://m.youtube.com/@channel'],
+      [true, 'https://music.youtube.com/channel/UC1234567890'],
+      [true, 'https://youtu.be/dQw4w9WgXcQ'],
+      [true, 'https://www.youtu.be/dQw4w9WgXcQ'],
+      [false, 'https://vimeo.com/channel'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(youtubeHandler.match(url)).toBe(expected)
     })
 
@@ -71,13 +71,13 @@ describe('youtubeHandler', () => {
     ]
 
     it('should return all feed variants for channel ID', () => {
-      const value = youtubeHandler.resolve('https://youtube.com/channel/UC1234567890')
+      const value = 'https://youtube.com/channel/UC1234567890'
 
-      expect(value).toEqual(expectedChannelFeeds)
+      expect(youtubeHandler.resolve(value)).toEqual(expectedChannelFeeds)
     })
 
     it('should return feed URL for playlist', () => {
-      const value = youtubeHandler.resolve('https://youtube.com/playlist?list=PL1234567890')
+      const value = 'https://youtube.com/playlist?list=PL1234567890'
       const expected: Array<DiscoverUriEntry> = [
         {
           uri: 'https://www.youtube.com/feeds/videos.xml?playlist_id=PL1234567890',
@@ -85,124 +85,116 @@ describe('youtubeHandler', () => {
         },
       ]
 
-      expect(value).toEqual(expected)
+      expect(youtubeHandler.resolve(value)).toEqual(expected)
+    })
+
+    it('should return only playlist feed for watch page with list param', () => {
+      const value = 'https://youtube.com/watch?v=abc123&list=PL1234567890'
+      const expected: Array<DiscoverUriEntry> = [
+        {
+          uri: 'https://www.youtube.com/feeds/videos.xml?playlist_id=PL1234567890',
+          hint: { key: 'youtube:playlist', label: 'Playlist' },
+        },
+      ]
+
+      expect(youtubeHandler.resolve(value, '{"channelId":"UC1234567890"}')).toEqual(expected)
+    })
+
+    it('should return all feed variants for channel ID on music.youtube.com', () => {
+      const value = 'https://music.youtube.com/channel/UC1234567890'
+
+      expect(youtubeHandler.resolve(value)).toEqual(expectedChannelFeeds)
     })
 
     it('should extract channel ID from @handle page content', () => {
-      const value = youtubeHandler.resolve(
-        'https://youtube.com/@veritasium',
-        '{"channelId":"UC1234567890"}',
-      )
+      const value = 'https://youtube.com/@veritasium'
+      const content = '{"channelId":"UC1234567890"}'
 
-      expect(value).toEqual(expectedChannelFeeds)
+      expect(youtubeHandler.resolve(value, content)).toEqual(expectedChannelFeeds)
     })
 
     it('should extract channel ID from legacy /user/ page content', () => {
-      const value = youtubeHandler.resolve(
-        'https://youtube.com/user/pewdiepie',
-        '{"channelId":"UC1234567890"}',
-      )
+      const value = 'https://youtube.com/user/pewdiepie'
+      const content = '{"channelId":"UC1234567890"}'
 
-      expect(value).toEqual(expectedChannelFeeds)
+      expect(youtubeHandler.resolve(value, content)).toEqual(expectedChannelFeeds)
     })
 
     it('should extract channel ID from /c/ custom URL page content', () => {
-      const value = youtubeHandler.resolve(
-        'https://youtube.com/c/mkbhd',
-        '{"channelId":"UC1234567890"}',
-      )
+      const value = 'https://youtube.com/c/mkbhd'
+      const content = '{"channelId":"UC1234567890"}'
 
-      expect(value).toEqual(expectedChannelFeeds)
+      expect(youtubeHandler.resolve(value, content)).toEqual(expectedChannelFeeds)
     })
 
     it('should extract channel ID from externalId in consent page content', () => {
-      const value = youtubeHandler.resolve(
-        'https://youtube.com/@testchannel',
-        '{"externalId":"UC1234567890"}',
-      )
+      const value = 'https://youtube.com/@testchannel'
+      const content = '{"externalId":"UC1234567890"}'
 
-      expect(value).toEqual(expectedChannelFeeds)
+      expect(youtubeHandler.resolve(value, content)).toEqual(expectedChannelFeeds)
     })
 
     it('should return empty array when @handle content has no channel ID', () => {
-      const value = youtubeHandler.resolve(
-        'https://youtube.com/@nonexistent',
-        '<html>No channel ID here</html>',
-      )
+      const value = 'https://youtube.com/@nonexistent'
 
-      expect(value).toEqual([])
+      expect(youtubeHandler.resolve(value, '<html>No channel ID here</html>')).toEqual([])
     })
 
     it('should return empty array when /user/ content has no channel ID', () => {
-      const value = youtubeHandler.resolve(
-        'https://youtube.com/user/nonexistent',
-        '<html>No channel ID here</html>',
-      )
+      const value = 'https://youtube.com/user/nonexistent'
 
-      expect(value).toEqual([])
+      expect(youtubeHandler.resolve(value, '<html>No channel ID here</html>')).toEqual([])
     })
 
     it('should return empty array when /c/ content has no channel ID', () => {
-      const value = youtubeHandler.resolve(
-        'https://youtube.com/c/nonexistent',
-        '<html>No channel ID here</html>',
-      )
+      const value = 'https://youtube.com/c/nonexistent'
 
-      expect(value).toEqual([])
+      expect(youtubeHandler.resolve(value, '<html>No channel ID here</html>')).toEqual([])
     })
 
     it('should return empty array for video page without content', () => {
-      const value = youtubeHandler.resolve('https://youtube.com/watch?v=abc123')
-
-      expect(value).toEqual([])
+      expect(youtubeHandler.resolve('https://youtube.com/watch?v=abc123')).toEqual([])
     })
 
     it('should extract channel ID from video page content', () => {
-      const value = youtubeHandler.resolve(
-        'https://youtube.com/watch?v=abc123',
-        '{"channelId":"UC1234567890"}',
-      )
+      const value = 'https://youtube.com/watch?v=abc123'
+      const content = '{"channelId":"UC1234567890"}'
 
-      expect(value).toEqual(expectedChannelFeeds)
+      expect(youtubeHandler.resolve(value, content)).toEqual(expectedChannelFeeds)
     })
 
     it('should extract channel ID from youtu.be short URL content', () => {
-      const value = youtubeHandler.resolve(
-        'https://youtu.be/abc123',
-        '{"channelId":"UC1234567890"}',
-      )
+      const value = 'https://youtu.be/abc123'
+      const content = '{"channelId":"UC1234567890"}'
 
-      expect(value).toEqual(expectedChannelFeeds)
+      expect(youtubeHandler.resolve(value, content)).toEqual(expectedChannelFeeds)
     })
 
     it('should extract channel ID from /shorts/{id} URL content', () => {
-      const value = youtubeHandler.resolve(
-        'https://youtube.com/shorts/abc123',
-        '{"channelId":"UC1234567890"}',
-      )
+      const value = 'https://youtube.com/shorts/abc123'
+      const content = '{"channelId":"UC1234567890"}'
 
-      expect(value).toEqual(expectedChannelFeeds)
+      expect(youtubeHandler.resolve(value, content)).toEqual(expectedChannelFeeds)
     })
 
     it('should extract channel ID from /live/{id} URL content', () => {
-      const value = youtubeHandler.resolve(
-        'https://youtube.com/live/abc123',
-        '{"channelId":"UC1234567890"}',
-      )
+      const value = 'https://youtube.com/live/abc123'
+      const content = '{"channelId":"UC1234567890"}'
 
-      expect(value).toEqual(expectedChannelFeeds)
+      expect(youtubeHandler.resolve(value, content)).toEqual(expectedChannelFeeds)
     })
 
     it('should return empty array for /shorts/{id} without content', () => {
-      const value = youtubeHandler.resolve('https://youtube.com/shorts/abc123')
-
-      expect(value).toEqual([])
+      expect(youtubeHandler.resolve('https://youtube.com/shorts/abc123')).toEqual([])
     })
 
     it('should return empty array for /live/{id} without content', () => {
-      const value = youtubeHandler.resolve('https://youtube.com/live/abc123')
+      expect(youtubeHandler.resolve('https://youtube.com/live/abc123')).toEqual([])
+    })
 
-      expect(value).toEqual([])
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/feeds/platform/handlers/zenn.test.ts
+++ b/src/feeds/platform/handlers/zenn.test.ts
@@ -3,14 +3,14 @@ import { zennHandler } from './zenn.js'
 
 describe('zennHandler', () => {
   describe('match', () => {
-    const cases = [
-      ['https://zenn.dev/zenn', true],
-      ['https://www.zenn.dev/user', true],
-      ['https://zenn.dev', true],
-      ['https://example.com', false],
-    ] as const
+    const values: Array<[boolean, string]> = [
+      [true, 'https://zenn.dev/zenn'],
+      [true, 'https://www.zenn.dev/user'],
+      [true, 'https://zenn.dev'],
+      [false, 'https://example.com'],
+    ]
 
-    it.each(cases)('%s -> %s', (url, expected) => {
+    it.each(values)('should return %s for %s', (expected, url) => {
       expect(zennHandler.match(url)).toBe(expected)
     })
 
@@ -93,9 +93,32 @@ describe('zennHandler', () => {
     })
 
     it('should return empty array for excluded paths', () => {
-      const value = 'https://zenn.dev/topics'
+      const values = [
+        'https://zenn.dev/topics',
+        'https://zenn.dev/about',
+        'https://zenn.dev/api',
+        'https://zenn.dev/articles',
+        'https://zenn.dev/books',
+        'https://zenn.dev/login',
+        'https://zenn.dev/notifications',
+        'https://zenn.dev/p',
+        'https://zenn.dev/privacy',
+        'https://zenn.dev/publications',
+        'https://zenn.dev/scraps',
+        'https://zenn.dev/search',
+        'https://zenn.dev/settings',
+        'https://zenn.dev/signup',
+        'https://zenn.dev/terms',
+      ]
 
-      expect(zennHandler.resolve(value)).toEqual([])
+      for (const value of values) {
+        expect(zennHandler.resolve(value)).toEqual([])
+      }
+    })
+
+    it.todo('should define behavior for invalid URL input', () => {
+      // resolve('not-a-url') currently throws a TypeError from the unguarded new URL call; the
+      // desired contract (throw vs empty array) is undecided.
     })
   })
 })

--- a/src/hubs/discover/index.test.ts
+++ b/src/hubs/discover/index.test.ts
@@ -128,6 +128,19 @@ describe('discoverHubs', () => {
       expect(value).toEqual([])
     })
 
+    it('should return empty array for empty methods array', async () => {
+      const html = '<link rel="hub" href="https://html-hub.example.com/">'
+      const headers = new Headers({
+        link: '<https://header-hub.example.com/>; rel="hub"',
+      })
+      const value = await discoverHubs(
+        { url: 'https://example.com/', content: html, headers },
+        { methods: [] },
+      )
+
+      expect(value).toEqual([])
+    })
+
     it('should use only feed method when specified', async () => {
       const feed = `
         <?xml version="1.0" encoding="UTF-8"?>

--- a/src/hubs/feed/index.test.ts
+++ b/src/hubs/feed/index.test.ts
@@ -296,4 +296,36 @@ describe('discoverHubsFromFeed', () => {
 
     expect(value).toEqual(expected)
   })
+
+  it('should keep raw hub and topic when resolveUrlFn returns undefined', () => {
+    const content = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Example Feed</title>
+        <link href="/hub" rel="hub"/>
+        <link href="/feed.xml" rel="self"/>
+      </feed>
+    `
+    const resolveNothingFn: DiscoverResolveUrlFn = () => undefined
+    const value = discoverHubsFromFeed(content, 'https://example.com/feed.xml', resolveNothingFn)
+    const expected: Array<HubResult> = [
+      {
+        hub: '/hub',
+        topic: '/feed.xml',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it.todo('should use baseUrl as topic when RSS feed has hub but no self link', () => {
+    // RSS feed with an atom:link rel="hub" but no atom:link rel="self".
+    // Expected: one result with the hub URL and topic equal to the baseUrl argument.
+  })
+
+  it.todo('should discover hub from RDF feed with atom namespace links', () => {
+    // RDF (RSS 1.0) feed with atom:link rel="hub" and rel="self" entries reads links from
+    // feed.atom.links, the same branch as RSS.
+    // Expected: one result with the hub URL and the self URL as topic.
+  })
 })

--- a/src/hubs/headers/index.test.ts
+++ b/src/hubs/headers/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import type { DiscoverResolveUrlFn } from '../../common/types.js'
 import type { HubResult } from '../discover/types.js'
 import { discoverHubsFromHeaders } from './index.js'
 
@@ -168,6 +169,22 @@ describe('discoverHubsFromHeaders', () => {
       {
         hub: 'https://example.com/hub',
         topic: 'https://example.com/feed.xml',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should keep raw hub and topic when resolveUrlFn returns undefined', () => {
+    const headers = new Headers({
+      link: '</hub>; rel="hub", </feed.xml>; rel="self"',
+    })
+    const resolveNothingFn: DiscoverResolveUrlFn = () => undefined
+    const value = discoverHubsFromHeaders(headers, 'https://example.com/', resolveNothingFn)
+    const expected: Array<HubResult> = [
+      {
+        hub: '/hub',
+        topic: '/feed.xml',
       },
     ]
 

--- a/src/hubs/html/index.test.ts
+++ b/src/hubs/html/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import type { DiscoverResolveUrlFn } from '../../common/types.js'
 import type { HubResult } from '../discover/types.js'
 import { discoverHubsFromHtml } from './index.js'
 
@@ -103,6 +104,20 @@ describe('discoverHubsFromHtml', () => {
       {
         hub: 'https://custom.example.com/hub',
         topic: 'https://example.com/',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should keep raw hub and topic when resolveUrlFn returns undefined', () => {
+    const html = '<link rel="hub" href="/hub"><link rel="self" href="/feed.xml">'
+    const resolveNothingFn: DiscoverResolveUrlFn = () => undefined
+    const value = discoverHubsFromHtml(html, 'https://example.com/', resolveNothingFn)
+    const expected: Array<HubResult> = [
+      {
+        hub: '/hub',
+        topic: '/feed.xml',
       },
     ]
 


### PR DESCRIPTION
Aligns the test suite with the conventions shared across the feed* libraries and fills coverage gaps. Tests only, no source changes.

- Converges the 81 handler match tables to should-phrased it.each templates with typed tuples instead of as-const
- Fixes three async rejection tests that relied on toThrow unwrapping returned promises; they now use rejects.toThrow
- Hard-codes computed expectations (predicate asserts, expected factories, loop-built values)
- Eliminates value-as-output naming: single-use calls inlined, multi-line calls renamed to result
- Removes ~10 duplicated tests, fixes misleading names, splits multi-behavior tests
- Adds ~80 tests: html and headers discovery methods end-to-end (previously never exercised), blogrolls headers method and sad path, extractFn/resolveUrlFn overrides, exclusion-list rows and branch coverage across handlers, hubs fallbacks
- Adds ~95 it.todo placeholders, mostly documenting the undecided resolve() throwing contract for malformed URLs

Suite grows from 2226 to 2445 passing tests. Source-side findings documented in todos instead of pinned: fireside www slug feed, weebly duplicate /blog entries, pinterest pin.it short codes, tumblr www blog-name loss, bluesky favicon undefined actor.