### PR TITLE
feat: Discover feed links by anchor title and aria-label

### DIFF
--- a/docs/feeds/html.md
+++ b/docs/feeds/html.md
@@ -29,14 +29,17 @@ Looks for `<link>` elements that advertise feeds:
 Scans `<a>` tags for feed links using two strategies:
 
 1. **URI matching** — Checks if `href` contains common feed paths like `/feed`, `/rss.xml`.
-2. **Label matching** — Checks if link text contains words like "RSS", "Feed", "Subscribe".
+2. **Label matching** — Checks if the link text, `title`, or `aria-label` contains words like "RSS", "Feed", "Subscribe". This catches icon-only links that have no visible text.
 
 ```html
 <!-- Matched by URI -->
 <a href="/feed.xml">XML</a>
 
-<!-- Matched by label -->
+<!-- Matched by label (text) -->
 <a href="/subscribe">RSS Feed</a>
+
+<!-- Matched by label (title / aria-label) on an icon-only link -->
+<a href="/blog/syndication" title="RSS feed"><svg>...</svg></a>
 ```
 
 ## Configuration

--- a/src/common/uris/html/handlers.test.ts
+++ b/src/common/uris/html/handlers.test.ts
@@ -271,6 +271,39 @@ describe('handleOpenTag', () => {
 
     expect(value.discoveredUris.has('/blog/post.html')).toBe(false)
   })
+
+  it('should add anchor tag with feed label in title attribute', () => {
+    // Icon-only links carry their label in title/aria-label, not visible text.
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: '/blog/syndication', title: 'RSS feed' })
+
+    expect(value.discoveredUris.has('/blog/syndication')).toBe(true)
+  })
+
+  it('should add anchor tag with feed label in aria-label attribute', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: '/blog/syndication', 'aria-label': 'Subscribe via RSS' })
+
+    expect(value.discoveredUris.has('/blog/syndication')).toBe(true)
+  })
+
+  it('should not add anchor tag when title and aria-label lack feed labels', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: '/about', title: 'About us', 'aria-label': 'Home' })
+
+    expect(value.discoveredUris.has('/about')).toBe(false)
+  })
+
+  it('should ignore feed label in title when href matches an ignored URI', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: '#section', title: 'RSS feed' })
+
+    expect(value.discoveredUris.has('#section')).toBe(false)
+  })
 })
 
 describe('handleText', () => {

--- a/src/common/uris/html/handlers.ts
+++ b/src/common/uris/html/handlers.ts
@@ -39,6 +39,17 @@ export const handleOpenTag = (
     if (endsWithAnyOf(lowerHref, context.options.anchorUris)) {
       context.discoveredUris.add(attribs.href)
     }
+
+    // Match feed-related labels in title / aria-label (covers icon-only links with no text).
+    const ariaLabel = attribs['aria-label']
+    const title = attribs.title
+
+    if (
+      (ariaLabel && includesAnyOf(ariaLabel, context.options.anchorLabels)) ||
+      (title && includesAnyOf(title, context.options.anchorLabels))
+    ) {
+      context.discoveredUris.add(attribs.href)
+    }
   }
 }
 

--- a/src/common/uris/html/index.test.ts
+++ b/src/common/uris/html/index.test.ts
@@ -387,6 +387,36 @@ describe('discoverUrisFromHtml', () => {
     })
   })
 
+  describe('anchor elements by title and aria-label', () => {
+    it('should find icon-only anchor with feed label in title', () => {
+      const value = '<a href="/blog/syndication" title="RSS feed"><svg></svg></a>'
+      const expected = ['/blog/syndication']
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should find icon-only anchor with feed label in aria-label', () => {
+      const value = '<a href="/blog/syndication" aria-label="Subscribe via RSS"><svg></svg></a>'
+      const expected = ['/blog/syndication']
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should not match anchor when title and aria-label lack feed labels', () => {
+      const value = '<a href="/about" title="About us" aria-label="Home"><svg></svg></a>'
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should ignore feed label in title when href is an ignored URI', () => {
+      const value = '<a href="/wp-json/wp/v2/posts" title="RSS feed"><svg></svg></a>'
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+  })
+
   describe('combined scenarios', () => {
     it('should find both link and anchor elements', () => {
       const value = `


### PR DESCRIPTION
Feed links rendered as icons (an RSS glyph with no visible text) carry their label in the `title` or `aria-label` attribute. The HTML method previously matched anchor labels only against visible text, so these icon-only links were missed unless their `href` happened to match a known feed path.

Anchors are now matched against `title` and `aria-label` using the existing `anchorLabels` patterns, so links like `<a href="/feed" title="RSS feed"><svg/></a>` are discovered. This reuses the existing option, no new API surface, and applies to every discoverer using the HTML method (feeds and blogrolls).