### PR TITLE
feat: Discover OPML blogrolls advertised via rel=alternate

### DIFF
--- a/docs/other/blogrolls.md
+++ b/docs/other/blogrolls.md
@@ -125,10 +125,11 @@ import { urisComprehensive } from 'feedscout/blogrolls'
 Blogroll discovery uses these link selectors:
 
 ```typescript
-import { linkSelectors, mimeTypes } from 'feedscout/blogrolls'
+import { linkSelectors } from 'feedscout/blogrolls'
 
 // [
 //   { rel: 'blogroll' },
-//   { rel: 'outline', types: mimeTypes },
+//   { rel: 'outline', types: ['text/x-opml', 'application/opml+xml', 'application/xml', 'text/xml'] },
+//   { rel: 'alternate', types: ['text/x-opml', 'application/opml+xml'] },
 // ]
 ```

--- a/src/blogrolls/defaults.ts
+++ b/src/blogrolls/defaults.ts
@@ -3,8 +3,6 @@ import type { GuessMethodOptions } from '../common/uris/guess/types.js'
 import type { HeadersMethodOptions } from '../common/uris/headers/types.js'
 import type { HtmlMethodOptions } from '../common/uris/html/types.js'
 
-export const mimeTypes = ['text/x-opml', 'application/xml', 'text/xml']
-
 export const urisMinimal = ['/.well-known/recommendations.opml', '/blogroll.opml', '/opml.xml']
 
 export const urisBalanced = [
@@ -25,7 +23,8 @@ export const anchorLabels = ['blogroll', 'opml', 'subscriptions', 'reading list'
 
 export const linkSelectors: Array<LinkSelector> = [
   { rel: 'blogroll' },
-  { rel: 'outline', types: mimeTypes },
+  { rel: 'outline', types: ['text/x-opml', 'application/opml+xml', 'application/xml', 'text/xml'] },
+  { rel: 'alternate', types: ['text/x-opml', 'application/opml+xml'] },
 ]
 
 export const defaultHtmlOptions: Omit<HtmlMethodOptions, 'baseUrl'> = {

--- a/src/blogrolls/index.test.ts
+++ b/src/blogrolls/index.test.ts
@@ -207,6 +207,52 @@ describe('discoverBlogrolls', () => {
     expect(value).toEqual(expected)
   })
 
+  it('should discover blogrolls from HTML link elements with rel="alternate" and OPML type', async () => {
+    const mockFetch = createMockFetch({
+      'https://example.com/blogroll.opml': opml,
+    })
+    const value = await discoverBlogrolls(
+      {
+        url: 'https://example.com',
+        content:
+          '<link rel="alternate" type="application/opml+xml" title="Outline" href="/blogroll.opml">',
+      },
+      {
+        methods: { html: true },
+        fetchFn: mockFetch,
+      },
+    )
+    const expected: Array<DiscoverResult<BlogrollResult>> = [
+      {
+        url: 'https://example.com/blogroll.opml',
+        isValid: true,
+        method: 'html',
+        title: 'My Blogroll',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should not discover regular feeds advertised as rel="alternate" with a feed MIME type', async () => {
+    const mockFetch = createMockFetch({
+      'https://example.com/feed.xml': opml,
+    })
+    const value = await discoverBlogrolls(
+      {
+        url: 'https://example.com',
+        content: '<link rel="alternate" type="application/rss+xml" href="/feed.xml">',
+      },
+      {
+        methods: { html: true },
+        fetchFn: mockFetch,
+      },
+    )
+    const expected: Array<DiscoverResult<BlogrollResult>> = []
+
+    expect(value).toEqual(expected)
+  })
+
   it('should discover blogrolls from anchor elements with .opml href', async () => {
     const mockFetch = createMockFetch({
       'https://example.com/reading-list.opml': opml,


### PR DESCRIPTION
Some sites expose their OPML blogroll through `<link rel="alternate" type="application/opml+xml">` rather than the `rel="blogroll"` / `rel="outline"` forms feedscout already matched. The blogrolls discoverer now recognizes this.

- Added a `{ rel: 'alternate', types: ['text/x-opml', 'application/opml+xml'] }` selector, gated to OPML-specific MIME types so regular feeds and sitemaps served as `application/xml` / `text/xml` are not picked up as blogrolls.
- Added `application/opml+xml` to the `rel="outline"` selector's accepted types.
- Inlined the link-selector MIME types and removed the now-unused `mimeTypes` export (breaking change to the public API surface, hence targeting `beta`).