### PR TITLE
fix: Resolve discovered URLs against HTML base href

### DIFF
--- a/src/common/uris/html/handlers.test.ts
+++ b/src/common/uris/html/handlers.test.ts
@@ -230,6 +230,31 @@ describe('handleOpenTag', () => {
     expect(value.discoveredUris.size).toBe(0)
   })
 
+  it('should capture the first <base href> into context', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'base', { href: 'https://example.com/sub/' })
+
+    expect(value.baseHref).toBe('https://example.com/sub/')
+  })
+
+  it('should ignore an empty <base href>', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'base', { href: '' })
+
+    expect(value.baseHref).toBeUndefined()
+  })
+
+  it('should keep the first <base href> when multiple are present', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'base', { href: '/first/' })
+    handleOpenTag(value, 'base', { href: '/second/' })
+
+    expect(value.baseHref).toBe('/first/')
+  })
+
   it('should handle multiple link tags in sequence', () => {
     const value = createMockContext()
 

--- a/src/common/uris/html/handlers.ts
+++ b/src/common/uris/html/handlers.ts
@@ -8,6 +8,15 @@ export const handleOpenTag = (
   attribs: { [key: string]: string },
   _isImplied?: boolean,
 ): void => {
+  // Capture the first <base href> to resolve relative URLs against (browser semantics).
+  if (name === 'base' && context.baseHref === undefined) {
+    const href = attribs.href?.trim()
+
+    if (href) {
+      context.baseHref = href
+    }
+  }
+
   if (name === 'link' && attribs.href) {
     const rel = attribs.rel?.toLowerCase()
 

--- a/src/common/uris/html/index.test.ts
+++ b/src/common/uris/html/index.test.ts
@@ -417,6 +417,48 @@ describe('discoverUrisFromHtml', () => {
     })
   })
 
+  describe('<base href> resolution', () => {
+    const withBase = { ...defaultOptions, baseUrl: 'https://example.com/page' }
+
+    it('should resolve relative anchor hrefs against an absolute <base href>', () => {
+      const value = '<base href="https://example.com/sub/"><a href="feed.xml">RSS</a>'
+      const expected = ['https://example.com/sub/feed.xml']
+
+      expect(discoverUrisFromHtml(value, withBase)).toEqual(expected)
+    })
+
+    it('should resolve relative link hrefs against a relative <base href> and the page URL', () => {
+      const value =
+        '<base href="/blog/"><link rel="alternate" type="application/rss+xml" href="rss">'
+      const expected = ['https://example.com/blog/rss']
+
+      expect(discoverUrisFromHtml(value, withBase)).toEqual(expected)
+    })
+
+    it('should leave absolute discovered URLs unchanged under a <base href>', () => {
+      const value =
+        '<base href="https://example.com/sub/"><link rel="alternate" type="application/rss+xml" href="https://feeds.example.org/rss.xml">'
+      const expected = ['https://feeds.example.org/rss.xml']
+
+      expect(discoverUrisFromHtml(value, withBase)).toEqual(expected)
+    })
+
+    it('should ignore an empty <base href> and leave URLs unchanged', () => {
+      const value = '<base href=""><a href="/feed.xml">RSS</a>'
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHtml(value, withBase)).toEqual(expected)
+    })
+
+    it('should use the first <base href> when multiple are present', () => {
+      const value =
+        '<base href="https://a.example/x/"><base href="https://b.example/y/"><a href="feed.xml">RSS</a>'
+      const expected = ['https://a.example/x/feed.xml']
+
+      expect(discoverUrisFromHtml(value, withBase)).toEqual(expected)
+    })
+  })
+
   describe('combined scenarios', () => {
     it('should find both link and anchor elements', () => {
       const value = `

--- a/src/common/uris/html/index.test.ts
+++ b/src/common/uris/html/index.test.ts
@@ -457,6 +457,24 @@ describe('discoverUrisFromHtml', () => {
 
       expect(discoverUrisFromHtml(value, withBase)).toEqual(expected)
     })
+
+    it('should resolve against an absolute <base href> when no page URL is provided', () => {
+      const value = '<base href="https://example.com/sub/"><a href="feed.xml">RSS</a>'
+      const expected = ['https://example.com/sub/feed.xml']
+
+      // defaultOptions has no baseUrl, so the base href is used directly.
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should leave URLs unchanged when the base cannot be resolved', () => {
+      const value = '<base href="/sub/"><a href="feed.xml">RSS</a>'
+      const expected = ['feed.xml']
+
+      // A relative base with an invalid page URL resolves to nothing usable.
+      expect(
+        discoverUrisFromHtml(value, { ...defaultOptions, baseUrl: 'not-a-valid-url' }),
+      ).toEqual(expected)
+    })
   })
 
   describe('combined scenarios', () => {

--- a/src/common/uris/html/index.ts
+++ b/src/common/uris/html/index.ts
@@ -15,5 +15,27 @@ export const discoverUrisFromHtml = (html: string, options: HtmlMethodOptions): 
   parser.write(html)
   parser.end()
 
-  return [...context.discoveredUris]
+  const uris = [...context.discoveredUris]
+
+  // Resolve discovered URLs against <base href> when present (browser semantics). Without a
+  // <base>, URLs are returned as-is and resolved downstream against the page URL.
+  if (context.baseHref) {
+    let base: string | undefined
+
+    try {
+      base = options.baseUrl ? new URL(context.baseHref, options.baseUrl).href : context.baseHref
+    } catch {
+      base = options.baseUrl
+    }
+
+    return uris.map((uri) => {
+      try {
+        return new URL(uri, base).href
+      } catch {
+        return uri
+      }
+    })
+  }
+
+  return uris
 }

--- a/src/common/uris/html/types.ts
+++ b/src/common/uris/html/types.ts
@@ -14,5 +14,6 @@ export type HtmlMethodContext = {
     href: string
     text: string
   }
+  baseHref?: string
   options: HtmlMethodOptions
 }


### PR DESCRIPTION
The HTML discovery method returned raw `href` values that were always resolved against the page URL, ignoring any `<base href>` on the page. On pages that set a `<base>`, relative feed/blogroll URLs resolved to the wrong location.

The method now tracks the first `<base href>` and resolves discovered URLs against it (resolved in turn against the page URL), matching how browsers resolve relative URLs. Absolute discovered URLs and pages without a `<base>` are unaffected, so behavior only changes for pages that actually set a base.

Applies to every discoverer using the HTML method (feeds, blogrolls, favicons, hubs).