### PR TITLE
fix: Reduce anchor false-positives in feed discovery

### DIFF
--- a/src/common/uris/html/handlers.test.ts
+++ b/src/common/uris/html/handlers.test.ts
@@ -14,8 +14,9 @@ const createMockContext = (): HtmlMethodContext => {
         { rel: 'alternate', types: ['application/rss+xml', 'application/atom+xml'] },
         { rel: 'feed' },
       ],
+      anchorUris: ['/feed', '/rss', '/atom.xml'],
       // biome-ignore lint/performance/useTopLevelRegex: Test-specific patterns.
-      anchorUris: ['/feed', '/rss', '/atom.xml', /\/rss\//, /\/atom\//, /\/feed\//],
+      anchorPathSegments: [/\/rss\//, /\/atom\//, /\/feed\//],
       anchorIgnoredUris: ['#', 'javascript:', 'mailto:'],
       anchorLabels: ['rss', 'feed', 'atom'],
     },
@@ -256,7 +257,7 @@ describe('handleOpenTag', () => {
     expect(value.discoveredUris.has('/blog/feed')).toBe(true)
   })
 
-  it('should add anchor tag with href matching a RegExp pattern', () => {
+  it('should add anchor tag with a feed path segment in the pathname', () => {
     const value = createMockContext()
 
     handleOpenTag(value, 'a', { href: '/rss/now.xml' })
@@ -264,12 +265,20 @@ describe('handleOpenTag', () => {
     expect(value.discoveredUris.has('/rss/now.xml')).toBe(true)
   })
 
-  it('should not add anchor tag when href does not match any RegExp pattern', () => {
+  it('should not add anchor tag when href does not match any path segment', () => {
     const value = createMockContext()
 
     handleOpenTag(value, 'a', { href: '/blog/post.html' })
 
     expect(value.discoveredUris.has('/blog/post.html')).toBe(false)
+  })
+
+  it('should not match a feed path segment that only appears in the query string', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: '/share?add=https://other.example/rss/section' })
+
+    expect(value.discoveredUris.has('/share?add=https://other.example/rss/section')).toBe(false)
   })
 
   it('should add anchor tag with feed label in title attribute', () => {

--- a/src/common/uris/html/handlers.ts
+++ b/src/common/uris/html/handlers.ts
@@ -40,6 +40,20 @@ export const handleOpenTag = (
       context.discoveredUris.add(attribs.href)
     }
 
+    // Match feed path segments against the pathname only, so a feed path embedded in a wrapper's
+    // query string (e.g. ?add=https://site/rss/x) does not count as a feed.
+    if (context.options.anchorPathSegments?.length) {
+      let pathname: string | undefined
+
+      try {
+        pathname = new URL(attribs.href, 'https://feedscout.invalid').pathname
+      } catch {}
+
+      if (pathname && includesAnyOf(pathname, context.options.anchorPathSegments)) {
+        context.discoveredUris.add(attribs.href)
+      }
+    }
+
     // Match feed-related labels in title / aria-label (covers icon-only links with no text).
     const ariaLabel = attribs['aria-label']
     const title = attribs.title

--- a/src/common/uris/html/index.test.ts
+++ b/src/common/uris/html/index.test.ts
@@ -54,7 +54,8 @@ const anchorPathSegments = [/\/rss\//, /\/atom\//, /\/feed\//]
 
 const defaultOptions: HtmlMethodOptions = {
   linkSelectors: [{ rel: 'alternate', types: linkMimeTypes }, { rel: 'feed' }],
-  anchorUris: [...anchorUris, ...anchorPathSegments],
+  anchorUris,
+  anchorPathSegments,
   anchorIgnoredUris,
   anchorLabels,
 }
@@ -273,8 +274,10 @@ describe('discoverUrisFromHtml', () => {
       const value = '<a href="/feed/comments">Comments</a>'
       const expected: Array<string> = []
 
-      // Uses string-only anchorUris to test pure suffix matching behavior.
-      expect(discoverUrisFromHtml(value, { ...defaultOptions, anchorUris })).toEqual(expected)
+      // Uses string-only anchorUris and no path segments to test pure suffix matching behavior.
+      expect(
+        discoverUrisFromHtml(value, { ...defaultOptions, anchorUris, anchorPathSegments: [] }),
+      ).toEqual(expected)
     })
 
     it('should ignore wp-json/oembed/ URI', () => {
@@ -331,6 +334,14 @@ describe('discoverUrisFromHtml', () => {
     it('should deduplicate with suffix matching', () => {
       const value = '<a href="/blog/feed/">Feed</a>'
       const expected = ['/blog/feed/']
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should not match a feed path segment that only appears in the query string', () => {
+      const value =
+        '<a href="https://www.live.com/Default.aspx?add=https://site.example/rss/section">x</a>'
+      const expected: Array<string> = []
 
       expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
     })

--- a/src/common/uris/html/types.ts
+++ b/src/common/uris/html/types.ts
@@ -4,6 +4,9 @@ export type HtmlMethodOptions = {
   baseUrl?: string
   linkSelectors: Array<LinkSelector>
   anchorUris: Array<Pattern>
+  // Matched against the href's pathname only (not the query), so a feed path embedded in a
+  // wrapper's query string (e.g. ?add=https://site/rss/x) does not count as a feed.
+  anchorPathSegments?: Array<Pattern>
   anchorIgnoredUris: Array<Pattern>
   anchorLabels: Array<Pattern>
 }

--- a/src/feeds/defaults.test.ts
+++ b/src/feeds/defaults.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test'
+import { discoverUrisFromHtml } from '../common/uris/html/index.js'
+import { defaultHtmlOptions } from './defaults.js'
+
+describe('defaultHtmlOptions ignores subscribe/share links that wrap a feed URL', () => {
+  const wrappers = [
+    'https://add.my.yahoo.com/content?url=http%3A%2F%2Fexample.com%2Ffeed',
+    'https://www.netvibes.com/subscribe.php?url=http%3A%2F%2Fexample.com%2Ffeed',
+    'https://podcasts.google.com/?feed=aHR0cDovL2V4YW1wbGUuY29tL2ZlZWQ',
+    'http://apicdn.viglink.com/api/click?u=http%3A%2F%2Fexample.com%2Ffeed',
+    'http://www.addthis.com/feed.php?h1=http%3A%2F%2Fexample.com%2Ffeed',
+  ]
+
+  for (const href of wrappers) {
+    it(`ignores ${href}`, () => {
+      const value = `<a href="${href}">Subscribe via RSS</a>`
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+    })
+  }
+
+  it('still discovers a same-site feed link matched by label', () => {
+    const value = '<a href="https://example.com/feed">RSS</a>'
+    const expected = ['https://example.com/feed']
+
+    expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+  })
+
+  it('still discovers a WordPress query feed (no embedded URL)', () => {
+    const value = '<a href="https://example.com/?feed=rss">RSS</a>'
+    const expected = ['https://example.com/?feed=rss']
+
+    expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+  })
+})
+
+describe('defaultHtmlOptions matches feed path segments in the pathname only', () => {
+  it('discovers an anchor with a feed segment in the path', () => {
+    const value = '<a href="https://example.com/rss/news.xml"><svg></svg></a>'
+    const expected = ['https://example.com/rss/news.xml']
+
+    expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+  })
+
+  it('ignores a feed segment that only appears in the query string', () => {
+    const value = '<a href="https://example.com/share?p=/rss/news"><svg></svg></a>'
+    const expected: Array<string> = []
+
+    expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+  })
+})
+
+describe('defaultHtmlOptions does not treat "subscribe" alone as a feed label', () => {
+  it('ignores a "Subscribe" link to a podcast app or newsletter', () => {
+    const value = '<a href="https://www.youtube.com/c/example">Subscribe</a>'
+    const expected: Array<string> = []
+
+    expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+  })
+
+  it('still discovers a "Subscribe via RSS" link via the rss label', () => {
+    const value = '<a href="https://example.com/updates">Subscribe via RSS</a>'
+    const expected = ['https://example.com/updates']
+
+    expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+  })
+})

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -1,4 +1,4 @@
-import type { LinkSelector, UriEntry } from '../common/types.js'
+import type { LinkSelector, Pattern, UriEntry } from '../common/types.js'
 import type { GuessMethodOptions } from '../common/uris/guess/types.js'
 import type { HeadersMethodOptions } from '../common/uris/headers/types.js'
 import type { HtmlMethodOptions } from '../common/uris/html/types.js'
@@ -156,32 +156,33 @@ export const urisComprehensive: Array<UriEntry> = [
   '/feeds/comments/default',
 ]
 
-// URIs to ignore when discovering feeds from anchor elements.
-export const ignoredUris = ['wp-json/oembed/', 'wp-json/wp/']
+// Subscribe/share endpoints (Add to My Yahoo, Netvibes, Google Podcasts, AddThis, affiliate
+// redirectors, …) pass the real feed URL as a query parameter, e.g. ?url=http…, ?feed=aHR0c…
+// (base64 of "http"). They would otherwise match on their "Subscribe"/"RSS" link text and waste
+// a fetch, so ignore any anchor whose href carries an embedded URL.
+const wrappedFeedUrl = /[?&][^=&]*=(https?:|https?%3a|aHR0c)/i
 
-// Text labels used to identify feed links in anchor elements.
-export const anchorLabels = [
-  'rss',
-  'feed',
-  'atom',
-  'subscribe',
-  'syndicate',
-  'syndication',
-  'json feed',
-]
+// URIs to ignore when discovering feeds from anchor elements.
+export const ignoredUris: Array<Pattern> = ['wp-json/oembed/', 'wp-json/wp/', wrappedFeedUrl]
+
+// Text labels used to identify feed links in anchor elements. "subscribe" is deliberately
+// excluded: on its own it overwhelmingly marks podcast-app, YouTube, and newsletter buttons
+// rather than feeds, and real feed links are still caught by their href or an rss/feed/atom label.
+export const anchorLabels = ['rss', 'feed', 'atom', 'syndicate', 'syndication', 'json feed']
 
 export const linkSelectors: Array<LinkSelector> = [
   { rel: 'alternate', types: mimeTypes },
   { rel: 'feed' },
 ]
 
-// Path segments that indicate feed URLs when found within anchor hrefs.
+// Path segments that indicate feed URLs when found in an anchor href's pathname.
 export const anchorPathSegments = [/\/rss\//, /\/atom\//, /\/feed\//]
 
 // Default options for HTML method.
 export const defaultHtmlOptions: Omit<HtmlMethodOptions, 'baseUrl'> = {
   linkSelectors,
-  anchorUris: [...urisComprehensive.flat(), ...anchorPathSegments],
+  anchorUris: urisComprehensive.flat(),
+  anchorPathSegments,
   anchorIgnoredUris: ignoredUris,
   anchorLabels,
 }


### PR DESCRIPTION
A combined effort to cut anchors that get picked up as feed candidates, fetched, and discarded as invalid. Each change is validated against a 6.25% unbiased sample of a real-page corpus (~360k pages).

## 1. Ignore anchors that wrap a feed URL in a query parameter

Subscribe/share endpoints (Add to My Yahoo, Netvibes, Google Podcasts, AddThis, affiliate redirectors, Facebook/Twitter/LinkedIn share, …) pass the real feed URL as a query parameter (`?url=http…`, `?feed=aHR0c…`) and carry an "RSS"/"Subscribe" label, so they matched on link text. A single rule in `ignoredUris` skips any anchor whose href carries an embedded URL: no host list to maintain.

- Matches **24,702 anchors (7.0% of feed-labelled anchors) across 411 hosts**, all share/subscribe/redirect wrappers; **zero real-feed false positives** in the sample.

## 2. Match feed path segments against the pathname only

The `/rss/`, `/atom/`, `/feed/` path-segment rules were tested against the whole href, so a feed path embedded in a wrapper's query string (e.g. `?add=https://site/rss/section`) counted as a feed. They now match the href's pathname via a dedicated `anchorPathSegments` option.

- Removes a further **6,228 matches (1.8%) with zero false negatives**: none had a feed segment in the actual path.

## 3. Drop "subscribe" from the default anchor labels

On its own, "subscribe" overwhelmingly marks podcast-app (iTunes/Apple Podcasts/Stitcher/Spotify), YouTube, and newsletter (Mailchimp/`eepurl`) buttons rather than feeds. Real feed links are still caught by their href or an `rss`/`feed`/`atom` label ("Subscribe via RSS" keeps the `rss` token).

- Removes **52,191 candidates (19.2% of discovered anchors)**, with **zero loss of feeds carrying any feed-ish URL or feed-host signal** (those are retained by the href rule). The dropped set is dominated by podcast-app/YouTube/newsletter buttons and `/subscribe` pages.

Real feeds: relative links, same-site feeds, query feeds like `?feed=rss`, and "Subscribe via RSS" links: are unaffected. `syndicate`/`syndication` are kept (they occasionally catch non-English feeds).