### PR TITLE
Backport discovery improvements for 1.9.x

### DIFF
--- a/docs/feeds/html.md
+++ b/docs/feeds/html.md
@@ -29,14 +29,17 @@ Looks for `<link>` elements that advertise feeds:
 Scans `<a>` tags for feed links using two strategies:
 
 1. **URI matching** — Checks if `href` contains common feed paths like `/feed`, `/rss.xml`.
-2. **Label matching** — Checks if link text contains words like "RSS", "Feed", "Subscribe".
+2. **Label matching** — Checks if the link text, `title`, or `aria-label` contains words like "RSS", "Feed", "Subscribe". This catches icon-only links that have no visible text.
 
 ```html
 <!-- Matched by URI -->
 <a href="/feed.xml">XML</a>
 
-<!-- Matched by label -->
+<!-- Matched by label (text) -->
 <a href="/subscribe">RSS Feed</a>
+
+<!-- Matched by label (title / aria-label) on an icon-only link -->
+<a href="/blog/syndication" title="RSS feed"><svg>...</svg></a>
 ```
 
 ## Configuration

--- a/docs/other/blogrolls.md
+++ b/docs/other/blogrolls.md
@@ -125,10 +125,11 @@ import { urisComprehensive } from 'feedscout/blogrolls'
 Blogroll discovery uses these link selectors:
 
 ```typescript
-import { linkSelectors, mimeTypes } from 'feedscout/blogrolls'
+import { linkSelectors } from 'feedscout/blogrolls'
 
 // [
 //   { rel: 'blogroll' },
-//   { rel: 'outline', types: mimeTypes },
+//   { rel: 'outline', types: ['text/x-opml', 'application/opml+xml', 'application/xml', 'text/xml'] },
+//   { rel: 'alternate', types: ['text/x-opml', 'application/opml+xml'] },
 // ]
 ```

--- a/src/blogrolls/defaults.ts
+++ b/src/blogrolls/defaults.ts
@@ -3,8 +3,6 @@ import type { GuessMethodOptions } from '../common/uris/guess/types.js'
 import type { HeadersMethodOptions } from '../common/uris/headers/types.js'
 import type { HtmlMethodOptions } from '../common/uris/html/types.js'
 
-export const mimeTypes = ['text/x-opml', 'application/xml', 'text/xml']
-
 export const urisMinimal = ['/.well-known/recommendations.opml', '/blogroll.opml', '/opml.xml']
 
 export const urisBalanced = [
@@ -25,7 +23,8 @@ export const anchorLabels = ['blogroll', 'opml', 'subscriptions', 'reading list'
 
 export const linkSelectors: Array<LinkSelector> = [
   { rel: 'blogroll' },
-  { rel: 'outline', types: mimeTypes },
+  { rel: 'outline', types: ['text/x-opml', 'application/opml+xml', 'application/xml', 'text/xml'] },
+  { rel: 'alternate', types: ['text/x-opml', 'application/opml+xml'] },
 ]
 
 export const defaultHtmlOptions: Omit<HtmlMethodOptions, 'baseUrl'> = {

--- a/src/blogrolls/index.test.ts
+++ b/src/blogrolls/index.test.ts
@@ -205,6 +205,52 @@ describe('discoverBlogrolls', () => {
     expect(value).toEqual(expected)
   })
 
+  it('should discover blogrolls from HTML link elements with rel="alternate" and OPML type', async () => {
+    const mockFetch = createMockFetch({
+      'https://example.com/blogroll.opml': opml,
+    })
+    const value = await discoverBlogrolls(
+      {
+        url: 'https://example.com',
+        content:
+          '<link rel="alternate" type="application/opml+xml" title="Outline" href="/blogroll.opml">',
+      },
+      {
+        methods: { html: true },
+        fetchFn: mockFetch,
+      },
+    )
+    const expected: Array<DiscoverResult<BlogrollResult>> = [
+      {
+        url: 'https://example.com/blogroll.opml',
+        isValid: true,
+        method: 'html',
+        title: 'My Blogroll',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should not discover regular feeds advertised as rel="alternate" with a feed MIME type', async () => {
+    const mockFetch = createMockFetch({
+      'https://example.com/feed.xml': opml,
+    })
+    const value = await discoverBlogrolls(
+      {
+        url: 'https://example.com',
+        content: '<link rel="alternate" type="application/rss+xml" href="/feed.xml">',
+      },
+      {
+        methods: { html: true },
+        fetchFn: mockFetch,
+      },
+    )
+    const expected: Array<DiscoverResult<BlogrollResult>> = []
+
+    expect(value).toEqual(expected)
+  })
+
   it('should discover blogrolls from anchor elements with .opml href', async () => {
     const mockFetch = createMockFetch({
       'https://example.com/reading-list.opml': opml,

--- a/src/common/uris/html/handlers.test.ts
+++ b/src/common/uris/html/handlers.test.ts
@@ -230,6 +230,31 @@ describe('handleOpenTag', () => {
     expect(value.discoveredUris.size).toBe(0)
   })
 
+  it('should capture the first <base href> into context', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'base', { href: 'https://example.com/sub/' })
+
+    expect(value.baseHref).toBe('https://example.com/sub/')
+  })
+
+  it('should ignore an empty <base href>', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'base', { href: '' })
+
+    expect(value.baseHref).toBeUndefined()
+  })
+
+  it('should keep the first <base href> when multiple are present', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'base', { href: '/first/' })
+    handleOpenTag(value, 'base', { href: '/second/' })
+
+    expect(value.baseHref).toBe('/first/')
+  })
+
   it('should handle multiple link tags in sequence', () => {
     const value = createMockContext()
 

--- a/src/common/uris/html/handlers.test.ts
+++ b/src/common/uris/html/handlers.test.ts
@@ -271,6 +271,39 @@ describe('handleOpenTag', () => {
 
     expect(value.discoveredUris.has('/blog/post.html')).toBe(false)
   })
+
+  it('should add anchor tag with feed label in title attribute', () => {
+    // Icon-only links carry their label in title/aria-label, not visible text.
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: '/blog/syndication', title: 'RSS feed' })
+
+    expect(value.discoveredUris.has('/blog/syndication')).toBe(true)
+  })
+
+  it('should add anchor tag with feed label in aria-label attribute', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: '/blog/syndication', 'aria-label': 'Subscribe via RSS' })
+
+    expect(value.discoveredUris.has('/blog/syndication')).toBe(true)
+  })
+
+  it('should not add anchor tag when title and aria-label lack feed labels', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: '/about', title: 'About us', 'aria-label': 'Home' })
+
+    expect(value.discoveredUris.has('/about')).toBe(false)
+  })
+
+  it('should ignore feed label in title when href matches an ignored URI', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: '#section', title: 'RSS feed' })
+
+    expect(value.discoveredUris.has('#section')).toBe(false)
+  })
 })
 
 describe('handleText', () => {

--- a/src/common/uris/html/handlers.test.ts
+++ b/src/common/uris/html/handlers.test.ts
@@ -14,8 +14,9 @@ const createMockContext = (): HtmlMethodContext => {
         { rel: 'alternate', types: ['application/rss+xml', 'application/atom+xml'] },
         { rel: 'feed' },
       ],
+      anchorUris: ['/feed', '/rss', '/atom.xml'],
       // biome-ignore lint/performance/useTopLevelRegex: Test-specific patterns.
-      anchorUris: ['/feed', '/rss', '/atom.xml', /\/rss\//, /\/atom\//, /\/feed\//],
+      anchorPathSegments: [/\/rss\//, /\/atom\//, /\/feed\//],
       anchorIgnoredUris: ['#', 'javascript:', 'mailto:'],
       anchorLabels: ['rss', 'feed', 'atom'],
     },
@@ -281,7 +282,7 @@ describe('handleOpenTag', () => {
     expect(value.discoveredUris.has('/blog/feed')).toBe(true)
   })
 
-  it('should add anchor tag with href matching a RegExp pattern', () => {
+  it('should add anchor tag with a feed path segment in the pathname', () => {
     const value = createMockContext()
 
     handleOpenTag(value, 'a', { href: '/rss/now.xml' })
@@ -289,12 +290,20 @@ describe('handleOpenTag', () => {
     expect(value.discoveredUris.has('/rss/now.xml')).toBe(true)
   })
 
-  it('should not add anchor tag when href does not match any RegExp pattern', () => {
+  it('should not add anchor tag when href does not match any path segment', () => {
     const value = createMockContext()
 
     handleOpenTag(value, 'a', { href: '/blog/post.html' })
 
     expect(value.discoveredUris.has('/blog/post.html')).toBe(false)
+  })
+
+  it('should not match a feed path segment that only appears in the query string', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: '/share?add=https://other.example/rss/section' })
+
+    expect(value.discoveredUris.has('/share?add=https://other.example/rss/section')).toBe(false)
   })
 
   it('should add anchor tag with feed label in title attribute', () => {

--- a/src/common/uris/html/handlers.ts
+++ b/src/common/uris/html/handlers.ts
@@ -49,6 +49,20 @@ export const handleOpenTag = (
       context.discoveredUris.add(attribs.href)
     }
 
+    // Match feed path segments against the pathname only, so a feed path embedded in a wrapper's
+    // query string (e.g. ?add=https://site/rss/x) does not count as a feed.
+    if (context.options.anchorPathSegments?.length) {
+      let pathname: string | undefined
+
+      try {
+        pathname = new URL(attribs.href, 'https://feedscout.invalid').pathname
+      } catch {}
+
+      if (pathname && includesAnyOf(pathname, context.options.anchorPathSegments)) {
+        context.discoveredUris.add(attribs.href)
+      }
+    }
+
     // Match feed-related labels in title / aria-label (covers icon-only links with no text).
     const ariaLabel = attribs['aria-label']
     const title = attribs.title

--- a/src/common/uris/html/handlers.ts
+++ b/src/common/uris/html/handlers.ts
@@ -8,6 +8,15 @@ export const handleOpenTag = (
   attribs: { [key: string]: string },
   _isImplied?: boolean,
 ): void => {
+  // Capture the first <base href> to resolve relative URLs against (browser semantics).
+  if (name === 'base' && context.baseHref === undefined) {
+    const href = attribs.href?.trim()
+
+    if (href) {
+      context.baseHref = href
+    }
+  }
+
   if (name === 'link' && attribs.href) {
     const rel = attribs.rel?.toLowerCase()
 

--- a/src/common/uris/html/handlers.ts
+++ b/src/common/uris/html/handlers.ts
@@ -39,6 +39,17 @@ export const handleOpenTag = (
     if (endsWithAnyOf(lowerHref, context.options.anchorUris)) {
       context.discoveredUris.add(attribs.href)
     }
+
+    // Match feed-related labels in title / aria-label (covers icon-only links with no text).
+    const ariaLabel = attribs['aria-label']
+    const title = attribs.title
+
+    if (
+      (ariaLabel && includesAnyOf(ariaLabel, context.options.anchorLabels)) ||
+      (title && includesAnyOf(title, context.options.anchorLabels))
+    ) {
+      context.discoveredUris.add(attribs.href)
+    }
   }
 }
 

--- a/src/common/uris/html/index.test.ts
+++ b/src/common/uris/html/index.test.ts
@@ -447,6 +447,48 @@ describe('discoverUrisFromHtml', () => {
     })
   })
 
+  describe('<base href> resolution', () => {
+    const withBase = { ...defaultOptions, baseUrl: 'https://example.com/page' }
+
+    it('should resolve relative anchor hrefs against an absolute <base href>', () => {
+      const value = '<base href="https://example.com/sub/"><a href="feed.xml">RSS</a>'
+      const expected = ['https://example.com/sub/feed.xml']
+
+      expect(discoverUrisFromHtml(value, withBase)).toEqual(expected)
+    })
+
+    it('should resolve relative link hrefs against a relative <base href> and the page URL', () => {
+      const value =
+        '<base href="/blog/"><link rel="alternate" type="application/rss+xml" href="rss">'
+      const expected = ['https://example.com/blog/rss']
+
+      expect(discoverUrisFromHtml(value, withBase)).toEqual(expected)
+    })
+
+    it('should leave absolute discovered URLs unchanged under a <base href>', () => {
+      const value =
+        '<base href="https://example.com/sub/"><link rel="alternate" type="application/rss+xml" href="https://feeds.example.org/rss.xml">'
+      const expected = ['https://feeds.example.org/rss.xml']
+
+      expect(discoverUrisFromHtml(value, withBase)).toEqual(expected)
+    })
+
+    it('should ignore an empty <base href> and leave URLs unchanged', () => {
+      const value = '<base href=""><a href="/feed.xml">RSS</a>'
+      const expected = ['/feed.xml']
+
+      expect(discoverUrisFromHtml(value, withBase)).toEqual(expected)
+    })
+
+    it('should use the first <base href> when multiple are present', () => {
+      const value =
+        '<base href="https://a.example/x/"><base href="https://b.example/y/"><a href="feed.xml">RSS</a>'
+      const expected = ['https://a.example/x/feed.xml']
+
+      expect(discoverUrisFromHtml(value, withBase)).toEqual(expected)
+    })
+  })
+
   describe('combined scenarios', () => {
     it('should find both link and anchor elements', () => {
       const value = `

--- a/src/common/uris/html/index.test.ts
+++ b/src/common/uris/html/index.test.ts
@@ -54,7 +54,8 @@ const anchorPathSegments = [/\/rss\//, /\/atom\//, /\/feed\//]
 
 const defaultOptions: HtmlMethodOptions = {
   linkSelectors: [{ rel: 'alternate', types: linkMimeTypes }, { rel: 'feed' }],
-  anchorUris: [...anchorUris, ...anchorPathSegments],
+  anchorUris,
+  anchorPathSegments,
   anchorIgnoredUris,
   anchorLabels,
 }
@@ -289,8 +290,10 @@ describe('discoverUrisFromHtml', () => {
       const value = '<a href="/feed/comments">Comments</a>'
       const expected: Array<string> = []
 
-      // Uses string-only anchorUris to test pure suffix matching behavior.
-      expect(discoverUrisFromHtml(value, { ...defaultOptions, anchorUris })).toEqual(expected)
+      // Uses string-only anchorUris and no path segments to test pure suffix matching behavior.
+      expect(
+        discoverUrisFromHtml(value, { ...defaultOptions, anchorUris, anchorPathSegments: [] }),
+      ).toEqual(expected)
     })
 
     it('should ignore wp-json/oembed/ URI', () => {
@@ -347,6 +350,14 @@ describe('discoverUrisFromHtml', () => {
     it('should deduplicate with suffix matching', () => {
       const value = '<a href="/blog/feed/">Feed</a>'
       const expected = ['/blog/feed/']
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should not match a feed path segment that only appears in the query string', () => {
+      const value =
+        '<a href="https://www.live.com/Default.aspx?add=https://site.example/rss/section">x</a>'
+      const expected: Array<string> = []
 
       expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
     })

--- a/src/common/uris/html/index.test.ts
+++ b/src/common/uris/html/index.test.ts
@@ -417,6 +417,36 @@ describe('discoverUrisFromHtml', () => {
     })
   })
 
+  describe('anchor elements by title and aria-label', () => {
+    it('should find icon-only anchor with feed label in title', () => {
+      const value = '<a href="/blog/syndication" title="RSS feed"><svg></svg></a>'
+      const expected = ['/blog/syndication']
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should find icon-only anchor with feed label in aria-label', () => {
+      const value = '<a href="/blog/syndication" aria-label="Subscribe via RSS"><svg></svg></a>'
+      const expected = ['/blog/syndication']
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should not match anchor when title and aria-label lack feed labels', () => {
+      const value = '<a href="/about" title="About us" aria-label="Home"><svg></svg></a>'
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should ignore feed label in title when href is an ignored URI', () => {
+      const value = '<a href="/wp-json/wp/v2/posts" title="RSS feed"><svg></svg></a>'
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+  })
+
   describe('combined scenarios', () => {
     it('should find both link and anchor elements', () => {
       const value = `

--- a/src/common/uris/html/index.test.ts
+++ b/src/common/uris/html/index.test.ts
@@ -487,6 +487,24 @@ describe('discoverUrisFromHtml', () => {
 
       expect(discoverUrisFromHtml(value, withBase)).toEqual(expected)
     })
+
+    it('should resolve against an absolute <base href> when no page URL is provided', () => {
+      const value = '<base href="https://example.com/sub/"><a href="feed.xml">RSS</a>'
+      const expected = ['https://example.com/sub/feed.xml']
+
+      // defaultOptions has no baseUrl, so the base href is used directly.
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should leave URLs unchanged when the base cannot be resolved', () => {
+      const value = '<base href="/sub/"><a href="feed.xml">RSS</a>'
+      const expected = ['feed.xml']
+
+      // A relative base with an invalid page URL resolves to nothing usable.
+      expect(
+        discoverUrisFromHtml(value, { ...defaultOptions, baseUrl: 'not-a-valid-url' }),
+      ).toEqual(expected)
+    })
   })
 
   describe('combined scenarios', () => {

--- a/src/common/uris/html/index.ts
+++ b/src/common/uris/html/index.ts
@@ -15,5 +15,27 @@ export const discoverUrisFromHtml = (html: string, options: HtmlMethodOptions): 
   parser.write(html)
   parser.end()
 
-  return [...context.discoveredUris]
+  const uris = [...context.discoveredUris]
+
+  // Resolve discovered URLs against <base href> when present (browser semantics). Without a
+  // <base>, URLs are returned as-is and resolved downstream against the page URL.
+  if (context.baseHref) {
+    let base: string | undefined
+
+    try {
+      base = options.baseUrl ? new URL(context.baseHref, options.baseUrl).href : context.baseHref
+    } catch {
+      base = options.baseUrl
+    }
+
+    return uris.map((uri) => {
+      try {
+        return new URL(uri, base).href
+      } catch {
+        return uri
+      }
+    })
+  }
+
+  return uris
 }

--- a/src/common/uris/html/types.ts
+++ b/src/common/uris/html/types.ts
@@ -14,5 +14,6 @@ export type HtmlMethodContext = {
     href: string
     text: string
   }
+  baseHref?: string
   options: HtmlMethodOptions
 }

--- a/src/common/uris/html/types.ts
+++ b/src/common/uris/html/types.ts
@@ -4,6 +4,9 @@ export type HtmlMethodOptions = {
   baseUrl?: string
   linkSelectors: Array<LinkSelector>
   anchorUris: Array<Pattern>
+  // Matched against the href's pathname only (not the query), so a feed path embedded in a
+  // wrapper's query string (e.g. ?add=https://site/rss/x) does not count as a feed.
+  anchorPathSegments?: Array<Pattern>
   anchorIgnoredUris: Array<Pattern>
   anchorLabels: Array<Pattern>
 }

--- a/src/feeds/defaults.test.ts
+++ b/src/feeds/defaults.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test'
+import { discoverUrisFromHtml } from '../common/uris/html/index.js'
+import { defaultHtmlOptions } from './defaults.js'
+
+describe('defaultHtmlOptions ignores subscribe/share links that wrap a feed URL', () => {
+  const wrappers = [
+    'https://add.my.yahoo.com/content?url=http%3A%2F%2Fexample.com%2Ffeed',
+    'https://www.netvibes.com/subscribe.php?url=http%3A%2F%2Fexample.com%2Ffeed',
+    'https://podcasts.google.com/?feed=aHR0cDovL2V4YW1wbGUuY29tL2ZlZWQ',
+    'http://apicdn.viglink.com/api/click?u=http%3A%2F%2Fexample.com%2Ffeed',
+    'http://www.addthis.com/feed.php?h1=http%3A%2F%2Fexample.com%2Ffeed',
+  ]
+
+  for (const href of wrappers) {
+    it(`ignores ${href}`, () => {
+      const value = `<a href="${href}">Subscribe via RSS</a>`
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+    })
+  }
+
+  it('still discovers a same-site feed link matched by label', () => {
+    const value = '<a href="https://example.com/feed">RSS</a>'
+    const expected = ['https://example.com/feed']
+
+    expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+  })
+
+  it('still discovers a WordPress query feed (no embedded URL)', () => {
+    const value = '<a href="https://example.com/?feed=rss">RSS</a>'
+    const expected = ['https://example.com/?feed=rss']
+
+    expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+  })
+})
+
+describe('defaultHtmlOptions matches feed path segments in the pathname only', () => {
+  it('discovers an anchor with a feed segment in the path', () => {
+    const value = '<a href="https://example.com/rss/news.xml"><svg></svg></a>'
+    const expected = ['https://example.com/rss/news.xml']
+
+    expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+  })
+
+  it('ignores a feed segment that only appears in the query string', () => {
+    const value = '<a href="https://example.com/share?p=/rss/news"><svg></svg></a>'
+    const expected: Array<string> = []
+
+    expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+  })
+})
+
+describe('defaultHtmlOptions does not treat "subscribe" alone as a feed label', () => {
+  it('ignores a "Subscribe" link to a podcast app or newsletter', () => {
+    const value = '<a href="https://www.youtube.com/c/example">Subscribe</a>'
+    const expected: Array<string> = []
+
+    expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+  })
+
+  it('still discovers a "Subscribe via RSS" link via the rss label', () => {
+    const value = '<a href="https://example.com/updates">Subscribe via RSS</a>'
+    const expected = ['https://example.com/updates']
+
+    expect(discoverUrisFromHtml(value, defaultHtmlOptions)).toEqual(expected)
+  })
+})

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -1,4 +1,4 @@
-import type { LinkSelector, UriEntry } from '../common/types.js'
+import type { LinkSelector, Pattern, UriEntry } from '../common/types.js'
 import type { GuessMethodOptions } from '../common/uris/guess/types.js'
 import type { HeadersMethodOptions } from '../common/uris/headers/types.js'
 import type { HtmlMethodOptions } from '../common/uris/html/types.js'
@@ -156,32 +156,33 @@ export const urisComprehensive: Array<UriEntry> = [
   '/feeds/comments/default',
 ]
 
-// URIs to ignore when discovering feeds from anchor elements.
-export const ignoredUris = ['wp-json/oembed/', 'wp-json/wp/']
+// Subscribe/share endpoints (Add to My Yahoo, Netvibes, Google Podcasts, AddThis, affiliate
+// redirectors, …) pass the real feed URL as a query parameter, e.g. ?url=http…, ?feed=aHR0c…
+// (base64 of "http"). They would otherwise match on their "Subscribe"/"RSS" link text and waste
+// a fetch, so ignore any anchor whose href carries an embedded URL.
+const wrappedFeedUrl = /[?&][^=&]*=(https?:|https?%3a|aHR0c)/i
 
-// Text labels used to identify feed links in anchor elements.
-export const anchorLabels = [
-  'rss',
-  'feed',
-  'atom',
-  'subscribe',
-  'syndicate',
-  'syndication',
-  'json feed',
-]
+// URIs to ignore when discovering feeds from anchor elements.
+export const ignoredUris: Array<Pattern> = ['wp-json/oembed/', 'wp-json/wp/', wrappedFeedUrl]
+
+// Text labels used to identify feed links in anchor elements. "subscribe" is deliberately
+// excluded: on its own it overwhelmingly marks podcast-app, YouTube, and newsletter buttons
+// rather than feeds, and real feed links are still caught by their href or an rss/feed/atom label.
+export const anchorLabels = ['rss', 'feed', 'atom', 'syndicate', 'syndication', 'json feed']
 
 export const linkSelectors: Array<LinkSelector> = [
   { rel: 'alternate', types: mimeTypes },
   { rel: 'feed' },
 ]
 
-// Path segments that indicate feed URLs when found within anchor hrefs.
+// Path segments that indicate feed URLs when found in an anchor href's pathname.
 export const anchorPathSegments = [/\/rss\//, /\/atom\//, /\/feed\//]
 
 // Default options for HTML method.
 export const defaultHtmlOptions: Omit<HtmlMethodOptions, 'baseUrl'> = {
   linkSelectors,
-  anchorUris: [...urisComprehensive.flat(), ...anchorPathSegments],
+  anchorUris: urisComprehensive.flat(),
+  anchorPathSegments,
   anchorIgnoredUris: ignoredUris,
   anchorLabels,
 }


### PR DESCRIPTION
Backports four discovery improvements from `beta` onto `main` for a 1.9.x release, excluding the breaking ESM-only switch and the Biome 2.5 / test-convention reformatting that also live on `beta`.

Cherry-picked cleanly, in order:

- **Discover feed links by anchor title and aria-label** (#133): icon-only feed links carry their label in `title`/`aria-label` rather than visible text.
- **Discover OPML blogrolls advertised via `rel="alternate"`** (#134): gated to OPML-specific MIME types.
- **Resolve discovered URLs against HTML `<base href>`** (#135): pages that set a `<base>` previously resolved relative feed URLs to the wrong location.
- **Reduce anchor false-positives** (#136): ignore anchors that wrap a feed URL in a query parameter, match feed path segments against the pathname only, and drop `subscribe` from the default anchor labels.

Verified on this branch: `tsc` clean, full test suite passes, and the changed files are Biome-clean.