### PR TITLE
Discover icon-only feed links via anchor attributes

### DIFF
--- a/docs/feeds/html.md
+++ b/docs/feeds/html.md
@@ -93,6 +93,20 @@ const feeds = await discoverFeeds(url, {
 })
 ```
 
+### Anchor Attributes
+
+Specify element attributes to scan for the anchor labels, on the anchor itself and on its descendants. This finds icon-only feed links whose label lives in an attribute rather than visible text — for example a `title`, an `aria-label`, or the layer name Framer emits on a feed icon (`data-framer-name="RSS Icon"`):
+
+```typescript
+const feeds = await discoverFeeds(url, {
+  methods: {
+    html: {
+      anchorAttributes: ['aria-label', 'title', 'data-framer-name'],
+    },
+  },
+})
+```
+
 ### Ignored URIs
 
 Exclude certain URI patterns from anchor matching:

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -282,8 +282,10 @@ type HtmlMethodOptions = {
   baseUrl?: string
   linkSelectors: Array<LinkSelector>
   anchorUris: Array<string>
+  anchorPathSegments?: Array<string>
   anchorIgnoredUris: Array<string>
   anchorLabels: Array<string>
+  anchorAttributes?: Array<string>
 }
 
 type LinkSelector = {

--- a/src/blogrolls/defaults.ts
+++ b/src/blogrolls/defaults.ts
@@ -32,6 +32,7 @@ export const defaultHtmlOptions: Omit<HtmlMethodOptions, 'baseUrl'> = {
   anchorUris: urisComprehensive,
   anchorIgnoredUris: [],
   anchorLabels,
+  anchorAttributes: ['aria-label', 'title'],
 }
 
 export const defaultHeadersOptions: Omit<HeadersMethodOptions, 'baseUrl'> = {

--- a/src/common/uris/html/handlers.test.ts
+++ b/src/common/uris/html/handlers.test.ts
@@ -19,6 +19,7 @@ const createMockContext = (): HtmlMethodContext => {
       anchorPathSegments: [/\/rss\//, /\/atom\//, /\/feed\//],
       anchorIgnoredUris: ['#', 'javascript:', 'mailto:'],
       anchorLabels: ['rss', 'feed', 'atom'],
+      anchorAttributes: ['aria-label', 'title', 'data-framer-name'],
     },
   }
 }
@@ -337,6 +338,44 @@ describe('handleOpenTag', () => {
     handleOpenTag(value, 'a', { href: '#section', title: 'RSS feed' })
 
     expect(value.discoveredUris.has('#section')).toBe(false)
+  })
+
+  it('should add anchor href when a descendant attribute carries a feed label', () => {
+    // Framer wraps an icon-only feed link around a child whose only signal is data-framer-name.
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: 'https://provider.example/fd/abc123.xml' })
+    handleOpenTag(value, 'div', { 'data-framer-name': 'RSS Icon' })
+
+    expect(value.discoveredUris.has('https://provider.example/fd/abc123.xml')).toBe(true)
+  })
+
+  it('should not add anchor href when descendant attributes lack a feed label', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: 'https://provider.example/fd/abc123.xml' })
+    handleOpenTag(value, 'div', { 'data-framer-name': 'Search Icon' })
+
+    expect(value.discoveredUris.has('https://provider.example/fd/abc123.xml')).toBe(false)
+  })
+
+  it('should not scan descendant attributes when the anchor was ignored', () => {
+    const value = createMockContext()
+
+    handleOpenTag(value, 'a', { href: '#section' })
+    handleOpenTag(value, 'div', { 'data-framer-name': 'RSS Icon' })
+
+    expect(value.discoveredUris.has('#section')).toBe(false)
+  })
+
+  it('should not scan descendant attributes when none are configured', () => {
+    const value = createMockContext()
+    value.options.anchorAttributes = undefined
+
+    handleOpenTag(value, 'a', { href: 'https://provider.example/fd/abc123.xml' })
+    handleOpenTag(value, 'div', { 'data-framer-name': 'RSS Icon' })
+
+    expect(value.discoveredUris.has('https://provider.example/fd/abc123.xml')).toBe(false)
   })
 })
 

--- a/src/common/uris/html/handlers.ts
+++ b/src/common/uris/html/handlers.ts
@@ -62,16 +62,21 @@ export const handleOpenTag = (
         context.discoveredUris.add(attribs.href)
       }
     }
+  }
 
-    // Match feed-related labels in title / aria-label (covers icon-only links with no text).
-    const ariaLabel = attribs['aria-label']
-    const title = attribs.title
+  // Match feed-related labels in configured attributes, covering icon-only links with no visible
+  // text. This runs both for the anchor itself (e.g. <a title="RSS feed">) and for any descendant
+  // element while the anchor is open (e.g. Framer renders the icon as a child element whose only
+  // signal is <div data-framer-name="RSS Icon">). Ignored anchors already cleared currentAnchor.href
+  // above, so neither they nor their descendants are scanned.
+  if (context.currentAnchor.href && context.options.anchorAttributes?.length) {
+    for (const attribute of context.options.anchorAttributes) {
+      const value = attribs[attribute]
 
-    if (
-      (ariaLabel && includesAnyOf(ariaLabel, context.options.anchorLabels)) ||
-      (title && includesAnyOf(title, context.options.anchorLabels))
-    ) {
-      context.discoveredUris.add(attribs.href)
+      if (value && includesAnyOf(value, context.options.anchorLabels)) {
+        context.discoveredUris.add(context.currentAnchor.href)
+        break
+      }
     }
   }
 }

--- a/src/common/uris/html/index.test.ts
+++ b/src/common/uris/html/index.test.ts
@@ -52,12 +52,15 @@ const anchorLabels = ['rss', 'feed', 'atom', 'subscribe', 'syndicate', 'json fee
 
 const anchorPathSegments = [/\/rss\//, /\/atom\//, /\/feed\//]
 
+const anchorAttributes = ['aria-label', 'title', 'data-framer-name']
+
 const defaultOptions: HtmlMethodOptions = {
   linkSelectors: [{ rel: 'alternate', types: linkMimeTypes }, { rel: 'feed' }],
   anchorUris,
   anchorPathSegments,
   anchorIgnoredUris,
   anchorLabels,
+  anchorAttributes,
 }
 
 describe('discoverUrisFromHtml', () => {
@@ -455,6 +458,36 @@ describe('discoverUrisFromHtml', () => {
       const expected: Array<string> = []
 
       expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+  })
+
+  describe('anchor elements by descendant attribute label', () => {
+    it('should find a Framer icon-only feed link via a descendant data-framer-name', () => {
+      // Framer wraps the feed link around an icon child whose layer name is the only feed signal;
+      // the anchor itself has no text, title, or aria-label.
+      const value =
+        '<a href="https://provider.example/fd/abc123.xml" target="_blank" rel="noopener"><div data-framer-component-type="SVG" data-framer-name="RSS Icon" aria-hidden="true"></div></a>'
+      const expected = ['https://provider.example/fd/abc123.xml']
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should not match when the descendant attribute lacks a feed label', () => {
+      const value =
+        '<a href="https://provider.example/fd/abc123.xml"><div data-framer-name="Search Icon"></div></a>'
+      const expected: Array<string> = []
+
+      expect(discoverUrisFromHtml(value, defaultOptions)).toEqual(expected)
+    })
+
+    it('should not scan descendant attributes when none are configured', () => {
+      const value =
+        '<a href="https://provider.example/fd/abc123.xml"><div data-framer-name="RSS Icon"></div></a>'
+      const expected: Array<string> = []
+
+      expect(
+        discoverUrisFromHtml(value, { ...defaultOptions, anchorAttributes: undefined }),
+      ).toEqual(expected)
     })
   })
 

--- a/src/common/uris/html/types.ts
+++ b/src/common/uris/html/types.ts
@@ -9,6 +9,11 @@ export type HtmlMethodOptions = {
   anchorPathSegments?: Array<Pattern>
   anchorIgnoredUris: Array<Pattern>
   anchorLabels: Array<Pattern>
+  // Element attributes scanned for feed labels (matched against anchorLabels), on the anchor itself
+  // and on any descendant while the anchor is open. Covers icon-only links whose only signal is an
+  // attribute rather than visible text — title, aria-label, or a layer name such as the one Framer
+  // emits for the feed icon (<div data-framer-name="RSS Icon">).
+  anchorAttributes?: Array<string>
 }
 
 export type HtmlMethodContext = {

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -178,6 +178,12 @@ export const linkSelectors: Array<LinkSelector> = [
 // Path segments that indicate feed URLs when found in an anchor href's pathname.
 export const anchorPathSegments = [/\/rss\//, /\/atom\//, /\/feed\//]
 
+// Descendant attributes scanned for feed labels on icon-only anchors that carry no text or label
+// of their own. Framer names its feed-icon layer with data-framer-name (e.g. "RSS Icon"), which is
+// the common case this covers. "class" is intentionally excluded: anchorLabels match as substrings,
+// so labels collide with ordinary class names ("feed" in "feedback", "atom" in "atomic").
+export const anchorAttributes = ['aria-label', 'title', 'data-framer-name']
+
 // Default options for HTML method.
 export const defaultHtmlOptions: Omit<HtmlMethodOptions, 'baseUrl'> = {
   linkSelectors,
@@ -185,6 +191,7 @@ export const defaultHtmlOptions: Omit<HtmlMethodOptions, 'baseUrl'> = {
   anchorPathSegments,
   anchorIgnoredUris: ignoredUris,
   anchorLabels,
+  anchorAttributes,
 }
 
 // Default options for Headers method.


### PR DESCRIPTION
Some sites (notably Framer blogs) expose their feed only as an icon-only anchor: the `<a href>` carries no visible text, no `title`, and no `aria-label`, while the feed signal sits on a child element. Framer, for instance, renders the feed icon as a child whose layer name is emitted verbatim, `<div data-framer-component-type="SVG" data-framer-name="RSS Icon">`, and these sites ship no `<link rel="alternate">` in the head, so head-based autodiscovery finds nothing either. Such feeds were missed entirely.

This adds a configurable `anchorAttributes` option to HTML discovery. While an anchor is open, the listed attributes are scanned for the existing `anchorLabels` (`rss`/`feed`/`atom`/…): on the anchor itself and on any descendant element. The previously hardcoded `title`/`aria-label` matching on the anchor is folded into this single list, so there is now one source of truth for attribute-based label matching rather than two.

Defaults:
- Feeds: `['aria-label', 'title', 'data-framer-name']`
- Blogrolls: `['aria-label', 'title']` (preserves prior anchor `title`/`aria-label` behavior)

`class` is intentionally excluded from the defaults: labels match as substrings, so common class names collide (`feed` in `feedback`, `atom` in `atomic`). Callers that want icon-font detection can opt in.

The option is optional; modules that do not set it (favicons, hubs) keep their current behavior.