### PR TITLE
style: Rename regex constants to *Regex suffix

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -101,12 +101,12 @@ export const isOfAllowedMimeType = (
 export const hasMetaContent = (content: string, name: string, value: string): boolean => {
   const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   const escapedValue = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const regex = new RegExp(
+  const metaTagRegex = new RegExp(
     `<meta(?=[^>]*(?:name|property)=["']${escapedName}["'])(?=[^>]*content=["']${escapedValue})`,
     'i',
   )
 
-  return regex.test(content)
+  return metaTagRegex.test(content)
 }
 
 export const omitEmpty = <T>(array: Array<T | null | undefined>): Array<T> => {

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -160,10 +160,10 @@ export const urisComprehensive: Array<UriEntry> = [
 // redirectors, …) pass the real feed URL as a query parameter, e.g. ?url=http…, ?feed=aHR0c…
 // (base64 of "http"). They would otherwise match on their "Subscribe"/"RSS" link text and waste
 // a fetch, so ignore any anchor whose href carries an embedded URL.
-const wrappedFeedUrl = /[?&][^=&]*=(https?:|https?%3a|aHR0c)/i
+const wrappedFeedUrlRegex = /[?&][^=&]*=(https?:|https?%3a|aHR0c)/i
 
 // URIs to ignore when discovering feeds from anchor elements.
-export const ignoredUris: Array<Pattern> = ['wp-json/oembed/', 'wp-json/wp/', wrappedFeedUrl]
+export const ignoredUris: Array<Pattern> = ['wp-json/oembed/', 'wp-json/wp/', wrappedFeedUrlRegex]
 
 // Text labels used to identify feed links in anchor elements. "subscribe" is deliberately
 // excluded: on its own it overwhelmingly marks podcast-app, YouTube, and newsletter buttons

--- a/src/feeds/platform/handlers/artstation.ts
+++ b/src/feeds/platform/handlers/artstation.ts
@@ -5,7 +5,7 @@ import { composeHint, isAnyOf, isHostOf, isSubdomainOf } from '../../../common/u
 // Not discoverable without handler.
 
 const hosts = ['artstation.com', 'www.artstation.com']
-const domainSuffix = /\.artstation\.com$/i
+const domainSuffixRegex = /\.artstation\.com$/i
 const excludedPaths = [
   'blogs',
   'channels',
@@ -32,7 +32,7 @@ export const artstationHandler: PlatformHandler = {
 
     // Subdomain form: {user}.artstation.com
     if (!isHostOf(url, hosts) && isSubdomainOf(url, 'artstation.com')) {
-      const username = parsed.hostname.replace(domainSuffix, '')
+      const username = parsed.hostname.replace(domainSuffixRegex, '')
 
       return [
         {

--- a/src/feeds/platform/handlers/fireside.ts
+++ b/src/feeds/platform/handlers/fireside.ts
@@ -4,7 +4,7 @@ import { composeHint, isSubdomainOf } from '../../../common/utils.js'
 
 // Partially discoverable without handler.
 
-const domainSuffix = /\.fireside\.fm$/i
+const domainSuffixRegex = /\.fireside\.fm$/i
 
 export const firesideHandler: PlatformHandler = {
   match: (url) => {
@@ -13,7 +13,7 @@ export const firesideHandler: PlatformHandler = {
 
   resolve: (url) => {
     const { hostname } = new URL(url)
-    const slug = hostname.replace(domainSuffix, '')
+    const slug = hostname.replace(domainSuffixRegex, '')
     const uris: Array<DiscoverUriEntry> = []
 
     uris.push({

--- a/src/feeds/platform/handlers/podbean.ts
+++ b/src/feeds/platform/handlers/podbean.ts
@@ -5,7 +5,7 @@ import { composeHint, isSubdomainOf } from '../../../common/utils.js'
 //
 // {slug}.podbean.com/feed.xml also works but 302-redirects to feed.podbean.com.
 
-const domainSuffix = /\.podbean\.com$/i
+const domainSuffixRegex = /\.podbean\.com$/i
 
 // Reserved Podbean subdomains that aren't user shows. Without this guard, hitting
 // podbean.com corporate/infra hosts produces feed.podbean.com/{reserved}/feed.xml
@@ -27,14 +27,14 @@ export const podbeanHandler: PlatformHandler = {
       return false
     }
 
-    const slug = new URL(url).hostname.toLowerCase().replace(domainSuffix, '')
+    const slug = new URL(url).hostname.toLowerCase().replace(domainSuffixRegex, '')
 
     return !reservedSlugs.has(slug)
   },
 
   resolve: (url) => {
     const { hostname } = new URL(url)
-    const slug = hostname.replace(domainSuffix, '')
+    const slug = hostname.replace(domainSuffixRegex, '')
 
     return [
       {

--- a/src/feeds/platform/handlers/podigee.ts
+++ b/src/feeds/platform/handlers/podigee.ts
@@ -3,7 +3,7 @@ import { composeHint, isSubdomainOf } from '../../../common/utils.js'
 
 // Discoverable without handler.
 
-const domainSuffix = /\.podigee\.io$/i
+const domainSuffixRegex = /\.podigee\.io$/i
 
 // Reserved Podigee subdomains that aren't user shows. Without this guard the handler
 // emits 404-bound URLs (e.g. https://www.podigee.io/feed/mp3 redirects to a 404 on
@@ -16,7 +16,7 @@ export const podigeeHandler: PlatformHandler = {
       return false
     }
 
-    const slug = new URL(url).hostname.toLowerCase().replace(domainSuffix, '')
+    const slug = new URL(url).hostname.toLowerCase().replace(domainSuffixRegex, '')
 
     return !reservedSlugs.has(slug)
   },

--- a/src/feeds/platform/handlers/transistor.ts
+++ b/src/feeds/platform/handlers/transistor.ts
@@ -3,7 +3,7 @@ import { composeHint, isSubdomainOf } from '../../../common/utils.js'
 
 // Not discoverable without handler.
 
-const domainSuffix = /\.transistor\.fm$/i
+const domainSuffixRegex = /\.transistor\.fm$/i
 
 // Reserved Transistor subdomains that aren't user shows. Without this guard the
 // handler emits feeds.transistor.fm/{www|share|support|...} URLs that 404.
@@ -24,14 +24,14 @@ export const transistorHandler: PlatformHandler = {
       return false
     }
 
-    const slug = new URL(url).hostname.toLowerCase().replace(domainSuffix, '')
+    const slug = new URL(url).hostname.toLowerCase().replace(domainSuffixRegex, '')
 
     return !reservedSlugs.has(slug)
   },
 
   resolve: (url) => {
     const { hostname } = new URL(url)
-    const slug = hostname.replace(domainSuffix, '')
+    const slug = hostname.replace(domainSuffixRegex, '')
 
     return [
       {


### PR DESCRIPTION
Enforces the `*Regex` naming convention for regex-valued constants.

Renames file-local regex constants to append `Regex`, updating declarations and all in-file usages:

- `src/common/utils.ts`: `regex` -> `metaTagRegex`
- `src/feeds/defaults.ts`: `wrappedFeedUrl` -> `wrappedFeedUrlRegex`
- `src/feeds/platform/handlers/{artstation,fireside,podbean,podigee,transistor}.ts`: `domainSuffix` -> `domainSuffixRegex`

Rename-only; no behavior change.