### PR TITLE
fix: Gate extractor validation on HTTP response status

### DIFF
--- a/docs/other/favicons.md
+++ b/docs/other/favicons.md
@@ -32,6 +32,10 @@ const favicons = await discoverFavicons('https://example.com', {
 })
 ```
 
+::: warning Untrusted SVG favicons
+A favicon validated as an SVG is returned by URL only — its contents are not sanitized. SVG files can carry active content (e.g. `<svg onload="...">`), so treat returned SVG favicon URLs as untrusted: render them as `<img src>` (which neutralizes scripts) rather than inlining the markup, or sanitize before use.
+:::
+
 ## Discovery Methods
 
 Favicons use the same discovery pipeline as feeds — see the [Feeds](/feeds) section for details on how each method works.

--- a/src/blogrolls/extractors.ts
+++ b/src/blogrolls/extractors.ts
@@ -1,9 +1,11 @@
 import { parseOpml } from 'feedsmith'
 import type { DiscoverExtractFn } from '../common/types.js'
+import { isSuccessfulStatus } from '../common/utils.js'
 import type { BlogrollResult } from './types.js'
 
-export const defaultExtractFn: DiscoverExtractFn<BlogrollResult> = ({ content, url }) => {
-  if (!content) {
+export const defaultExtractFn: DiscoverExtractFn<BlogrollResult> = ({ content, url, status }) => {
+  // Never accept the body of a non-2xx response (404/500 error pages) as a blogroll.
+  if (!content || !isSuccessfulStatus(status)) {
     return { url, isValid: false }
   }
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -8,6 +8,12 @@ export const composeHint = (key: string): DiscoverUriHint => ({
   label: locales.hints[key as keyof typeof locales.hints],
 })
 
+// A response is only acceptable when its status is in the 2xx range. A missing
+// status means the body was supplied directly (no fetch), so treat it as valid.
+export const isSuccessfulStatus = (status: number | undefined): boolean => {
+  return status === undefined || (status >= 200 && status < 300)
+}
+
 export const normalizeMimeType = (type: string): string => {
   return type.split(';')[0].trim().toLowerCase()
 }

--- a/src/favicons/extractors.test.ts
+++ b/src/favicons/extractors.test.ts
@@ -170,30 +170,23 @@ describe('defaultExtractFn', () => {
   })
 
   describe('status code', () => {
-    it('should return isValid: true for status 200', async () => {
+    it('should return isValid: false for status 200 without an image signal', async () => {
       const value = { url: 'https://example.com/icon.png', content: '', status: 200 }
-      const expected = { url: 'https://example.com/icon.png', isValid: true }
+      const expected = { url: 'https://example.com/icon.png', isValid: false }
 
       expect(await defaultExtractFn(value)).toEqual(expected)
     })
 
-    it('should return isValid: true for status 299', async () => {
+    it('should return isValid: false for status 299 without an image signal', async () => {
       const value = { url: 'https://example.com/icon.png', content: '', status: 299 }
-      const expected = { url: 'https://example.com/icon.png', isValid: true }
+      const expected = { url: 'https://example.com/icon.png', isValid: false }
 
       expect(await defaultExtractFn(value)).toEqual(expected)
     })
 
-    it('should return isValid: true for status 301', async () => {
+    it('should return isValid: false for status 301 without an image signal', async () => {
       const value = { url: 'https://example.com/icon.png', content: '', status: 301 }
-      const expected = { url: 'https://example.com/icon.png', isValid: true }
-
-      expect(await defaultExtractFn(value)).toEqual(expected)
-    })
-
-    it('should return isValid: true for status 399', async () => {
-      const value = { url: 'https://example.com/icon.png', content: '', status: 399 }
-      const expected = { url: 'https://example.com/icon.png', isValid: true }
+      const expected = { url: 'https://example.com/icon.png', isValid: false }
 
       expect(await defaultExtractFn(value)).toEqual(expected)
     })
@@ -228,6 +221,29 @@ describe('defaultExtractFn', () => {
 
     it('should return isValid: false for undefined status without other signals', async () => {
       const value = { url: 'https://example.com/icon.png', content: '' }
+      const expected = { url: 'https://example.com/icon.png', isValid: false }
+
+      expect(await defaultExtractFn(value)).toEqual(expected)
+    })
+
+    it('should return isValid: true for an image signal on a 2xx status', async () => {
+      const value = {
+        url: 'https://example.com/icon.png',
+        content: '',
+        headers: new Headers({ 'content-type': 'image/png' }),
+        status: 200,
+      }
+      const expected = { url: 'https://example.com/icon.png', isValid: true }
+
+      expect(await defaultExtractFn(value)).toEqual(expected)
+    })
+
+    it('should return isValid: false for an image signal on an error status', async () => {
+      const value = {
+        url: 'https://example.com/icon.png',
+        content: '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+        status: 404,
+      }
       const expected = { url: 'https://example.com/icon.png', isValid: false }
 
       expect(await defaultExtractFn(value)).toEqual(expected)

--- a/src/favicons/extractors.ts
+++ b/src/favicons/extractors.ts
@@ -1,4 +1,5 @@
 import type { DiscoverExtractFn } from '../common/types.js'
+import { isSuccessfulStatus } from '../common/utils.js'
 import type { FaviconResult } from './types.js'
 
 const isImageContentType = (headers?: Headers): boolean => {
@@ -8,6 +9,10 @@ const isImageContentType = (headers?: Headers): boolean => {
 // TODO: Consider exposing byte data from fetch responses to detect JPEG and ICO
 // via magic bytes. Their signatures are fully non-ASCII and get mangled by UTF-8
 // decoding, making them undetectable from string content.
+//
+// Security: SVG favicons are accepted here but returned unvalidated. An SVG can
+// carry active content (e.g. <svg onload=...>), so consumers must treat returned
+// SVG favicon URLs as untrusted and never inline them without sanitization.
 const isImageContent = (content: string): boolean => {
   if (content.includes('<html')) {
     return false
@@ -25,18 +30,10 @@ const isImageContent = (content: string): boolean => {
   )
 }
 
-const isSuccessStatus = (status?: number): boolean => {
-  return status !== undefined && status >= 200 && status < 400
-}
-
 export const defaultExtractFn: DiscoverExtractFn<FaviconResult> = (input) => {
-  if (
-    isImageContentType(input.headers) ||
-    isImageContent(input.content) ||
-    isSuccessStatus(input.status)
-  ) {
-    return { url: input.url, isValid: true }
-  }
+  // Require an actual image signal (content-type or sniffed body) on a 2xx
+  // response. A successful status alone never implies the body is an image.
+  const isImage = isImageContentType(input.headers) || isImageContent(input.content)
 
-  return { url: input.url, isValid: false }
+  return { url: input.url, isValid: isImage && isSuccessfulStatus(input.status) }
 }

--- a/src/favicons/index.test.ts
+++ b/src/favicons/index.test.ts
@@ -4,13 +4,21 @@ import { discoverFavicons } from './index.js'
 import type { FaviconResult } from './types.js'
 
 const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => {
-  return async (url: string) => ({
-    url,
-    body: responses[url] ?? '',
-    headers: new Headers(),
-    status: url in responses ? 200 : 404,
-    statusText: url in responses ? 'OK' : 'Not Found',
-  })
+  return (url: string) => {
+    const found = url in responses
+    const body = responses[url] ?? ''
+    // Mocked image endpoints use the 'binary' placeholder body; serve them with
+    // an image content-type so they pass favicon image validation.
+    const headers = new Headers(body === 'binary' ? { 'content-type': 'image/x-icon' } : {})
+
+    return {
+      url,
+      body,
+      headers,
+      status: found ? 200 : 404,
+      statusText: found ? 'OK' : 'Not Found',
+    }
+  }
 }
 
 describe('discoverFavicons', () => {
@@ -37,6 +45,7 @@ describe('discoverFavicons', () => {
       body: '',
       headers: new Headers({
         link: '</favicon.png>; rel="icon"',
+        ...(url.endsWith('.png') ? { 'content-type': 'image/png' } : {}),
       }),
       status: 200,
       statusText: 'OK',

--- a/src/feeds/extractors.ts
+++ b/src/feeds/extractors.ts
@@ -2,10 +2,12 @@ import { parseFeed } from 'feedsmith'
 import { defaultResolveUrlFn } from '../common/discover/defaults.js'
 import { getFeedSiteUrl } from '../common/discover/utils.js'
 import type { DiscoverExtractFn } from '../common/types.js'
+import { isSuccessfulStatus } from '../common/utils.js'
 import type { FeedResult } from './types.js'
 
-export const defaultExtractFn: DiscoverExtractFn<FeedResult> = ({ content, url }) => {
-  if (!content) {
+export const defaultExtractFn: DiscoverExtractFn<FeedResult> = ({ content, url, status }) => {
+  // Never accept the body of a non-2xx response (404/500 error pages) as a feed.
+  if (!content || !isSuccessfulStatus(status)) {
     return { url, isValid: false }
   }
 


### PR DESCRIPTION
Tightens result validation so a successful HTTP status alone can no longer mark content as valid.

- **Favicons:** a result is valid only when there is an actual image signal (an `image/*` content-type or a sniffed image body) **and** the response is 2xx. Previously any 2xx/3xx response, including a soft-404 HTML page served at `/favicon.ico`: was accepted as a valid icon, which made the image sniffing dead code.
- **Feeds & blogrolls:** the body of a non-2xx response (404/500 error pages) is no longer parsed and accepted as a valid feed/blogroll.
- **Docs:** adds a warning that SVG favicons are returned by URL only and are not sanitized: an SVG can carry active content (`<svg onload=...>`), so consumers must treat returned SVG favicon URLs as untrusted.

A shared `isSuccessfulStatus` helper centralizes the 2xx check (a missing status, i.e. content supplied directly without a fetch, is still treated as valid).