### PR TITLE
fix: Guard against invalid concurrency values

### DIFF
--- a/src/common/discover/index.ts
+++ b/src/common/discover/index.ts
@@ -30,6 +30,11 @@ export const discover = async <TValid>(
     onProgress,
   } = options
 
+  // Clamp to a positive integer and cap the upper bound; anything invalid
+  // (NaN, < 1, non-integer) falls back to the default.
+  const safeConcurrency =
+    Number.isInteger(concurrency) && concurrency >= 1 ? Math.min(concurrency, 100) : 3
+
   // Normalize input: string → fetch URL, object → use provided content.
   const sourceInput = await normalizeInput(input, fetchFn)
 
@@ -150,7 +155,7 @@ export const discover = async <TValid>(
     const foundBefore = found
 
     await processConcurrently(entries, (entry) => processUri(entry, method), {
-      concurrency,
+      concurrency: safeConcurrency,
       shouldStop: () => {
         return stopOnFirstResult && found > 0
       },

--- a/src/common/discover/index.ts
+++ b/src/common/discover/index.ts
@@ -30,10 +30,9 @@ export const discover = async <TValid>(
     onProgress,
   } = options
 
-  // Clamp to a positive integer and cap the upper bound; anything invalid
-  // (NaN, < 1, non-integer) falls back to the default.
-  const safeConcurrency =
-    Number.isInteger(concurrency) && concurrency >= 1 ? Math.min(concurrency, 100) : 3
+  // Reject NaN, < 1, and non-integer concurrency (which would hang or no-op the
+  // worker loop); a valid explicit value is respected as-is.
+  const safeConcurrency = Number.isInteger(concurrency) && concurrency >= 1 ? concurrency : 3
 
   // Normalize input: string → fetch URL, object → use provided content.
   const sourceInput = await normalizeInput(input, fetchFn)

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -147,7 +147,9 @@ export const processConcurrently = async <T>(
     shouldStop?: () => boolean
   },
 ): Promise<void> => {
-  if (options.concurrency < 1) {
+  // Guard against < 1 and non-numeric (NaN) concurrency, which would otherwise
+  // spin the loop forever since `active.size < NaN` is always false.
+  if (!(options.concurrency >= 1)) {
     return
   }
 


### PR DESCRIPTION
Hardens the `concurrency` option against values that would hang or stall the discovery loop.

- `processConcurrently` previously guarded only `concurrency < 1`. A `NaN` value (e.g. from `Number(someString)`) slipped past it, and because `active.size < NaN` is always false the worker loop spun forever at 100% CPU. The guard is now `!(concurrency >= 1)`, which rejects `NaN` as well.
- The discover orchestrator sanitizes the user-supplied value once: `NaN`, non-integer, or `< 1` falls back to the default of 3. A valid explicit integer is respected as-is (no upper cap, the value is the caller's deliberate choice).