### PR TITLE
fix: Validate discover input is a plain object

### DIFF
--- a/src/common/discover/utils.test.ts
+++ b/src/common/discover/utils.test.ts
@@ -295,6 +295,28 @@ describe('normalizeInput', () => {
     expect(await normalizeInput(value, fetchFn)).toEqual(value)
   })
 
+  it('should not treat null as object input', async () => {
+    const expected = {
+      url: null,
+      content: '<html>content</html>',
+      headers: expect.any(Headers),
+    }
+
+    // null reports typeof 'object'; it must take the fetch path, not be returned as-is.
+    expect((await normalizeInput(null as never, fetchFn)) as unknown).toEqual(expected)
+  })
+
+  it('should not treat an array as object input', async () => {
+    const expected = {
+      url: [],
+      content: '<html>content</html>',
+      headers: expect.any(Headers),
+    }
+
+    // Arrays report typeof 'object'; they must take the fetch path, not be returned as-is.
+    expect((await normalizeInput([] as never, fetchFn)) as unknown).toEqual(expected)
+  })
+
   it('should return object input with url and headers', async () => {
     const headers = new Headers()
     const value = {
@@ -1405,9 +1427,7 @@ describe('defaultResolveSiteUrlFn', () => {
   const resolveUrlFn: DiscoverResolveUrlFn = (url, baseUrl) => {
     try {
       return new URL(url, baseUrl).href
-    } catch {
-      return
-    }
+    } catch {}
   }
 
   it('should return site URL from RSS feed with channel link', () => {
@@ -1771,9 +1791,7 @@ describe('normalizeUriEntry', () => {
   const resolveUrlFn: DiscoverResolveUrlFn = (url, baseUrl) => {
     try {
       return new URL(url, baseUrl).href
-    } catch {
-      return
-    }
+    } catch {}
   }
 
   it('should normalize string entry', () => {

--- a/src/common/discover/utils.ts
+++ b/src/common/discover/utils.ts
@@ -11,12 +11,13 @@ import type {
   DiscoverResolveUrlFn,
   DiscoverUriEntry,
 } from '../types.js'
+import { isObject } from '../utils.js'
 
 export const normalizeInput = async (
   input: DiscoverInput,
   fetchFn: DiscoverFetchFn,
 ): Promise<DiscoverInputObject> => {
-  if (typeof input === 'object') {
+  if (isObject(input)) {
     return input
   }
 

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -7,6 +7,7 @@ import {
   includesAnyOf,
   isAnyOf,
   isHostOf,
+  isObject,
   isOfAllowedMimeType,
   isSubdomainOf,
   matchesAnyOfLinkSelectors,
@@ -1203,5 +1204,27 @@ describe('hasMetaContent', () => {
 
   it('should return false for empty HTML', () => {
     expect(hasMetaContent('', 'generator', 'Mastodon')).toBe(false)
+  })
+})
+
+describe('isObject', () => {
+  it('should return true for plain objects', () => {
+    expect(isObject({})).toBe(true)
+    expect(isObject({ url: 'https://example.com' })).toBe(true)
+  })
+
+  it('should return false for null', () => {
+    expect(isObject(null)).toBe(false)
+  })
+
+  it('should return false for arrays', () => {
+    expect(isObject([])).toBe(false)
+    expect(isObject(['https://example.com'])).toBe(false)
+  })
+
+  it('should return false for primitives', () => {
+    expect(isObject('https://example.com')).toBe(false)
+    expect(isObject(42)).toBe(false)
+    expect(isObject(undefined)).toBe(false)
   })
 })

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -14,6 +14,11 @@ export const isSuccessfulStatus = (status: number | undefined): boolean => {
   return status === undefined || (status >= 200 && status < 300)
 }
 
+// Narrow to a plain object, excluding null and arrays (both report typeof 'object').
+export const isObject = (value: unknown): value is object => {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
 export const normalizeMimeType = (type: string): string => {
   return type.split(';')[0].trim().toLowerCase()
 }


### PR DESCRIPTION
The discover entry point distinguishes a string input (a URL to fetch) from an object input (pre-supplied content) with `typeof input === "object"`. That check also passes for `null` and arrays, since both report `typeof "object"`.

As a result `discoverFeeds(null)` returned `null` as the normalized input and then threw `TypeError: Cannot read properties of null` downstream, and an array input was passed through and silently mis-routed.

`normalizeInput` now uses an `isObject` helper that excludes `null` and arrays, so only a real input object short-circuits the fetch path; everything else is treated as a URL string.