### PR TITLE
feat: Cap total candidate URIs before fetching

### DIFF
--- a/docs/reference/discover-blogrolls.md
+++ b/docs/reference/discover-blogrolls.md
@@ -46,6 +46,7 @@ All options are optional. When not provided, sensible defaults are used.
 | `stopOnFirstMethod` | `boolean` | `false` | Stop URI collection after first method with results |
 | `stopOnFirstResult` | `boolean` | `false` | Stop after first valid blogroll |
 | `concurrency` | `number` | `3` | Max parallel validations |
+| `maxUris` | `number` | `50` | Max total candidate URIs to fetch across all methods |
 | `includeInvalid` | `boolean` | `false` | Include invalid results |
 | `onProgress` | `DiscoverOnProgressFn` | | Progress callback |
 

--- a/docs/reference/discover-favicons.md
+++ b/docs/reference/discover-favicons.md
@@ -46,6 +46,7 @@ All options are optional. When not provided, sensible defaults are used.
 | `stopOnFirstMethod` | `boolean` | `false` | Stop URI collection after first method with results |
 | `stopOnFirstResult` | `boolean` | `false` | Stop after first valid favicon |
 | `concurrency` | `number` | `3` | Max parallel validations |
+| `maxUris` | `number` | `50` | Max total candidate URIs to fetch across all methods |
 | `includeInvalid` | `boolean` | `false` | Include invalid results |
 | `onProgress` | `DiscoverOnProgressFn` | | Progress callback |
 

--- a/docs/reference/discover-feeds.md
+++ b/docs/reference/discover-feeds.md
@@ -46,6 +46,7 @@ All options are optional. When not provided, sensible defaults are used.
 | `stopOnFirstMethod` | `boolean` | `false` | Stop URI collection after first method with results |
 | `stopOnFirstResult` | `boolean` | `false` | Stop after first valid feed |
 | `concurrency` | `number` | `3` | Max parallel validations |
+| `maxUris` | `number` | `50` | Max total candidate URIs to fetch across all methods |
 | `includeInvalid` | `boolean` | `false` | Include invalid results |
 | `onProgress` | `DiscoverOnProgressFn` | | Progress callback |
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -54,6 +54,7 @@ type DiscoverOptions<TValid, TMethods extends DiscoverMethod = DiscoverMethod> =
   stopOnFirstMethod?: boolean
   stopOnFirstResult?: boolean
   concurrency?: number
+  maxUris?: number
   includeInvalid?: boolean
   onProgress?: DiscoverOnProgressFn
 }

--- a/src/common/discover/index.ts
+++ b/src/common/discover/index.ts
@@ -9,7 +9,7 @@ import {
   discoverMethodOrder,
 } from '../types.js'
 import { discoverUris } from '../uris/index.js'
-import { processConcurrently } from '../utils.js'
+import { processConcurrently, toPositiveInteger } from '../utils.js'
 import { normalizeInput, normalizeMethodsConfig, normalizeUriEntry } from './utils.js'
 
 export const discover = async <TValid>(
@@ -26,14 +26,16 @@ export const discover = async <TValid>(
     stopOnFirstMethod = false,
     stopOnFirstResult = false,
     concurrency = 3,
+    maxUris = 50,
     includeInvalid = false,
     onProgress,
     onError,
   } = options
 
-  // Reject NaN, < 1, and non-integer concurrency (which would hang or no-op the
-  // worker loop); a valid explicit value is respected as-is.
-  const safeConcurrency = Number.isInteger(concurrency) && concurrency >= 1 ? concurrency : 3
+  // Sanitize numeric options: reject NaN, < 1, and non-integer values, which
+  // would otherwise hang the worker loop or fetch nothing.
+  const safeConcurrency = toPositiveInteger(concurrency, 3)
+  const safeMaxUris = toPositiveInteger(maxUris, 50)
 
   // Normalize input: string → fetch URL, object → use provided content.
   const sourceInput = await normalizeInput(input, fetchFn, onError)
@@ -81,8 +83,13 @@ export const discover = async <TValid>(
   // Step 4: Normalize and deduplicate URIs per method group, deduping across groups.
   const seen = new Set<string>()
   const methodGroups: Array<{ method: DiscoverMethod; entries: Array<DiscoverUriEntry> }> = []
+  let remaining = safeMaxUris
 
   for (const method of discoverMethodOrder) {
+    if (remaining <= 0) {
+      break
+    }
+
     const rawUris = urisByMethod[method]
 
     if (!rawUris || rawUris.length === 0) {
@@ -107,7 +114,9 @@ export const discover = async <TValid>(
     })
 
     if (unique.length > 0) {
-      methodGroups.push({ method, entries: unique })
+      const capped = unique.slice(0, remaining)
+      remaining -= capped.length
+      methodGroups.push({ method, entries: capped })
     }
   }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -163,7 +163,7 @@ export type DiscoverOptions<TValid, TMethods extends DiscoverMethod = DiscoverMe
   stopOnFirstMethod?: boolean
   stopOnFirstResult?: boolean
   concurrency?: number
-  maxUris?: number // Cap on total candidate URIs fetched across all methods (default 50).
+  maxUris?: number
   onProgress?: DiscoverOnProgressFn
   onError?: DiscoverOnErrorFn
   includeInvalid?: boolean

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -163,6 +163,7 @@ export type DiscoverOptions<TValid, TMethods extends DiscoverMethod = DiscoverMe
   stopOnFirstMethod?: boolean
   stopOnFirstResult?: boolean
   concurrency?: number
+  maxUris?: number // Cap on total candidate URIs fetched across all methods (default 50).
   onProgress?: DiscoverOnProgressFn
   onError?: DiscoverOnErrorFn
   includeInvalid?: boolean
@@ -178,6 +179,7 @@ export type DiscoverOptionsInternal<TValid> = {
   stopOnFirstMethod?: boolean
   stopOnFirstResult?: boolean
   concurrency?: number
+  maxUris?: number
   includeInvalid?: boolean
   onProgress?: DiscoverOnProgressFn
   onError?: DiscoverOnErrorFn

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -14,6 +14,7 @@ import {
   normalizeMimeType,
   omitEmpty,
   processConcurrently,
+  toPositiveInteger,
 } from './utils.js'
 
 describe('composeHint', () => {
@@ -1226,5 +1227,29 @@ describe('isObject', () => {
     expect(isObject('https://example.com')).toBe(false)
     expect(isObject(42)).toBe(false)
     expect(isObject(undefined)).toBe(false)
+  })
+})
+
+describe('toPositiveInteger', () => {
+  it('should return the value when it is a positive integer', () => {
+    expect(toPositiveInteger(5, 3)).toBe(5)
+    expect(toPositiveInteger(1, 3)).toBe(1)
+  })
+
+  it('should fall back for undefined', () => {
+    expect(toPositiveInteger(undefined, 3)).toBe(3)
+  })
+
+  it('should fall back for NaN', () => {
+    expect(toPositiveInteger(Number.NaN, 3)).toBe(3)
+  })
+
+  it('should fall back for values below 1', () => {
+    expect(toPositiveInteger(0, 3)).toBe(3)
+    expect(toPositiveInteger(-1, 3)).toBe(3)
+  })
+
+  it('should fall back for non-integer values', () => {
+    expect(toPositiveInteger(2.5, 3)).toBe(3)
   })
 })

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -19,6 +19,11 @@ export const isObject = (value: unknown): value is object => {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
 }
 
+// Coerce to a positive integer, falling back when missing or invalid (NaN, < 1, non-integer).
+export const toPositiveInteger = (value: number | undefined, fallback: number): number => {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1 ? value : fallback
+}
+
 export const normalizeMimeType = (type: string): string => {
   return type.split(';')[0].trim().toLowerCase()
 }


### PR DESCRIPTION
Adds a `maxUris` option (default 50) that bounds the total number of candidate URIs the discovery pipeline will fetch across all methods.

Without a cap, the number of fetches is limited only by the size of the scanned page: a hostile or pathological page with thousands of feed-like anchors could make the library issue thousands of outbound requests. The cap is applied after dedup, in discovery-method order, so earlier methods (platform, feed, html, …) keep priority and the guess method fills whatever budget remains.

The default of 50 sits above every built-in preset (the largest, the comprehensive guess list, is ~30 entries) so normal discovery is unaffected; callers that want exhaustive guessing can raise it, and an invalid value falls back to the default.