### PR TITLE
feat: Add onError callback for swallowed fetch errors

### DIFF
--- a/src/common/discover/index.test.ts
+++ b/src/common/discover/index.test.ts
@@ -461,6 +461,60 @@ describe('discover', () => {
     })
   })
 
+  describe('onError', () => {
+    it('should call onError when the input fetch fails', async () => {
+      const errors: Array<{ error: unknown; phase: string; url?: string }> = []
+      const fetchError = new Error('Input fetch failed')
+      const mockFetch: DiscoverFetchFn = () => Promise.reject(fetchError)
+
+      await discoverFeeds('https://example.com', {
+        methods: ['guess'],
+        fetchFn: mockFetch,
+        onError: (error, context) => {
+          errors.push({ error, ...context })
+        },
+      })
+      const expected = [{ error: fetchError, phase: 'fetchInput', url: 'https://example.com' }]
+
+      expect(errors).toEqual(expected)
+    })
+
+    it('should call onError when site URL resolution fails', async () => {
+      const errors: Array<{ error: unknown; phase: string; url?: string }> = []
+      const fetchError = new Error('Site fetch failed')
+      const mockFetch: DiscoverFetchFn = (url) => {
+        if (url === 'https://example.com/site') {
+          return Promise.reject(fetchError)
+        }
+
+        return Promise.resolve({
+          url,
+          body: '',
+          headers: new Headers(),
+          status: 404,
+          statusText: 'Not Found',
+        })
+      }
+
+      await discoverFeeds(
+        { url: 'https://example.com/feed.xml', content: 'not a feed' },
+        {
+          methods: ['guess'],
+          fetchFn: mockFetch,
+          resolveSiteUrlFn: () => 'https://example.com/site',
+          onError: (error, context) => {
+            errors.push({ error, ...context })
+          },
+        },
+      )
+      const expected = [
+        { error: fetchError, phase: 'resolveSiteUrl', url: 'https://example.com/site' },
+      ]
+
+      expect(errors).toEqual(expected)
+    })
+  })
+
   describe('concurrency', () => {
     it('should respect concurrency limit', async () => {
       let maxConcurrent = 0

--- a/src/common/discover/index.ts
+++ b/src/common/discover/index.ts
@@ -28,10 +28,11 @@ export const discover = async <TValid>(
     concurrency = 3,
     includeInvalid = false,
     onProgress,
+    onError,
   } = options
 
   // Normalize input: string → fetch URL, object → use provided content.
-  const sourceInput = await normalizeInput(input, fetchFn)
+  const sourceInput = await normalizeInput(input, fetchFn, onError)
 
   // Step 1: Check if content is already valid (only if content is provided).
   if (sourceInput.content) {
@@ -61,7 +62,9 @@ export const discover = async <TValid>(
           content: typeof response.body === 'string' ? response.body : '',
           headers: response.headers,
         }
-      } catch {}
+      } catch (error) {
+        onError?.(error, { phase: 'resolveSiteUrl', url: siteUrl })
+      }
     }
   }
 

--- a/src/common/discover/utils.ts
+++ b/src/common/discover/utils.ts
@@ -8,6 +8,7 @@ import type {
   DiscoverMethodsConfig,
   DiscoverMethodsConfigDefaults,
   DiscoverMethodsConfigInternal,
+  DiscoverOnErrorFn,
   DiscoverResolveUrlFn,
   DiscoverUriEntry,
 } from '../types.js'
@@ -15,6 +16,7 @@ import type {
 export const normalizeInput = async (
   input: DiscoverInput,
   fetchFn: DiscoverFetchFn,
+  onError?: DiscoverOnErrorFn,
 ): Promise<DiscoverInputObject> => {
   if (typeof input === 'object') {
     return input
@@ -29,7 +31,9 @@ export const normalizeInput = async (
       content: typeof response.body === 'string' ? response.body : undefined,
       headers: response.headers,
     }
-  } catch {}
+  } catch (error) {
+    onError?.(error, { phase: 'fetchInput', url: input })
+  }
 
   // When the fetch fails, return the URL without content so that URL-only
   // methods like guess can still run.

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -67,6 +67,13 @@ export type DiscoverProgress = {
 
 export type DiscoverOnProgressFn = (progress: DiscoverProgress) => void
 
+export type DiscoverErrorContext = {
+  phase: 'fetchInput' | 'resolveSiteUrl'
+  url?: string
+}
+
+export type DiscoverOnErrorFn = (error: unknown, context: DiscoverErrorContext) => void
+
 // Base result type - TValid contains fields present when isValid = true.
 export type DiscoverResult<TValid = object> =
   | ({
@@ -157,6 +164,7 @@ export type DiscoverOptions<TValid, TMethods extends DiscoverMethod = DiscoverMe
   stopOnFirstResult?: boolean
   concurrency?: number
   onProgress?: DiscoverOnProgressFn
+  onError?: DiscoverOnErrorFn
   includeInvalid?: boolean
 }
 
@@ -172,4 +180,5 @@ export type DiscoverOptionsInternal<TValid> = {
   concurrency?: number
   includeInvalid?: boolean
   onProgress?: DiscoverOnProgressFn
+  onError?: DiscoverOnErrorFn
 }


### PR DESCRIPTION
Adds an optional `onError(error, context)` callback to the discover options so callers can observe failures that were previously swallowed silently.

Two fetch sites caught their errors with an empty `catch {}`: normalizing a string input (when the initial fetch fails) and resolving a feed-derived site URL. Both are intentionally non-fatal, discovery continues, but swallowing them meant a DNS/connection error was indistinguishable from "the page simply had no feed". The callback receives the error plus a `{ phase, url }` context (`phase` is `fetchInput` or `resolveSiteUrl`); the empty-result fallback behaviour is unchanged when no callback is provided.