### PR TITLE
fix: Make URI dedup key order-independent

### DIFF
--- a/src/common/discover/index.ts
+++ b/src/common/discover/index.ts
@@ -87,7 +87,8 @@ export const discover = async <TValid>(
     })
 
     const unique = normalized.filter((entry) => {
-      const key = typeof entry.uri === 'string' ? entry.uri : entry.uri.join('\0')
+      // Sort array alternatives so the key is order-independent.
+      const key = typeof entry.uri === 'string' ? entry.uri : [...entry.uri].sort().join('\0')
 
       if (seen.has(key)) {
         return false


### PR DESCRIPTION
When a discovered URI is an array of alternatives (try the first, fall back to the next), the dedup key was built by joining the alternatives in their original order. As a result `["/feed/atom/", "?feed=atom"]` and `["?feed=atom", "/feed/atom/"]` produced different keys and were treated as two distinct entries, leading to redundant fetches of the same set.

The key now sorts the alternatives before joining, so the same set of alternatives in any order dedupes to a single entry. String entries are unaffected.