### PR TITLE
feat: Guess feeds at the base path and origin root

### DIFF
--- a/src/common/uris/guess/utils.test.ts
+++ b/src/common/uris/guess/utils.test.ts
@@ -55,10 +55,21 @@ describe('generateUrlCombinations', () => {
     expect(generateUrlCombinations(baseUrls, feedUris)).toEqual(expected)
   })
 
-  it('should handle base URLs with paths', () => {
+  it('should emit path-rooted and origin-rooted variants for absolute paths on a base with a subpath', () => {
     const baseUrls = ['https://example.com/blog/']
     const feedUris = ['/feed.xml', 'rss.xml']
-    const expected = ['https://example.com/feed.xml', 'https://example.com/blog/rss.xml']
+    const expected = [
+      ['https://example.com/blog/feed.xml', 'https://example.com/feed.xml'],
+      'https://example.com/blog/rss.xml',
+    ]
+
+    expect(generateUrlCombinations(baseUrls, feedUris)).toEqual(expected)
+  })
+
+  it('should root absolute paths at the base directory when the base has no trailing slash', () => {
+    const baseUrls = ['https://example.com/blog/post']
+    const feedUris = ['/feed.xml']
+    const expected = [['https://example.com/blog/feed.xml', 'https://example.com/feed.xml']]
 
     expect(generateUrlCombinations(baseUrls, feedUris)).toEqual(expected)
   })

--- a/src/common/uris/guess/utils.ts
+++ b/src/common/uris/guess/utils.ts
@@ -2,16 +2,30 @@ import type { UriEntry } from '../../types.js'
 
 const ipAddressRegex = /^\d+\.\d+\.\d+\.\d+$/
 
-const resolveUri = (uri: string, base: string, origin: string, pathname: string): string => {
+// Resolve a guess URI against a base, returning every candidate to try. For an
+// absolute path on a base that has a subpath (e.g. https://site.com/blog/), both
+// the path-rooted variant (https://site.com/blog/feed) and the origin-rooted one
+// (https://site.com/feed) are returned, path-rooted first; they collapse to a
+// single candidate when the base is at the root.
+const resolveUri = (
+  uri: string,
+  base: string,
+  origin: string,
+  pathname: string,
+  directory: string,
+): Array<string> => {
   if (uri.startsWith('/')) {
-    return `${origin}${uri}`
+    const originRooted = `${origin}${uri}`
+    const pathRooted = `${directory}${uri.slice(1)}`
+
+    return pathRooted === originRooted ? [originRooted] : [pathRooted, originRooted]
   }
 
   if (uri.startsWith('?')) {
-    return `${origin}${pathname}${uri}`
+    return [`${origin}${pathname}${uri}`]
   }
 
-  return new URL(uri, base).href
+  return [new URL(uri, base).href]
 }
 
 export const generateUrlCombinations = (
@@ -22,13 +36,18 @@ export const generateUrlCombinations = (
     const parsed = new URL(base)
     const origin = parsed.origin
     const pathname = parsed.pathname
+    const directory = new URL('.', base).href
 
     return uris.map((uri) => {
       if (typeof uri === 'string') {
-        return resolveUri(uri, base, origin, pathname)
+        const resolved = resolveUri(uri, base, origin, pathname, directory)
+
+        return resolved.length === 1 ? resolved[0] : resolved
       }
 
-      return uri.map((alternative) => resolveUri(alternative, base, origin, pathname))
+      return uri.flatMap((alternative) => {
+        return resolveUri(alternative, base, origin, pathname, directory)
+      })
     })
   })
 }


### PR DESCRIPTION
Makes the guess method consistent for sites hosted under a subpath.

Previously an absolute guess path (e.g. `/feed.xml`) was always resolved against the **origin**, dropping any base path, so for a blog at `https://example.com/blog/`, the guesser only tried `https://example.com/feed.xml` and never `https://example.com/blog/feed.xml`, while query-only paths (`?feed=rss`) *did* keep the base path. That asymmetry meant path-hosted feeds were missed.

Now an absolute path on a base with a subpath yields both candidates as alternatives: the path-rooted one first (more likely correct for the given URL), then the origin-rooted one as a fallback. When the base is at the root, the two collapse to a single candidate, so root-hosted sites are unaffected.