### PR TITLE
docs: Note charset handling as a reason for a custom fetchFn

### DIFF
--- a/docs/customization/data-fetching.md
+++ b/docs/customization/data-fetching.md
@@ -160,4 +160,5 @@ Use a custom `fetchFn` when you need:
 - **Consistent HTTP client** — Use the same library across your app.
 - **Custom configuration** — Timeouts, proxies, retry logic.
 - **Request interceptors** — Logging, authentication, caching.
+- **Character encoding** — Decode non-UTF-8 feeds (e.g. `ISO-8859-1`, `Shift_JIS`) by reading the response as bytes and decoding with `TextDecoder` using the charset from the `Content-Type` header or the feed's XML declaration.
 - **Environment compatibility** — Some runtimes may not support native fetch.


### PR DESCRIPTION
Adds a bullet to the "When to Use Custom HTTP Clients" list documenting that a custom `fetchFn` can decode non-UTF-8 feeds (e.g. `ISO-8859-1`, `Shift_JIS`) by reading the response as bytes and decoding with `TextDecoder` using the charset from the `Content-Type` header or the feed XML declaration.

The default `fetchFn` uses `response.text()`, which honors only the HTTP charset; feeds that declare a non-UTF-8 encoding solely in their XML prolog need a charset-aware fetcher. Pointing users to the existing extension point is the intended way to handle this.