### PR TITLE
feat: Probe section links found in page HTML in guess method

### DIFF
--- a/docs/feeds/guess.md
+++ b/docs/feeds/guess.md
@@ -46,6 +46,39 @@ const feeds = await discoverFeeds(url, {
 
 Every configured URI is tested against each ancestor directory the same way it is tested against the root: `/feed.xml` resolves under the directory, and a bare query URI like `?feed=rss` is appended to it (`https://example.com/blog/?feed=rss`).
 
+## Section Links
+
+Sites often keep their feed under a content section that isn't part of the current page's path — for example, a homepage linking to `/blog` with the feed at `/blog/rss.xml`. The Guess method scans the page HTML for same-origin links whose path is a single section segment and tests path-style URIs against them:
+
+```
+https://example.com/ with <a href="/blog">
+→ https://example.com/blog/rss.xml
+→ https://example.com/blog/feed.xml
+→ ...
+```
+
+The recognized section segments are exported as `sectionNames`:
+
+```typescript
+import { sectionNames } from 'feedscout/feeds'
+
+// ['blog', 'news', 'posts', 'articles', 'writing', 'notes', 'journal', 'podcast', 'changelog']
+```
+
+You can pass your own list:
+
+```typescript
+const feeds = await discoverFeeds(url, {
+  methods: {
+    guess: {
+      sectionNames: ['blog', 'updates'],
+    },
+  },
+})
+```
+
+Setting `sectionNames: []` disables section-link probing.
+
 ## URI Sets
 
 There are three predefined URI sets:

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -316,5 +316,7 @@ type GuessMethodOptions = {
   uris: Array<string>
   additionalBaseUrls?: Array<string>
   maxAncestorDepth?: number
+  content?: string
+  sectionNames?: Array<string>
 }
 ```

--- a/src/common/discover/utils.test.ts
+++ b/src/common/discover/utils.test.ts
@@ -548,7 +548,10 @@ describe('normalizeMethodsConfig', () => {
         options: expectedHeadersOptions,
       },
       guess: {
-        options: expectedGuessOptions,
+        options: {
+          ...expectedGuessOptions,
+          content: '<html></html>',
+        },
       },
     }
 
@@ -602,6 +605,7 @@ describe('normalizeMethodsConfig', () => {
         options: {
           ...expectedGuessOptions,
           uris: ['/custom'],
+          content: '<html></html>',
         },
       },
     }
@@ -672,6 +676,7 @@ describe('normalizeMethodsConfig', () => {
       guess: {
         options: {
           ...expectedGuessOptions,
+          content: '<html></html>',
           baseUrl: 'https://blog.example.com',
         },
       },
@@ -756,7 +761,10 @@ describe('normalizeMethodsConfig', () => {
         options: expectedHeadersOptions,
       },
       guess: {
-        options: expectedGuessOptions,
+        options: {
+          ...expectedGuessOptions,
+          content: '<html></html>',
+        },
       },
     }
 
@@ -1077,6 +1085,7 @@ describe('normalizeMethodsConfig', () => {
         guess: {
           options: {
             uris: ['/favicon.ico'],
+            content: '<html><link rel="icon" href="/favicon.ico"></html>',
             baseUrl: 'https://example.com',
           },
         },
@@ -1129,6 +1138,7 @@ describe('normalizeMethodsConfig', () => {
         guess: {
           options: {
             uris: ['/favicon.ico'],
+            content: '<html>content</html>',
             baseUrl: 'https://example.com',
           },
         },

--- a/src/common/discover/utils.ts
+++ b/src/common/discover/utils.ts
@@ -170,6 +170,8 @@ export const normalizeMethodsConfig = (
     methodsConfig.guess = {
       options: {
         ...defaults.guess,
+        // Page HTML for section-link scanning; explicit method options may override it.
+        content: resolvedInput.content,
         ...guessOptions,
         baseUrl: resolvedInput.url,
       },

--- a/src/common/uris/guess/index.test.ts
+++ b/src/common/uris/guess/index.test.ts
@@ -172,4 +172,51 @@ describe('discoverUrisFromGuess', () => {
 
     expect(value).toEqual(expected)
   })
+
+  it('should probe section links found in content', () => {
+    const value = discoverUrisFromGuess({
+      baseUrl: 'https://example.com/',
+      uris: ['/rss.xml'],
+      content: '<a href="/blog">Blog</a>',
+      sectionNames: ['blog'],
+    })
+    const expected = ['https://example.com/rss.xml', 'https://example.com/blog/rss.xml']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should not probe sections without content', () => {
+    const value = discoverUrisFromGuess({
+      baseUrl: 'https://example.com/',
+      uris: ['/rss.xml'],
+      sectionNames: ['blog'],
+    })
+    const expected = ['https://example.com/rss.xml']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should not probe sections without sectionNames', () => {
+    const value = discoverUrisFromGuess({
+      baseUrl: 'https://example.com/',
+      uris: ['/rss.xml'],
+      content: '<a href="/blog">Blog</a>',
+    })
+    const expected = ['https://example.com/rss.xml']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should deduplicate section bases against ancestor bases', () => {
+    const value = discoverUrisFromGuess({
+      baseUrl: 'https://example.com/blog/post-slug/',
+      uris: ['/feed.xml'],
+      maxAncestorDepth: 1,
+      content: '<a href="/blog/">Blog</a>',
+      sectionNames: ['blog'],
+    })
+    const expected = ['https://example.com/feed.xml', 'https://example.com/blog/feed.xml']
+
+    expect(value).toEqual(expected)
+  })
 })

--- a/src/common/uris/guess/index.ts
+++ b/src/common/uris/guess/index.ts
@@ -1,6 +1,7 @@
 import type { UriEntry } from '../../types.js'
 import type { GuessMethodOptions } from './types.js'
 import {
+  extractSectionBaseUrls,
   generatePathUrlCombinations,
   generateUrlCombinations,
   getAncestorPathBases,
@@ -8,15 +9,28 @@ import {
 
 export const discoverUrisFromGuess = (options: GuessMethodOptions): Array<UriEntry> => {
   const { baseUrl, uris, additionalBaseUrls = [], maxAncestorDepth = 0 } = options
+  const { content, sectionNames } = options
   const baseUrls = [baseUrl, ...additionalBaseUrls]
 
   // Origin-level combinations come first: root-level feeds are the most common case, and the
   // discover-level maxUris cap truncates from the tail.
   const combinations = generateUrlCombinations(baseUrls, uris)
+  const pathBases: Array<string> = []
 
   if (maxAncestorDepth > 0) {
-    const ancestorBases = getAncestorPathBases(baseUrl, maxAncestorDepth)
-    combinations.push(...generatePathUrlCombinations(ancestorBases, uris))
+    pathBases.push(...getAncestorPathBases(baseUrl, maxAncestorDepth))
+  }
+
+  if (content && sectionNames && sectionNames.length > 0) {
+    for (const sectionBase of extractSectionBaseUrls(content, baseUrl, sectionNames)) {
+      if (!pathBases.includes(sectionBase)) {
+        pathBases.push(sectionBase)
+      }
+    }
+  }
+
+  if (pathBases.length > 0) {
+    combinations.push(...generatePathUrlCombinations(pathBases, uris))
   }
 
   return combinations

--- a/src/common/uris/guess/types.ts
+++ b/src/common/uris/guess/types.ts
@@ -7,4 +7,9 @@ export type GuessMethodOptions = {
   // How many directory levels of the base URL's path to also probe with path-style URIs
   // (e.g. /blog/feed.xml for a page under /blog/). 0 or undefined disables ancestor probing.
   maxAncestorDepth?: number
+  // Page HTML scanned for same-origin section links (e.g. /blog) to probe with path-style URIs.
+  // Filled automatically from the fetched page during discovery.
+  content?: string
+  // Path segments that mark a linked page as a content section worth probing (e.g. "blog").
+  sectionNames?: Array<string>
 }

--- a/src/common/uris/guess/utils.test.ts
+++ b/src/common/uris/guess/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import type { UriEntry } from '../../types.js'
 import {
+  extractSectionBaseUrls,
   generatePathUrlCombinations,
   generateUrlCombinations,
   getAncestorPathBases,
@@ -365,6 +366,113 @@ describe('getAncestorPathBases', () => {
 
   it('should return empty array for invalid URLs', () => {
     const value = getAncestorPathBases('not-a-url', 2)
+    const expected: Array<string> = []
+
+    expect(value).toEqual(expected)
+  })
+})
+
+describe('extractSectionBaseUrls', () => {
+  const sectionNames = ['blog', 'news', 'podcast']
+
+  it('should extract same-origin section links', () => {
+    const html = '<nav><a href="/blog">Blog</a><a href="/about">About</a></nav>'
+    const value = extractSectionBaseUrls(html, 'https://example.com/', sectionNames)
+    const expected = ['https://example.com/blog/']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should handle absolute same-origin links', () => {
+    const html = '<a href="https://example.com/news">News</a>'
+    const value = extractSectionBaseUrls(html, 'https://example.com/', sectionNames)
+    const expected = ['https://example.com/news/']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should ignore cross-origin links', () => {
+    const html = '<a href="https://other.com/blog">Blog</a>'
+    const value = extractSectionBaseUrls(html, 'https://example.com/', sectionNames)
+    const expected: Array<string> = []
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should ignore links with more than one path segment', () => {
+    const html = '<a href="/blog/post-slug/">Post</a><a href="/en/blog">Blog</a>'
+    const value = extractSectionBaseUrls(html, 'https://example.com/', sectionNames)
+    const expected: Array<string> = []
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should ignore links outside the section vocabulary', () => {
+    const html = '<a href="/pricing">Pricing</a><a href="/team">Team</a>'
+    const value = extractSectionBaseUrls(html, 'https://example.com/', sectionNames)
+    const expected: Array<string> = []
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should normalize trailing slash variants to one base', () => {
+    const html = '<a href="/blog">Blog</a><a href="/blog/">Blog</a>'
+    const value = extractSectionBaseUrls(html, 'https://example.com/', sectionNames)
+    const expected = ['https://example.com/blog/']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should match case-insensitively while preserving the original casing', () => {
+    const html = '<a href="/Blog">Blog</a>'
+    const value = extractSectionBaseUrls(html, 'https://example.com/', sectionNames)
+    const expected = ['https://example.com/Blog/']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should resolve relative links against a deep base URL', () => {
+    const html = '<a href="/blog">Blog</a>'
+    const value = extractSectionBaseUrls(html, 'https://example.com/some/page/', sectionNames)
+    const expected = ['https://example.com/blog/']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should collect multiple sections in document order', () => {
+    const html = '<a href="/news">News</a><a href="/blog">Blog</a>'
+    const value = extractSectionBaseUrls(html, 'https://example.com/', sectionNames)
+    const expected = ['https://example.com/news/', 'https://example.com/blog/']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should ignore unparsable hrefs', () => {
+    const html = '<a href="http://">Broken</a><a href="/blog">Blog</a>'
+    const value = extractSectionBaseUrls(html, 'https://example.com/', sectionNames)
+    const expected = ['https://example.com/blog/']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should ignore anchors without href', () => {
+    const html = '<a name="top">Top</a>'
+    const value = extractSectionBaseUrls(html, 'https://example.com/', sectionNames)
+    const expected: Array<string> = []
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should return empty array for invalid base URL', () => {
+    const html = '<a href="/blog">Blog</a>'
+    const value = extractSectionBaseUrls(html, 'not-a-url', sectionNames)
+    const expected: Array<string> = []
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should return empty array for empty content', () => {
+    const value = extractSectionBaseUrls('', 'https://example.com/', sectionNames)
     const expected: Array<string> = []
 
     expect(value).toEqual(expected)

--- a/src/common/uris/guess/utils.ts
+++ b/src/common/uris/guess/utils.ts
@@ -1,3 +1,4 @@
+import { Parser } from 'htmlparser2'
 import { parseUrl } from 'trousse'
 import type { UriEntry } from '../../types.js'
 
@@ -87,6 +88,58 @@ export const getAncestorPathBases = (baseUrl: string, maxDepth: number): Array<s
   }
 
   return bases
+}
+
+// Scans page HTML for same-origin anchors whose path is a single section segment (e.g. /blog)
+// and returns them as path bases for probing, preserving the segment's original casing.
+export const extractSectionBaseUrls = (
+  content: string,
+  baseUrl: string,
+  sectionNames: Array<string>,
+): Array<string> => {
+  let base: URL
+
+  try {
+    base = new URL(baseUrl)
+  } catch {
+    return []
+  }
+
+  const bases = new Set<string>()
+  const parser = new Parser(
+    {
+      onopentag: (name, attributes) => {
+        if (name !== 'a' || !attributes.href) {
+          return
+        }
+
+        let url: URL
+
+        try {
+          url = new URL(attributes.href, base)
+        } catch {
+          return
+        }
+
+        if (url.origin !== base.origin) {
+          return
+        }
+
+        const segments = url.pathname.split('/').filter((segment) => segment !== '')
+        const segment = segments.length === 1 ? segments[0] : undefined
+
+        if (segment && sectionNames.includes(segment.toLowerCase())) {
+          bases.add(`${url.origin}/${segment}/`)
+        }
+      },
+    },
+    { decodeEntities: true },
+  )
+
+  parser.write(content)
+  parser.end()
+
+  return [...bases]
 }
 
 export const getWwwCounterpart = (baseUrl: string): string => {

--- a/src/common/uris/guess/utils.ts
+++ b/src/common/uris/guess/utils.ts
@@ -1,5 +1,5 @@
 import { Parser } from 'htmlparser2'
-import { parseUrl } from 'trousse'
+import { getPathSegments, parseUrl } from 'trousse'
 import type { UriEntry } from '../../types.js'
 
 const ipAddressRegex = /^\d+\.\d+\.\d+\.\d+$/
@@ -97,11 +97,9 @@ export const extractSectionBaseUrls = (
   baseUrl: string,
   sectionNames: Array<string>,
 ): Array<string> => {
-  let base: URL
+  const base = parseUrl(baseUrl)
 
-  try {
-    base = new URL(baseUrl)
-  } catch {
+  if (!base) {
     return []
   }
 
@@ -113,19 +111,13 @@ export const extractSectionBaseUrls = (
           return
         }
 
-        let url: URL
+        const url = parseUrl(attributes.href, base)
 
-        try {
-          url = new URL(attributes.href, base)
-        } catch {
+        if (!url || url.origin !== base.origin) {
           return
         }
 
-        if (url.origin !== base.origin) {
-          return
-        }
-
-        const segments = url.pathname.split('/').filter((segment) => segment !== '')
+        const segments = getPathSegments(url)
         const segment = segments.length === 1 ? segments[0] : undefined
 
         if (segment && sectionNames.includes(segment.toLowerCase())) {

--- a/src/exports/methods.ts
+++ b/src/exports/methods.ts
@@ -1,6 +1,7 @@
 export { discoverUrisFromFeed } from '../common/uris/feed/index.js'
 export { discoverUrisFromGuess } from '../common/uris/guess/index.js'
 export {
+  extractSectionBaseUrls,
   generateUrlCombinations,
   getSubdomainVariants,
   getWwwCounterpart,

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -199,10 +199,24 @@ export const defaultHeadersOptions: Omit<HeadersMethodOptions, 'baseUrl'> = {
   linkSelectors,
 }
 
+// Path segments of same-origin links that mark a content section likely to host its own feed.
+export const sectionNames = [
+  'blog',
+  'news',
+  'posts',
+  'articles',
+  'writing',
+  'notes',
+  'journal',
+  'podcast',
+  'changelog',
+]
+
 // Default options for Guess method (excluding baseUrl which is required).
 export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
   uris: urisBalanced,
   maxAncestorDepth: 2,
+  sectionNames,
 }
 
 // Default options for Platform method.

--- a/src/feeds/index.test.ts
+++ b/src/feeds/index.test.ts
@@ -88,6 +88,42 @@ describe('discoverFeeds', () => {
     expect(value).toEqual(expected)
   })
 
+  it('should find feeds under linked sections when the root has no feed hints', async () => {
+    const rss = `
+      <rss version="2.0">
+        <channel>
+          <title>Blog RSS</title>
+          <link>https://example.com/blog</link>
+          <description>Blog feed</description>
+        </channel>
+      </rss>
+    `
+    const html = `
+      <html>
+        <head><title>Home</title></head>
+        <body><nav><a href="/blog">Blog</a><a href="/about">About</a></nav></body>
+      </html>
+    `
+    const mockFetch = createMockFetch({
+      'https://example.com/': html,
+      'https://example.com/blog/rss.xml': rss,
+    })
+    const value = await discoverFeeds('https://example.com/', { fetchFn: mockFetch })
+    const expected: Array<DiscoverResult<FeedResult>> = [
+      {
+        url: 'https://example.com/blog/rss.xml',
+        isValid: true,
+        method: 'guess',
+        format: 'rss',
+        title: 'Blog RSS',
+        description: 'Blog feed',
+        siteUrl: 'https://example.com/blog',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
   it('should find valid feeds using guess method with default URIs', async () => {
     const rss = `
       <rss version="2.0">


### PR DESCRIPTION
Stacked on #155 (replaces the reverted #152).

When a site keeps its feed under a content section that isn't part of the input URL's path: a homepage linking to `/blog` with the feed at `/blog/rss.xml` and no autodiscovery anywhere: no method could find it.

The guess method now scans the page HTML for same-origin anchors whose path is a single section segment (`blog`, `news`, `posts`, …, exported as `sectionNames`) and tests path-style URIs against those sections, after the origin and ancestor candidates. Only sections the page actually links to are probed, so the extra fetches stay bounded. The page HTML is wired into the guess options during discovery; the favicons and blogrolls discoverers don't set `sectionNames`, so they are unaffected.

Real-world example: https://chsm.dev/ has no autodiscovery on `/` or `/blog` and serves feeds at `/blog/rss.xml` and `/blog/atom.xml`; the `/blog` nav link is the only signal.
