### PR TITLE
refactor: Align object literal property order with type declarations

### DIFF
--- a/src/blogrolls/index.test.ts
+++ b/src/blogrolls/index.test.ts
@@ -7,9 +7,9 @@ import type { BlogrollResult } from './types.js'
 
 const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => {
   return async (url: string) => ({
-    url,
-    body: responses[url] ?? '',
     headers: new Headers(),
+    body: responses[url] ?? '',
+    url,
     status: 200,
     statusText: 'OK',
   })
@@ -402,9 +402,9 @@ describe('discoverBlogrolls', () => {
 
   it('should filter out invalid results when fetchFn returns 404', async () => {
     const mockFetch: DiscoverFetchFn = async (url: string) => ({
-      url,
-      body: 'Not Found',
       headers: new Headers(),
+      body: 'Not Found',
+      url,
       status: 404,
       statusText: 'Not Found',
     })
@@ -457,9 +457,9 @@ describe('discoverBlogrolls', () => {
       }
 
       return Promise.resolve({
-        url,
-        body: url === 'https://example.com/blogroll.opml' ? opml : '',
         headers: new Headers(),
+        body: url === 'https://example.com/blogroll.opml' ? opml : '',
+        url,
         status: url === 'https://example.com/blogroll.opml' ? 200 : 404,
         statusText: url === 'https://example.com/blogroll.opml' ? 'OK' : 'Not Found',
       })

--- a/src/common/discover/index.test.ts
+++ b/src/common/discover/index.test.ts
@@ -23,9 +23,9 @@ const rss = `
 
 const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => {
   return async (url: string) => ({
-    url,
-    body: responses[url] ?? '',
     headers: new Headers(),
+    body: responses[url] ?? '',
+    url,
     status: 200,
     statusText: 'OK',
   })
@@ -86,9 +86,9 @@ describe('discoverFeeds', () => {
         fetchedUrls.push(url)
 
         return Promise.resolve({
-          url,
-          body: url === 'https://example.com/platform-feed' ? rss : '',
           headers: new Headers(),
+          body: url === 'https://example.com/platform-feed' ? rss : '',
+          url,
           status: 200,
           statusText: 'OK',
         })
@@ -131,9 +131,9 @@ describe('discoverFeeds', () => {
         fetchedUrls.push(url)
 
         return Promise.resolve({
-          url,
-          body: url === 'https://example.com/guess-feed' ? rss : '',
           headers: new Headers(),
+          body: url === 'https://example.com/guess-feed' ? rss : '',
+          url,
           status: 200,
           statusText: 'OK',
         })
@@ -179,9 +179,9 @@ describe('discoverFeeds', () => {
         fetchedUrls.push(url)
 
         return Promise.resolve({
-          url,
-          body: url.includes('guess') ? rss : '',
           headers: new Headers(),
+          body: url.includes('guess') ? rss : '',
+          url,
           status: 200,
           statusText: 'OK',
         })
@@ -257,9 +257,9 @@ describe('discoverFeeds', () => {
       const mockFetch: DiscoverFetchFn = (url) => {
         fetchCount++
         return Promise.resolve({
-          url,
-          body: rss,
           headers: new Headers(),
+          body: rss,
+          url,
           status: 200,
           statusText: 'OK',
         })
@@ -296,9 +296,9 @@ describe('discoverFeeds', () => {
       const mockFetch: DiscoverFetchFn = (url) => {
         fetchedUrls.push(url)
         return Promise.resolve({
-          url,
-          body: url === 'https://example.com/feed/' ? rss : '',
           headers: new Headers(),
+          body: url === 'https://example.com/feed/' ? rss : '',
+          url,
           status: 200,
           statusText: 'OK',
         })
@@ -331,9 +331,9 @@ describe('discoverFeeds', () => {
       const mockFetch: DiscoverFetchFn = (url) => {
         fetchedUrls.push(url)
         return Promise.resolve({
-          url,
-          body: url === 'https://example.com/?feed=rss' ? rss : '',
           headers: new Headers(),
+          body: url === 'https://example.com/?feed=rss' ? rss : '',
+          url,
           status: 200,
           statusText: 'OK',
         })
@@ -495,9 +495,9 @@ describe('discoverFeeds', () => {
         }
 
         return Promise.resolve({
-          url,
-          body: '',
           headers: new Headers(),
+          body: '',
+          url,
           status: 404,
           statusText: 'Not Found',
         })
@@ -534,9 +534,9 @@ describe('discoverFeeds', () => {
         })
         currentConcurrent--
         return {
-          url,
-          body: rss,
           headers: new Headers(),
+          body: rss,
+          url,
           status: 200,
           statusText: 'OK',
         }
@@ -910,9 +910,9 @@ describe('discoverFeeds', () => {
       }
       const mockFetch: DiscoverFetchFn = (url) =>
         Promise.resolve({
-          url,
-          body: '<rss><channel><title>Test</title></channel></rss>',
           headers: new Headers({ etag: '"abc123"' }),
+          body: '<rss><channel><title>Test</title></channel></rss>',
+          url,
           status: 200,
           statusText: 'OK',
         })
@@ -1096,9 +1096,9 @@ describe('discoverFeeds', () => {
       }
       const mockFetch: DiscoverFetchFn = (url: string) =>
         Promise.resolve({
-          url,
-          body: rss,
           headers: responseHeaders,
+          body: rss,
+          url,
           status: 200,
           statusText: 'OK',
         })

--- a/src/common/discover/utils.test.ts
+++ b/src/common/discover/utils.test.ts
@@ -57,9 +57,9 @@ describe('defaultFetchFn', () => {
       }),
     )
     const expected = {
-      url: 'https://example.com/feed.xml',
-      body: 'response body',
       headers: expect.any(Headers),
+      body: 'response body',
+      url: 'https://example.com/feed.xml',
       status: 200,
       statusText: 'OK',
     }
@@ -125,9 +125,9 @@ describe('defaultFetchFn', () => {
     )
     const result = await defaultFetchFn('https://example.com/feed.xml')
     const expected = {
-      url: 'https://example.com/feed.xml',
-      body: 'feed content',
       headers: expect.any(Headers),
+      body: 'feed content',
+      url: 'https://example.com/feed.xml',
       status: 200,
       statusText: 'OK',
     }
@@ -145,9 +145,9 @@ describe('defaultFetchFn', () => {
       }),
     )
     const expected = {
-      url: 'https://redirect.example.com/feed.xml',
-      body: '',
       headers: expect.any(Headers),
+      body: '',
+      url: 'https://redirect.example.com/feed.xml',
       status: 200,
       statusText: 'OK',
     }
@@ -164,9 +164,9 @@ describe('defaultFetchFn', () => {
       }),
     )
     const expected = {
-      url: '',
-      body: '<rss>feed content</rss>',
       headers: expect.any(Headers),
+      body: '<rss>feed content</rss>',
+      url: '',
       status: 200,
       statusText: 'OK',
     }
@@ -184,9 +184,9 @@ describe('defaultFetchFn', () => {
       }),
     )
     const expected = {
-      url: '',
-      body: '',
       headers: expect.any(Headers),
+      body: '',
+      url: '',
       status: 404,
       statusText: 'Not Found',
     }
@@ -198,9 +198,9 @@ describe('defaultFetchFn', () => {
 describe('normalizeInput', () => {
   const fetchFn: DiscoverFetchFn = (url) => {
     return Promise.resolve({
-      url,
-      body: '<html>content</html>',
       headers: new Headers({ 'content-type': 'text/html' }),
+      body: '<html>content</html>',
+      url,
       status: 200,
       statusText: 'OK',
     })
@@ -219,9 +219,9 @@ describe('normalizeInput', () => {
   it('should preserve redirected URL from fetch response', async () => {
     const redirectFetchFn: DiscoverFetchFn = () => {
       return Promise.resolve({
-        url: 'https://example.com/redirected',
-        body: '<html>content</html>',
         headers: new Headers(),
+        body: '<html>content</html>',
+        url: 'https://example.com/redirected',
         status: 200,
         statusText: 'OK',
       })
@@ -238,9 +238,9 @@ describe('normalizeInput', () => {
   it('should handle ReadableStream body by returning undefined content', async () => {
     const streamFetchFn: DiscoverFetchFn = (url) => {
       return Promise.resolve({
-        url,
-        body: new ReadableStream(),
         headers: new Headers(),
+        body: new ReadableStream(),
+        url,
         status: 200,
         statusText: 'OK',
       })
@@ -258,9 +258,9 @@ describe('normalizeInput', () => {
     const headers = new Headers({ 'content-type': 'text/html', link: '</feed>; rel="alternate"' })
     const headersFetchFn: DiscoverFetchFn = (url) => {
       return Promise.resolve({
-        url,
-        body: '<html></html>',
         headers,
+        body: '<html></html>',
+        url,
         status: 200,
         statusText: 'OK',
       })
@@ -347,9 +347,9 @@ describe('normalizeInput', () => {
   it('should handle empty string content from fetch', async () => {
     const emptyFetchFn: DiscoverFetchFn = (url) => {
       return Promise.resolve({
-        url,
-        body: '',
         headers: new Headers(),
+        body: '',
+        url,
         status: 200,
         statusText: 'OK',
       })
@@ -368,9 +368,9 @@ describe('normalizeInput', () => {
     const trackingFetchFn: DiscoverFetchFn = (url) => {
       fetchCalled = true
       return Promise.resolve({
-        url,
-        body: '<html></html>',
         headers: new Headers(),
+        body: '<html></html>',
+        url,
         status: 200,
         statusText: 'OK',
       })
@@ -388,9 +388,9 @@ describe('normalizeInput', () => {
   it('should handle fetch response with different status codes', async () => {
     const statusFetchFn: DiscoverFetchFn = (url) => {
       return Promise.resolve({
-        url,
-        body: '<html>content</html>',
         headers: new Headers(),
+        body: '<html>content</html>',
+        url,
         status: 301,
         statusText: 'Moved Permanently',
       })
@@ -500,19 +500,19 @@ describe('normalizeMethodsConfig', () => {
     },
   }
   const expectedHtmlOptions = {
+    baseUrl: 'https://example.com',
     linkSelectors,
     anchorUris: feedUrisComprehensive,
     anchorIgnoredUris: ignoredUris,
     anchorLabels,
-    baseUrl: 'https://example.com',
   }
   const expectedHeadersOptions = {
-    linkSelectors,
     baseUrl: 'https://example.com',
+    linkSelectors,
   }
   const expectedGuessOptions = {
-    uris: feedUrisBalanced,
     baseUrl: 'https://example.com',
+    uris: feedUrisBalanced,
   }
 
   it('should normalize array with single method to config with defaults', () => {
@@ -1068,25 +1068,25 @@ describe('normalizeMethodsConfig', () => {
         html: {
           html: '<html><link rel="icon" href="/favicon.ico"></html>',
           options: {
+            baseUrl: 'https://example.com',
             linkSelectors: [{ rel: 'icon' }],
             anchorUris: [],
             anchorIgnoredUris: [],
             anchorLabels: [],
-            baseUrl: 'https://example.com',
           },
         },
         headers: {
           headers: siteHeaders,
           options: {
-            linkSelectors: [{ rel: 'icon' }],
             baseUrl: 'https://example.com',
+            linkSelectors: [{ rel: 'icon' }],
           },
         },
         guess: {
           options: {
+            baseUrl: 'https://example.com',
             uris: ['/favicon.ico'],
             content: '<html><link rel="icon" href="/favicon.ico"></html>',
-            baseUrl: 'https://example.com',
           },
         },
       }
@@ -1128,18 +1128,18 @@ describe('normalizeMethodsConfig', () => {
         html: {
           html: '<html>content</html>',
           options: {
+            baseUrl: 'https://example.com',
             linkSelectors: [{ rel: 'icon' }],
             anchorUris: [],
             anchorIgnoredUris: [],
             anchorLabels: [],
-            baseUrl: 'https://example.com',
           },
         },
         guess: {
           options: {
+            baseUrl: 'https://example.com',
             uris: ['/favicon.ico'],
             content: '<html>content</html>',
-            baseUrl: 'https://example.com',
           },
         },
       }

--- a/src/favicons/index.test.ts
+++ b/src/favicons/index.test.ts
@@ -47,12 +47,12 @@ describe('discoverFavicons', () => {
 
   it('should discover favicons from headers', async () => {
     const mockFetch: DiscoverFetchFn = async (url: string) => ({
-      url,
-      body: '',
       headers: new Headers({
         link: '</favicon.png>; rel="icon"',
         ...(url.endsWith('.png') ? { 'content-type': 'image/png' } : {}),
       }),
+      body: '',
+      url,
       status: 200,
       statusText: 'OK',
     })
@@ -331,9 +331,9 @@ describe('discoverFavicons', () => {
 
   it('should recognize direct favicon URL via image content-type', async () => {
     const mockFetch: DiscoverFetchFn = async (url: string) => ({
-      url,
-      body: 'binary',
       headers: new Headers({ 'content-type': 'image/png' }),
+      body: 'binary',
+      url,
       status: 200,
       statusText: 'OK',
     })
@@ -348,9 +348,9 @@ describe('discoverFavicons', () => {
   it('should recognize direct SVG favicon via content', async () => {
     const svgContent = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>'
     const mockFetch: DiscoverFetchFn = async (url: string) => ({
-      url,
-      body: svgContent,
       headers: new Headers(),
+      body: svgContent,
+      url,
       status: 200,
       statusText: 'OK',
     })
@@ -573,9 +573,9 @@ describe('discoverFavicons', () => {
       }
 
       return Promise.resolve({
-        url,
-        body: url === 'https://example.com/feed.xml' ? rssContent : '',
         headers: new Headers(),
+        body: url === 'https://example.com/feed.xml' ? rssContent : '',
+        url,
         status: 200,
         statusText: 'OK',
       })
@@ -596,9 +596,9 @@ describe('discoverFavicons', () => {
       }
 
       return Promise.resolve({
-        url,
-        body: url === 'https://example.com/favicon.ico' ? pngContent : '',
         headers: new Headers(),
+        body: url === 'https://example.com/favicon.ico' ? pngContent : '',
+        url,
         status: url === 'https://example.com/favicon.ico' ? 200 : 404,
         statusText: url === 'https://example.com/favicon.ico' ? 'OK' : 'Not Found',
       })

--- a/src/favicons/platform/handlers/bluesky.test.ts
+++ b/src/favicons/platform/handlers/bluesky.test.ts
@@ -4,9 +4,9 @@ import { blueskyHandler, isProfilePath } from './bluesky.js'
 
 const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => {
   return async (url: string) => ({
-    url,
-    body: responses[url] ?? '',
     headers: new Headers(),
+    body: responses[url] ?? '',
+    url,
     status: url in responses ? 200 : 404,
     statusText: url in responses ? 'OK' : 'Not Found',
   })

--- a/src/favicons/platform/handlers/devto.test.ts
+++ b/src/favicons/platform/handlers/devto.test.ts
@@ -4,9 +4,9 @@ import { devtoHandler } from './devto.js'
 
 const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => {
   return async (url: string) => ({
-    url,
-    body: responses[url] ?? '',
     headers: new Headers(),
+    body: responses[url] ?? '',
+    url,
     status: url in responses ? 200 : 404,
     statusText: url in responses ? 'OK' : 'Not Found',
   })

--- a/src/favicons/platform/handlers/gitlab.test.ts
+++ b/src/favicons/platform/handlers/gitlab.test.ts
@@ -7,9 +7,9 @@ const gitlabHeaders = new Headers({ 'x-gitlab-meta': '{"version":"1"}' })
 
 const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => {
   return async (url: string) => ({
-    url,
-    body: responses[url] ?? '',
     headers: new Headers(),
+    body: responses[url] ?? '',
+    url,
     status: url in responses ? 200 : 404,
     statusText: url in responses ? 'OK' : 'Not Found',
   })

--- a/src/favicons/platform/handlers/mastodon.test.ts
+++ b/src/favicons/platform/handlers/mastodon.test.ts
@@ -4,9 +4,9 @@ import { isMastodonHeaders, isMastodonHtml, isProfilePath, mastodonHandler } fro
 
 const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => {
   return async (url: string) => ({
-    url,
-    body: responses[url] ?? '',
     headers: new Headers(),
+    body: responses[url] ?? '',
+    url,
     status: url in responses ? 200 : 404,
     statusText: url in responses ? 'OK' : 'Not Found',
   })

--- a/src/favicons/platform/handlers/reddit.test.ts
+++ b/src/favicons/platform/handlers/reddit.test.ts
@@ -4,9 +4,9 @@ import { isSubredditPath, isUserPath, redditHandler } from './reddit.js'
 
 const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => {
   return async (url: string) => ({
-    url,
-    body: responses[url] ?? '',
     headers: new Headers(),
+    body: responses[url] ?? '',
+    url,
     status: url in responses ? 200 : 404,
     statusText: url in responses ? 'OK' : 'Not Found',
   })

--- a/src/feeds/index.test.ts
+++ b/src/feeds/index.test.ts
@@ -12,9 +12,9 @@ import type { FeedResult } from './types.js'
 
 const createMockFetch = (responses: Record<string, string>): DiscoverFetchFn => {
   return async (url: string) => ({
-    url,
-    body: responses[url] ?? '',
     headers: new Headers(),
+    body: responses[url] ?? '',
+    url,
     status: 200,
     statusText: 'OK',
   })
@@ -421,9 +421,9 @@ describe('discoverFeeds', () => {
       }
 
       return Promise.resolve({
-        url,
-        body: url === 'https://example.com/feed.xml' ? rssContent : '',
         headers: new Headers(),
+        body: url === 'https://example.com/feed.xml' ? rssContent : '',
+        url,
         status: url === 'https://example.com/feed.xml' ? 200 : 404,
         statusText: url === 'https://example.com/feed.xml' ? 'OK' : 'Not Found',
       })
@@ -538,11 +538,11 @@ describe('discoverFeeds', () => {
           url: 'https://www.reddit.com/r/programming/.rss',
           isValid: true,
           method: 'platform',
+          hint: { key: 'reddit:posts', label: 'Posts' },
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
           siteUrl: 'https://reddit.com/',
-          hint: { key: 'reddit:posts', label: 'Posts' },
         },
       ]
 
@@ -570,21 +570,21 @@ describe('discoverFeeds', () => {
           url: 'https://github.com/owner/repo/releases.atom',
           isValid: true,
           method: 'platform',
+          hint: { key: 'github:releases', label: 'Releases' },
           format: 'atom',
           title: 'Test Atom',
           description: 'Test feed',
           siteUrl: 'https://github.com/owner/repo',
-          hint: { key: 'github:releases', label: 'Releases' },
         },
         {
           url: 'https://github.com/owner/repo/commits.atom',
           isValid: true,
           method: 'platform',
+          hint: { key: 'github:commits', label: 'Commits' },
           format: 'atom',
           title: 'Test Atom',
           description: 'Test feed',
           siteUrl: 'https://github.com/owner/repo',
-          hint: { key: 'github:commits', label: 'Commits' },
         },
       ]
 
@@ -653,11 +653,11 @@ describe('discoverFeeds', () => {
           url: 'https://www.reddit.com/r/programming/.rss',
           isValid: true,
           method: 'platform',
+          hint: { key: 'reddit:posts', label: 'Posts' },
           format: 'rss',
           title: 'Test RSS',
           description: 'Test feed',
           siteUrl: 'https://reddit.com/',
-          hint: { key: 'reddit:posts', label: 'Posts' },
         },
         {
           url: 'https://reddit.com/feed',
@@ -794,14 +794,14 @@ describe('discoverFeeds', () => {
         </rss>
       `
       const fetchFn: DiscoverFetchFn = async (url: string) => ({
-        url,
-        body: url === 'https://example.com/feed.xml' ? rss : '',
         headers:
           url === 'https://example.com'
             ? new Headers({
                 link: '<https://example.com/feed.xml>; rel="alternate"; type="application/rss+xml"',
               })
             : new Headers(),
+        body: url === 'https://example.com/feed.xml' ? rss : '',
+        url,
         status: 200,
         statusText: 'OK',
       })

--- a/src/hubs/discover/index.test.ts
+++ b/src/hubs/discover/index.test.ts
@@ -5,9 +5,9 @@ import type { HubResult } from './types.js'
 
 const createMockFetch = (body: string, headers: Record<string, string> = {}): DiscoverFetchFn => {
   return async (url: string) => ({
-    url,
-    body,
     headers: new Headers(headers),
+    body,
+    url,
     status: 200,
     statusText: 'OK',
   })


### PR DESCRIPTION
Stacked on #153.

Object literals across tests and fixtures had drifted from the property order of the types they conform to. This reorders them so literals read in type-declaration order: a pure permutation (123 insertions == 123 deletions), no values, names, or behavior changed.

Three kinds of drift were found:

- Mock fetch responses written `{url, body, headers, status, statusText}` while `DiscoverFetchFnResponse` (and `defaultFetchFn`) declare `{headers, body, url, status, statusText}`: 39 literals across 11 files.
- Method-options fixtures in `normalizeMethodsConfig` tests put `baseUrl` last while every `*MethodOptions` type declares it first, 39 blocks.
- `hint` placed after the `FeedResult` fields in result fixtures while `DiscoverResult` declares it right after `method`: 4 fixtures.

Spread-based constructions (`{...defaults, ...options, baseUrl}`) are deliberately untouched: there, position is override semantics, not style.