### PR TITLE
feat: Probe ancestor directory paths in guess method

### DIFF
--- a/docs/feeds/guess.md
+++ b/docs/feeds/guess.md
@@ -21,6 +21,31 @@ Many websites place feeds at predictable paths. The Guess method tests these pat
 
 Each path is appended to the base URL and checked for a valid feed.
 
+## Ancestor Paths
+
+Some sites serve their feed from a section directory rather than the root — for example, a post at `/blog/post-slug/` with the feed at `/blog/feed.xml`. In addition to the root-level paths, the Guess method tests path-style URIs against the directory ancestors of the base URL:
+
+```
+https://example.com/blog/post-slug/
+→ https://example.com/feed.xml          (root)
+→ https://example.com/blog/feed.xml     (ancestor)
+→ https://example.com/blog/post-slug/feed.xml
+```
+
+The `maxAncestorDepth` option controls how many directory levels from the root are tested (default: `2` for feeds). Set it to `0` to only test root-level paths:
+
+```typescript
+const feeds = await discoverFeeds(url, {
+  methods: {
+    guess: {
+      maxAncestorDepth: 0,
+    },
+  },
+})
+```
+
+Every configured URI is tested against each ancestor directory the same way it is tested against the root: `/feed.xml` resolves under the directory, and a bare query URI like `?feed=rss` is appended to it (`https://example.com/blog/?feed=rss`).
+
 ## URI Sets
 
 There are three predefined URI sets:
@@ -65,12 +90,16 @@ Includes WordPress, Blogger, and many other patterns:
 import { urisComprehensive } from 'feedscout/feeds'
 
 // urisBalanced + [
-//   '/?feed=rss',
-//   '/?feed=atom',
+//   '/atom',
+//   '/rss2.xml',
+//   '?format=rss',
+//   '?rss=1',
 //   '/feeds/posts/default',
 //   ...
 // ]
 ```
+
+Query URIs behave differently from path URIs: a bare `?format=rss` is appended to the current page's path (`https://example.com/blog?format=rss`), while `/`-prefixed paths always resolve from the site root. This matches platforms like WordPress and Squarespace that serve feeds via a query parameter on the page you're on.
 
 ## Configuration
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -315,5 +315,6 @@ type GuessMethodOptions = {
   baseUrl: string
   uris: Array<string>
   additionalBaseUrls?: Array<string>
+  maxAncestorDepth?: number
 }
 ```

--- a/src/common/uris/guess/index.test.ts
+++ b/src/common/uris/guess/index.test.ts
@@ -115,4 +115,61 @@ describe('discoverUrisFromGuess', () => {
 
     expect(throwing).toThrow(TypeError)
   })
+
+  it('should not probe ancestor paths by default', () => {
+    const value = discoverUrisFromGuess({
+      baseUrl: 'https://example.com/blog/post-slug/',
+      uris: ['/feed.xml'],
+    })
+    const expected = ['https://example.com/feed.xml']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should probe ancestor paths after origin URIs when maxAncestorDepth is set', () => {
+    const value = discoverUrisFromGuess({
+      baseUrl: 'https://example.com/blog/post-slug/',
+      uris: ['/feed.xml', '/rss'],
+      maxAncestorDepth: 2,
+    })
+    const expected = [
+      'https://example.com/feed.xml',
+      'https://example.com/rss',
+      'https://example.com/blog/feed.xml',
+      'https://example.com/blog/rss',
+      'https://example.com/blog/post-slug/feed.xml',
+      'https://example.com/blog/post-slug/rss',
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should apply query URIs and array alternatives to ancestor paths', () => {
+    const value = discoverUrisFromGuess({
+      baseUrl: 'https://example.com/blog/post-slug/',
+      uris: ['/feed.xml', '?format=rss', ['/feed/atom/', '?feed=atom']],
+      maxAncestorDepth: 1,
+    })
+    const expected = [
+      'https://example.com/feed.xml',
+      'https://example.com/blog/post-slug/?format=rss',
+      ['https://example.com/feed/atom/', 'https://example.com/blog/post-slug/?feed=atom'],
+      'https://example.com/blog/feed.xml',
+      'https://example.com/blog/?format=rss',
+      ['https://example.com/blog/feed/atom/', 'https://example.com/blog/?feed=atom'],
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should not generate ancestor URIs for root base URLs', () => {
+    const value = discoverUrisFromGuess({
+      baseUrl: 'https://example.com',
+      uris: ['/feed.xml'],
+      maxAncestorDepth: 2,
+    })
+    const expected = ['https://example.com/feed.xml']
+
+    expect(value).toEqual(expected)
+  })
 })

--- a/src/common/uris/guess/index.ts
+++ b/src/common/uris/guess/index.ts
@@ -1,10 +1,23 @@
 import type { UriEntry } from '../../types.js'
 import type { GuessMethodOptions } from './types.js'
-import { generateUrlCombinations } from './utils.js'
+import {
+  generatePathUrlCombinations,
+  generateUrlCombinations,
+  getAncestorPathBases,
+} from './utils.js'
 
 export const discoverUrisFromGuess = (options: GuessMethodOptions): Array<UriEntry> => {
-  const { baseUrl, uris, additionalBaseUrls = [] } = options
+  const { baseUrl, uris, additionalBaseUrls = [], maxAncestorDepth = 0 } = options
   const baseUrls = [baseUrl, ...additionalBaseUrls]
 
-  return generateUrlCombinations(baseUrls, uris)
+  // Origin-level combinations come first: root-level feeds are the most common case, and the
+  // discover-level maxUris cap truncates from the tail.
+  const combinations = generateUrlCombinations(baseUrls, uris)
+
+  if (maxAncestorDepth > 0) {
+    const ancestorBases = getAncestorPathBases(baseUrl, maxAncestorDepth)
+    combinations.push(...generatePathUrlCombinations(ancestorBases, uris))
+  }
+
+  return combinations
 }

--- a/src/common/uris/guess/types.ts
+++ b/src/common/uris/guess/types.ts
@@ -4,4 +4,7 @@ export type GuessMethodOptions = {
   baseUrl: string
   uris: Array<UriEntry>
   additionalBaseUrls?: Array<string>
+  // How many directory levels of the base URL's path to also probe with path-style URIs
+  // (e.g. /blog/feed.xml for a page under /blog/). 0 or undefined disables ancestor probing.
+  maxAncestorDepth?: number
 }

--- a/src/common/uris/guess/utils.test.ts
+++ b/src/common/uris/guess/utils.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test'
 import type { UriEntry } from '../../types.js'
-import { generateUrlCombinations, getSubdomainVariants, getWwwCounterpart } from './utils.js'
+import {
+  generatePathUrlCombinations,
+  generateUrlCombinations,
+  getAncestorPathBases,
+  getSubdomainVariants,
+  getWwwCounterpart,
+} from './utils.js'
 
 describe('generateUrlCombinations', () => {
   it('should generate all URL combinations from multiple bases and URIs', () => {
@@ -232,6 +238,136 @@ describe('generateUrlCombinations', () => {
     ]
 
     expect(generateUrlCombinations(baseUrls, feedUris)).toEqual(expected)
+  })
+})
+
+describe('generatePathUrlCombinations', () => {
+  it('should resolve URIs relative to the base directory', () => {
+    const value = generatePathUrlCombinations(['https://example.com/blog/'], ['/feed.xml', '/rss'])
+    const expected = ['https://example.com/blog/feed.xml', 'https://example.com/blog/rss']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should normalize bases without trailing slash', () => {
+    const value = generatePathUrlCombinations(['https://example.com/blog'], ['/feed.xml'])
+    const expected = ['https://example.com/blog/feed.xml']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should generate combinations for multiple bases in order', () => {
+    const value = generatePathUrlCombinations(
+      ['https://example.com/blog/', 'https://example.com/blog/2026/'],
+      ['/feed.xml', '/rss.xml'],
+    )
+    const expected = [
+      'https://example.com/blog/feed.xml',
+      'https://example.com/blog/rss.xml',
+      'https://example.com/blog/2026/feed.xml',
+      'https://example.com/blog/2026/rss.xml',
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should append bare query URIs to the base directory', () => {
+    const value = generatePathUrlCombinations(['https://example.com/blog/'], ['?format=rss'])
+    const expected = ['https://example.com/blog/?format=rss']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should resolve array entries as alternative groups', () => {
+    const value = generatePathUrlCombinations(
+      ['https://example.com/blog/'],
+      [['/feed/rss/', '?feed=rss']],
+    )
+    const expected = [['https://example.com/blog/feed/rss/', 'https://example.com/blog/?feed=rss']]
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should pass absolute URIs through unchanged', () => {
+    const value = generatePathUrlCombinations(
+      ['https://example.com/blog/'],
+      ['https://feeds.example.com/rss.xml'],
+    )
+    const expected = ['https://feeds.example.com/rss.xml']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should return empty array when bases are empty', () => {
+    const value = generatePathUrlCombinations([], ['/feed.xml'])
+    const expected: Array<string> = []
+
+    expect(value).toEqual(expected)
+  })
+})
+
+describe('getAncestorPathBases', () => {
+  it('should return directory prefixes shallowest first', () => {
+    const value = getAncestorPathBases('https://example.com/blog/post-slug/', 2)
+    const expected = ['https://example.com/blog/', 'https://example.com/blog/post-slug/']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should treat the last segment without trailing slash as a file', () => {
+    const value = getAncestorPathBases('https://example.com/blog/post-slug', 2)
+    const expected = ['https://example.com/blog/']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should use the directory of a file path', () => {
+    const value = getAncestorPathBases('https://example.com/blog/post.html', 2)
+    const expected = ['https://example.com/blog/']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should cap the number of segments at maxDepth', () => {
+    const value = getAncestorPathBases('https://example.com/a/b/c/', 2)
+    const expected = ['https://example.com/a/', 'https://example.com/a/b/']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should return empty array for root URLs', () => {
+    const value = getAncestorPathBases('https://example.com/', 2)
+    const expected: Array<string> = []
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should return empty array when maxDepth is 0', () => {
+    const value = getAncestorPathBases('https://example.com/blog/post-slug/', 0)
+    const expected: Array<string> = []
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should ignore query strings and hashes', () => {
+    const value = getAncestorPathBases('https://example.com/blog/?page=2#latest', 2)
+    const expected = ['https://example.com/blog/']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should preserve ports', () => {
+    const value = getAncestorPathBases('https://example.com:8080/blog/post/', 1)
+    const expected = ['https://example.com:8080/blog/']
+
+    expect(value).toEqual(expected)
+  })
+
+  it('should return empty array for invalid URLs', () => {
+    const value = getAncestorPathBases('not-a-url', 2)
+    const expected: Array<string> = []
+
+    expect(value).toEqual(expected)
   })
 })
 

--- a/src/common/uris/guess/utils.ts
+++ b/src/common/uris/guess/utils.ts
@@ -33,6 +33,63 @@ export const generateUrlCombinations = (
   })
 }
 
+// Unlike resolveUri, a leading slash anchors at the base's directory instead of the origin:
+// /feed.xml + https://example.com/blog/ → https://example.com/blog/feed.xml.
+const resolvePathUri = (uri: string, base: string): string => {
+  if (uri.startsWith('/')) {
+    return new URL(uri.slice(1), base).href
+  }
+
+  return new URL(uri, base).href
+}
+
+// Resolves every URI against each base's directory: query URIs append to the directory
+// (?feed=rss → /blog/?feed=rss) and array alternatives stay paired, same as at origin level.
+export const generatePathUrlCombinations = (
+  pathBases: Array<string>,
+  uris: Array<UriEntry>,
+): Array<UriEntry> => {
+  return pathBases.flatMap((base) => {
+    const normalizedBase = base.endsWith('/') ? base : `${base}/`
+
+    return uris.map((uri) => {
+      if (typeof uri === 'string') {
+        return resolvePathUri(uri, normalizedBase)
+      }
+
+      return uri.map((alternative) => resolvePathUri(alternative, normalizedBase))
+    })
+  })
+}
+
+// Returns the directory prefixes of the URL's pathname as absolute URLs, shallowest first,
+// excluding the root, capped at maxDepth segments from the root.
+export const getAncestorPathBases = (baseUrl: string, maxDepth: number): Array<string> => {
+  let url: URL
+
+  try {
+    url = new URL(baseUrl)
+  } catch {
+    return []
+  }
+
+  // The first split element is always empty (pathname starts with /) and the last is either empty
+  // (directory URL) or the filename, so both are dropped. The filter collapses double slashes.
+  const segments = url.pathname
+    .split('/')
+    .slice(1, -1)
+    .filter((segment) => segment !== '')
+  const bases: Array<string> = []
+  let base = `${url.origin}/`
+
+  for (const segment of segments.slice(0, maxDepth)) {
+    base += `${segment}/`
+    bases.push(base)
+  }
+
+  return bases
+}
+
 export const getWwwCounterpart = (baseUrl: string): string => {
   const url = new URL(baseUrl)
   const port = url.port ? `:${url.port}` : ''

--- a/src/common/uris/guess/utils.ts
+++ b/src/common/uris/guess/utils.ts
@@ -1,3 +1,4 @@
+import { parseUrl } from 'trousse'
 import type { UriEntry } from '../../types.js'
 
 const ipAddressRegex = /^\d+\.\d+\.\d+\.\d+$/
@@ -65,11 +66,9 @@ export const generatePathUrlCombinations = (
 // Returns the directory prefixes of the URL's pathname as absolute URLs, shallowest first,
 // excluding the root, capped at maxDepth segments from the root.
 export const getAncestorPathBases = (baseUrl: string, maxDepth: number): Array<string> => {
-  let url: URL
+  const url = parseUrl(baseUrl)
 
-  try {
-    url = new URL(baseUrl)
-  } catch {
+  if (!url) {
     return []
   }
 

--- a/src/feeds/defaults.ts
+++ b/src/feeds/defaults.ts
@@ -202,6 +202,7 @@ export const defaultHeadersOptions: Omit<HeadersMethodOptions, 'baseUrl'> = {
 // Default options for Guess method (excluding baseUrl which is required).
 export const defaultGuessOptions: Omit<GuessMethodOptions, 'baseUrl'> = {
   uris: urisBalanced,
+  maxAncestorDepth: 2,
 }
 
 // Default options for Platform method.

--- a/src/feeds/index.test.ts
+++ b/src/feeds/index.test.ts
@@ -50,6 +50,44 @@ describe('discoverFeeds', () => {
     expect(result).toEqual(expected)
   })
 
+  it('should find feeds at ancestor paths when the page has no feed hints', async () => {
+    const rss = `
+      <rss version="2.0">
+        <channel>
+          <title>Blog RSS</title>
+          <link>https://example.com/blog/</link>
+          <description>Blog feed</description>
+        </channel>
+      </rss>
+    `
+    const html = `
+      <html>
+        <head><title>Post</title></head>
+        <body><a href="/blog/">Blog</a></body>
+      </html>
+    `
+    const mockFetch = createMockFetch({
+      'https://example.com/blog/post-slug/': html,
+      'https://example.com/blog/feed.xml': rss,
+    })
+    const value = await discoverFeeds('https://example.com/blog/post-slug/', {
+      fetchFn: mockFetch,
+    })
+    const expected: Array<DiscoverResult<FeedResult>> = [
+      {
+        url: 'https://example.com/blog/feed.xml',
+        isValid: true,
+        method: 'guess',
+        format: 'rss',
+        title: 'Blog RSS',
+        description: 'Blog feed',
+        siteUrl: 'https://example.com/blog/',
+      },
+    ]
+
+    expect(value).toEqual(expected)
+  })
+
   it('should find valid feeds using guess method with default URIs', async () => {
     const rss = `
       <rss version="2.0">


### PR DESCRIPTION
Replaces #152, which was mistakenly based on `main` (merged there and reverted in ec409e7); this targets `rc` where it belongs.

The guess method resolved every path-style URI against the origin only, so feeds served from a section directory were never probed: a page at `/blog/post-slug/` with its feed at `/blog/feed.xml` and nothing at `/feed.xml` came back empty when the page had no autodiscovery hints.

The guess method now also tests the configured URIs against the directory ancestors of the input URL (`/blog/`, then `/blog/post-slug/`), after the origin-level candidates. Every URI keeps its established semantics at each level: `/feed.xml` resolves under the directory, a bare `?feed=rss` is appended to it, and alternative pairs stay paired: the user's list is applied uniformly, never filtered. The new `maxAncestorDepth` option controls how many directory levels from the root are probed; it defaults to `2` for feeds and stays off for the favicons and blogrolls discoverers.

Real-world example: https://julienreszka.com/blog/rss-is-back-ai-agents-are-reading-it/ has no feed hints in its HTML and serves the feed at `/blog/feed.xml`.