### PR TITLE
fix: Widen the feedsmith version ranges to carets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,14 +11,14 @@
       "devDependencies": {
         "@types/bun": "^1.3.13",
         "@types/http-link-header": "^1.0.7",
-        "feedsmith": "3.0.0-rc.1",
+        "feedsmith": "^3.0.0-rc.1",
         "kvalita": "^1.15.1",
         "trousse": "^1.0.1",
         "tsdown": "^0.22.2",
         "vitepress": "^2.0.0-alpha.17",
       },
       "peerDependencies": {
-        "feedsmith": "3.0.0-rc.1",
+        "feedsmith": "^3.0.0-rc.1",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -65,12 +65,12 @@
     "http-link-header": "^1.1.3"
   },
   "peerDependencies": {
-    "feedsmith": "3.0.0-rc.1"
+    "feedsmith": "^3.0.0-rc.1"
   },
   "devDependencies": {
     "@types/bun": "^1.3.13",
     "@types/http-link-header": "^1.0.7",
-    "feedsmith": "3.0.0-rc.1",
+    "feedsmith": "^3.0.0-rc.1",
     "kvalita": "^1.15.1",
     "trousse": "^1.0.1",
     "tsdown": "^0.22.2",


### PR DESCRIPTION
The `feedsmith` peer range was pinned to the exact version `3.0.0-rc.1`, which defeats the point of declaring a peer: it tells the consumer to install precisely that build or nothing. The conflict is already live, feedstand resolves `feedsmith ^3.0.0-rc.2`, a version this range rejects, and it gets worse with every new prerelease.

The `devDependencies` entry moves to a caret too. The committed lockfile is what makes CI reproducible; an exact range there only adds friction, since bumping means editing package.json instead of running an update. The lockfile still resolves to rc.1, so the tested build does not move.

Companion changes: feedmatch macieklamberski/feedmatch#43, feedsweep macieklamberski/feedsweep#397.